### PR TITLE
ci: update copilot-review-fix with working configuration

### DIFF
--- a/.github/workflows/copilot-review-fix.yml
+++ b/.github/workflows/copilot-review-fix.yml
@@ -26,7 +26,7 @@ jobs:
             && github.event.sender.login == 'kotakanbe')
       )
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     permissions:
       contents: write
       pull-requests: write
@@ -62,14 +62,14 @@ jobs:
         run: go install golang.org/x/tools/cmd/goimports@v0.34.0
 
       - name: Install golangci-lint
-        uses: golangci/golangci-lint-action@4afd733a84b2f1a21f7c3a9d0135a3a8360b1ee2 # v7.0.0
+        uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
         with:
-          install-only: true
+          install-mode: binary
 
       - name: Run Claude Code to fix Copilot review comments
-        uses: anthropics/claude-code-action@f28709ede76ab727eab14d1e5a0e4c21a006e85c # v0.0.22
+        uses: anthropics/claude-code-action@e7b588b6eaa5263c2e7c6c7b34a29e190d32ee68 # v1.0.81
         with:
-          direct_prompt: |
+          prompt: |
             You are running in CI to automatically fix Copilot review comments on PR #${{ github.event.pull_request.number }}.
 
             Follow the procedure defined in .github/prompts/review.prompt.md with --copilot-only mode:
@@ -98,10 +98,11 @@ jobs:
             - Always verify go build passes before committing
             - If go test fails after fixes, revert the failing change and classify as WONT_FIX
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          model: claude-opus-4-6
-          timeout_minutes: 10
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          claude_args: "--model opus --allowedTools 'Bash(*)' Edit Write Read Glob Grep"
+          show_full_output: true
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CLAUDE_CODE_MAX_TURNS: "50"
 
       - name: Notify on failure
         if: failure()


### PR DESCRIPTION
## Summary
- Switch from `direct_prompt` to `prompt` (claude-code-action v1.0.81)
- Use `--allowedTools` to grant Edit/Write permissions in CI
- Use `--model opus` via `claude_args`
- Increase timeout to 30 minutes
- Enable `show_full_output` for debugging
- Fix `install-mode: binary` for golangci-lint-action v7
- Use `CLAUDE_CODE_OAUTH_TOKEN` instead of `ANTHROPIC_API_KEY`

Tested and verified on uzomuzo-catalog PR #67.

## Test plan
- [ ] Verify `CLAUDE_CODE_OAUTH_TOKEN` secret is set in repo settings
- [ ] Trigger via `copilot-review` label on a PR and confirm it works

🤖 Generated with [Claude Code](https://claude.com/claude-code)