### PR TITLE
feat: restrict auto-fix to kotakanbe PRs and add completion notify

### DIFF
--- a/.github/workflows/copilot-review-fix.yml
+++ b/.github/workflows/copilot-review-fix.yml
@@ -15,9 +15,10 @@ concurrency:
 jobs:
   claude-fix-copilot:
     # Run when: Copilot submits a review OR 'copilot-review' label is added
-    # Skip fork PRs to prevent untrusted code execution
+    # Only for PRs authored by kotakanbe, skip fork PRs
     if: >-
       github.event.pull_request.head.repo.full_name == github.repository
+      && github.event.pull_request.user.login == 'kotakanbe'
       && (
         (github.event_name == 'pull_request_review'
          && github.event.review.user.login == 'copilot-pull-request-reviewer')
@@ -97,4 +98,18 @@ jobs:
           timeout_minutes: 10
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Notify completion
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "${{ job.status }}" = "success" ]; then
+            body="@kotakanbe Copilot review auto-fix completed. Please check the changes and press **re-review** if needed."
+          else
+            body="@kotakanbe Copilot review auto-fix failed. Check the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details."
+          fi
+          gh pr comment "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" \
+            --body "$body"
 


### PR DESCRIPTION
## Summary

- Restrict auto-fix workflow to PRs authored by `kotakanbe` only (public repo safety)
- Add completion notification as PR comment with `@kotakanbe` mention
  - Success: prompt to press re-review button
  - Failure: link to workflow run for debugging

## Flow

```
Copilot review completes
  → Claude auto-fix (only if PR author is kotakanbe)
  → PR comment: "@kotakanbe ... press re-review if needed"
```

## Test plan

- [ ] Verify workflow does NOT trigger for PRs by other authors
- [ ] Verify success notification includes @kotakanbe mention
- [ ] Verify failure notification includes workflow run link

🤖 Generated with [Claude Code](https://claude.com/claude-code)