### PR TITLE
ci: switch Claude Code auth to OAuth token

### DIFF
--- a/.github/workflows/copilot-review-fix.yml
+++ b/.github/workflows/copilot-review-fix.yml
@@ -97,7 +97,7 @@ jobs:
             - Only modify source files within the scope of Copilot's comments (Phase 2) or .github/instructions/ (Phase 3). Running make sync-instructions is allowed to regenerate derived files under .claude/rules/.
             - Always verify go build passes before committing
             - If go test fails after fixes, revert the failing change and classify as WONT_FIX
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           model: claude-opus-4-6
           timeout_minutes: 10
         env:


### PR DESCRIPTION
## Summary
- Switch `copilot-review-fix.yml` from `ANTHROPIC_API_KEY` to `CLAUDE_CODE_OAUTH_TOKEN`
- Enables using Max plan OAuth authentication instead of paid API key

## Test plan
- [ ] Verify `CLAUDE_CODE_OAUTH_TOKEN` secret is set in repo settings
- [ ] Trigger the workflow (add `copilot-review` label to a PR) and confirm authentication succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)