### PR TITLE
fix: prevent NuGet tests from hitting real nuget.org

### DIFF
--- a/internal/infrastructure/nuget/client_test.go
+++ b/internal/infrastructure/nuget/client_test.go
@@ -55,6 +55,7 @@ func TestGetDeprecation_NotFound(t *testing.T) {
 
 	c := NewClient()
 	c.SetBaseURL(srv.URL + "/v3/registration5-semver2")
+	c.SetHTMLBase(srv.URL) // prevent HTML fallback from hitting real nuget.org
 
 	info, found, err := c.GetDeprecation(context.Background(), "NoSuch")
 	if err != nil {
@@ -116,7 +117,8 @@ func TestGetDeprecation_NoCacheNotFound_AllowsFreshLookup(t *testing.T) {
 
 	c := NewClient()
 	c.SetBaseURL(srv.URL + "/v3/registration5-semver2")
-	c.SetCacheTTL(1) // enable caching
+	c.SetHTMLBase(srv.URL)   // prevent HTML fallback from hitting real nuget.org
+	c.SetCacheTTL(time.Hour) // enable caching with a long TTL
 	c.NoCacheNotFound = true
 
 	// First attempt: 404 -> found=false


### PR DESCRIPTION
## Summary
- `TestGetDeprecation_NotFound` and `TestGetDeprecation_NoCacheNotFound_AllowsFreshLookup` were not setting `htmlBase` on the NuGet client
- After all registration candidates returned 404, the HTML deprecation scraper fell through to real `https://www.nuget.org`, making tests flaky depending on network availability and nuget.org page content
- Fixed by calling `c.SetHTMLBase(srv.URL)` so the HTML fallback also targets the test server

## Test plan
- [x] `go test ./internal/infrastructure/nuget/...` — all 10 tests pass
- [x] No external network calls during test execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)