### PR TITLE
fix: update claude-code-action to v1.0.82 and add allowed_bots

### DIFF
--- a/.github/workflows/copilot-review-fix.yml
+++ b/.github/workflows/copilot-review-fix.yml
@@ -67,7 +67,7 @@ jobs:
           install-mode: binary
 
       - name: Run Claude Code to fix Copilot review comments
-        uses: anthropics/claude-code-action@e7b588b6eaa5263c2e7c6c7b34a29e190d32ee68 # v1.0.81
+        uses: anthropics/claude-code-action@33ea56dd1072951fc382b7bffdb52125f2994e68 # v1.0.82
         with:
           prompt: |
             You are running in CI to automatically fix Copilot review comments on PR #${{ github.event.pull_request.number }}.
@@ -101,6 +101,8 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: "--model opus --allowedTools 'Bash(*)' Edit Write Read Glob Grep"
           show_full_output: true
+          allowed_bots: "Copilot"
+          allowed_non_write_users: "Copilot"
         env:
           CLAUDE_CODE_MAX_TURNS: "50"
 


### PR DESCRIPTION
## Summary
- Update claude-code-action from v1.0.81 to v1.0.82
- Add `allowed_bots: "Copilot"` and `allowed_non_write_users: "Copilot"`
- Fixes "Copilot is not a user" error on pull_request_review trigger

**Must be merged to main** before PR #36 can be tested with Copilot auto-trigger.