### PR TITLE
feat: re-export CommitStats, ResolvedLicense, NewScoreEntity

### DIFF
--- a/pkg/uzomuzo/types.go
+++ b/pkg/uzomuzo/types.go
@@ -50,6 +50,15 @@ type Repository = domain.Repository
 // PackageLinks holds canonical project links.
 type PackageLinks = domain.PackageLinks
 
+// CommitStats represents commit statistics (total, bot, user counts and ratios).
+type CommitStats = domain.CommitStats
+
+// ResolvedLicense represents normalized license information.
+type ResolvedLicense = domain.ResolvedLicense
+
+// NewScoreEntity creates a new ScoreEntity with the given name, value, maxValue, and reason.
+var NewScoreEntity = domain.NewScoreEntity
+
 // EOLStatus aggregates primary-source EOL evaluation + evidences.
 type EOLStatus = domain.EOLStatus
 


### PR DESCRIPTION
## Summary
- Re-export `CommitStats`, `ResolvedLicense` type aliases and `NewScoreEntity` constructor from `pkg/uzomuzo/types.go`
- These types were accessible via the `Analysis` type alias but not directly importable by external packages
- Enables external consumers to construct and convert Analysis aggregates

## Test plan
- [x] `go build ./...` passes
- [x] Existing tests unaffected (additive change only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)