### PR TITLE
fix: use startsWith for Copilot reviewer login check

### DIFF
--- a/.github/workflows/copilot-review-fix.yml
+++ b/.github/workflows/copilot-review-fix.yml
@@ -20,7 +20,7 @@ jobs:
       github.event.pull_request.user.login == 'kotakanbe'
       && (
         (github.event_name == 'pull_request_review'
-         && github.event.review.user.login == 'copilot-pull-request-reviewer[bot]')
+         && startsWith(github.event.review.user.login, 'copilot-pull-request-reviewer'))
         || (github.event_name == 'pull_request'
             && github.event.label.name == 'copilot-review'
             && github.event.sender.login == 'kotakanbe')


### PR DESCRIPTION
## Summary
- Fix `pull_request_review` trigger condition for Copilot auto-fix workflow
- The webhook event may send the reviewer login without `[bot]` suffix, causing the job to skip
- Use `startsWith()` to match both `copilot-pull-request-reviewer` and `copilot-pull-request-reviewer[bot]`

**This must be merged to main** for the `pull_request_review` trigger to work, since GitHub uses the default branch workflow for review events.

## Test plan
- [ ] Merge to main
- [ ] Push to any open PR → Copilot reviews → auto-fix workflow should trigger (not skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)