### PR TITLE
chore: add 'Debug with Data, Not Guesswork' rule

### DIFF
--- a/.claude/rules/project-conventions.md
+++ b/.claude/rules/project-conventions.md
@@ -8,6 +8,15 @@
 - **Test Data Organization**: Follow Go conventions for test data structure and naming
 - **Test Data Reuse**: Reuse existing test data files instead of creating duplicates
 
+## Debug with Data, Not Guesswork
+
+When encountering unknown behavior (runtime values, API responses, tool parameters):
+
+1. **Observe first** — Add temporary debug output to capture actual values before writing a fix. Never guess at runtime values.
+2. **Read the docs** — Check official documentation before implementing. For GitHub Actions: webhook payload docs, expression security docs, action README/source code.
+3. **One unknown per change** — If unsure about multiple things, verify them separately. Do not stack untested assumptions in one PR.
+4. **Verify versions** — Check that dependencies are current. Use the latest stable release, not whatever was used in a past example.
+
 ## General Principles
 
 - Explain concepts clearly, as if to a beginner. Avoid jargon, or explain it simply.

--- a/.github/instructions/project-conventions.instructions.md
+++ b/.github/instructions/project-conventions.instructions.md
@@ -6,6 +6,15 @@
 - **Test Data Organization**: Follow Go conventions for test data structure and naming
 - **Test Data Reuse**: Reuse existing test data files instead of creating duplicates
 
+## Debug with Data, Not Guesswork
+
+When encountering unknown behavior (runtime values, API responses, tool parameters):
+
+1. **Observe first** — Add temporary debug output to capture actual values before writing a fix. Never guess at runtime values.
+2. **Read the docs** — Check official documentation before implementing. For GitHub Actions: webhook payload docs, expression security docs, action README/source code.
+3. **One unknown per change** — If unsure about multiple things, verify them separately. Do not stack untested assumptions in one PR.
+4. **Verify versions** — Check that dependencies are current. Use the latest stable release, not whatever was used in a past example.
+
 ## General Principles
 
 - Explain concepts clearly, as if to a beginner. Avoid jargon, or explain it simply.


### PR DESCRIPTION
## Summary
Add a general debugging principle to project conventions:
1. Observe actual values before writing a fix
2. Read official docs before implementing
3. One unknown per change
4. Verify dependency versions

Learned from the copilot-review-fix workflow setup where multiple PRs were wasted guessing runtime values.

Will sync to uzomuzo-catalog via CI sync.