### PR TITLE
chore: add pre-push hook to remind doc updates

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,18 @@
 {
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node -e \"let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{const cmd=JSON.parse(d).tool_input?.command||'';if(/^git\\s+push/.test(cmd)){console.log(JSON.stringify({hookSpecificOutput:{hookEventName:'PreToolUse',additionalContext:'IMPORTANT: Before pushing, check if documentation needs updating for the changes on this branch. Run git diff main...HEAD --name-only to see changed files. If Go source files changed, launch the doc-updater agent to update README and godoc comments. Only proceed with git push after docs are confirmed up-to-date or updated.'}}));}});\"",
+            "timeout": 10,
+            "statusMessage": "Checking if docs need updating..."
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Edit|Write",


### PR DESCRIPTION
## Summary
- Add a `PreToolUse` hook that detects `git push` commands and injects context to Claude
- Claude will check if documentation needs updating before proceeding with the push
- Ensures docs stay in sync with code changes automatically

## Test plan
- [ ] Verify hook fires when running `git push` in Claude Code
- [ ] Verify hook does NOT fire for other git commands (`git status`, `git commit`, etc.)
- [ ] Verify doc-updater agent is launched when Go source files are changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)