### PR TITLE
ci: add Claude Code workflow for PR/issue comment triggers

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -37,8 +37,8 @@ jobs:
           fi
 
           if [[ "$EVENT_NAME" == "issue_comment" && "$IS_PR_ISSUE" == "true" ]]; then
-            head_ref=$(gh pr view "$PR_NUMBER" --repo "$GH_REPO" --json headRefName --jq .headRefName)
-            echo "ref=$head_ref" >> "$GITHUB_OUTPUT"
+            head_sha=$(gh pr view "$PR_NUMBER" --repo "$GH_REPO" --json headRefOid --jq .headRefOid)
+            echo "ref=$head_sha" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 


### PR DESCRIPTION
## Summary
- Add `.github/workflows/claude.yml` to enable `@claude` mentions in PR review comments and issue comments
- Follows existing workflow patterns: SHA-pinned actions, Go tooling setup, `CLAUDE_CODE_OAUTH_TOKEN` auth
- Scoped to `kotakanbe` user with concurrency control and `show_full_output: false` for secret protection

## Test plan
- [ ] Verify workflow appears in Actions tab after merge
- [ ] Test `@claude` mention in a PR review comment triggers the workflow
- [ ] Test `@claude` mention in an issue comment triggers the workflow
- [ ] Confirm non-`kotakanbe` comments do not trigger the workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)