### PR TITLE
refactor: remove unused AxisEvaluator dead code

### DIFF
--- a/internal/interfaces/cli/mode_router.go
+++ b/internal/interfaces/cli/mode_router.go
@@ -155,22 +155,6 @@ func handleBatchFile(_ context.Context, _ *config.Config, inputs *ProcessingInpu
 
 // ---------------- Post Hooks ----------------
 
-// Axis registry for future analysis axes (e.g., lifecycle, security, etc.)
-type AxisEvaluator interface {
-	Key() string
-	Evaluate(a *ProcessingResults) error
-}
-
-var axisRegistry []AxisEvaluator
-
-func RegisterAxis(e AxisEvaluator) {
-	axisRegistry = append(axisRegistry, e)
-}
-
-func AllAxes() []AxisEvaluator {
-	return axisRegistry
-}
-
 func postErrors(_ *config.Config, _ *ProcessingInputs, results *ProcessingResults, _ ProcessingOptions) {
 	displayBatchErrors(results.AllAnalyses)
 }


### PR DESCRIPTION
## Summary
- Remove `AxisEvaluator` interface, `axisRegistry` var, `RegisterAxis()`, and `AllAxes()`
- All were defined but never referenced anywhere in the codebase (YAGNI violation)

Addresses review item #4 from PR #10 review.

## Test plan
- [x] `go build` succeeds
- [x] `go test ./internal/interfaces/cli/...` passes
- [x] Verified no references exist via grep

🤖 Generated with [Claude Code](https://claude.com/claude-code)