### PR TITLE
docs: add "Why Uzomuzo?" section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,14 @@ See [Data Flow](docs/data-flow.md) for API integration diagram and two-path asse
 | [License Resolution](docs/license-resolution.md) | ResolvedLicense / normalization / fallback / promotion |
 | [Development Guide](docs/development.md) | SPDX updates, testing, performance, troubleshooting |
 
+## Why "Uzomuzo"?
+
+Pronounced **oo-zoh-moo-zoh** — from the Japanese *uzōmuzō* (有象無象).
+
+In Japanese Buddhist philosophy, *uzō* (有象) means "things with form" and *muzō* (無象) means "things without form." Together, *uzōmuzō* originally described "all things in the universe — the visible and the invisible."
+
+Modern software supply chains are exactly that: a vast universe of seen (direct) and unseen (transitive) dependencies. **uzomuzo** illuminates this complexity — mapping every element of your dependency tree to bring clarity to the chaos.
+
 ## About
 
 Developed by kotakanbe, creator of [Vuls](https://github.com/future-architect/vuls) — an open-source vulnerability scanner with 12,000+ GitHub stars. uzomuzo extends this mission from reactive vulnerability scanning to **proactive supply chain lifecycle governance**.


### PR DESCRIPTION
## Summary
- Add "Why Uzomuzo?" section to README explaining the name's Buddhist philosophical origin (*uzōmuzō* = all things visible and invisible)
- Include pronunciation guide (**oo-zoh-moo-zoh**) for English speakers
- Connect the name's meaning to uzomuzo's mission of illuminating seen (direct) and unseen (transitive) dependencies

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Confirm section placement (before "About" section)

🤖 Generated with [Claude Code](https://claude.com/claude-code)