### PR TITLE
fix: disable show_full_output on public repo

### DIFF
--- a/.github/workflows/copilot-review-fix.yml
+++ b/.github/workflows/copilot-review-fix.yml
@@ -99,7 +99,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: "--model opus --allowedTools 'Bash(*)' Edit Write Read Glob Grep"
-          show_full_output: true
+          show_full_output: false
           allowed_bots: "Copilot"
           allowed_non_write_users: "Copilot"
         env:


### PR DESCRIPTION
## Summary
`show_full_output: true` posts Claude's full tool output as PR comments. On a public repo, if prompt injection causes Claude to run `env`/`printenv`, secrets (GITHUB_TOKEN, CLAUDE_CODE_OAUTH_TOKEN) would be visible to everyone.

GitHub Actions log masking does NOT apply to PR comments posted via API.

**Merge immediately.**