### PR TITLE
ci: replace copilot-review-fix with @claude comment trigger

### DIFF
--- a/.github/workflows/copilot-review-fix.yml
+++ b/.github/workflows/copilot-review-fix.yml
@@ -50,7 +50,14 @@ jobs:
       - name: Post @claude comment to trigger fix
         env:
           GH_TOKEN: ${{ secrets.GH_ACTIONS_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
         run: |
-          gh pr comment "${{ github.event.pull_request.number }}" \
-            --repo "${{ github.repository }}" \
-            --body "@claude fix copilot reviews on this PR. Discover unresolved Copilot review threads, fix them, run build/test/lint, commit, push, and resolve the threads."
+          gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$(cat <<'BODY'
+          @claude Follow the procedure in `.github/prompts/review.prompt.md` with `--copilot-only` mode for this PR.
+
+          Phase 2: Resolve all unresolved Copilot review threads (discover → classify → fix → build/test/lint → commit/push → reply/resolve).
+          Phase 3: Detect recurring patterns from FIX-classified comments, propose and apply coding rules to `.github/instructions/`, then run `make sync-instructions`.
+          Phase 4: Post a summary comment on this PR.
+          BODY
+          )"


### PR DESCRIPTION
## Summary
- Rewrite `copilot-review-fix.yml` from a heavy claude-code-action runner to a lightweight trigger
- When Copilot submits a review, posts a detailed `@claude` comment referencing `review.prompt.md`
- This triggers `claude.yml` which runs claude-code-action with full Phase 2-4 procedure:
  - Phase 2: Resolve Copilot review threads (discover → classify → fix → build/test → commit/push → reply/resolve)
  - Phase 3: Learn from recurring patterns and update `.github/instructions/` rules
  - Phase 4: Post summary comment
- Avoids `GET /users/Copilot` 404 issue (claude-code-action#900)
- Removes `Bash(*)` from the Copilot-triggered workflow (reduces prompt injection risk for OSS)

## Setup required
- Add `GH_ACTIONS_TOKEN` secret (kotakanbe PAT with `issues: rw`, `pull-requests: rw`) ← done

## Flow
```
Copilot review → copilot-review-fix.yml → posts @claude comment (PAT) → claude.yml → Claude fixes (full review procedure)
```

## Test plan
- [ ] Verify Copilot review triggers the workflow and posts `@claude` comment with detailed prompt
- [ ] Verify `claude.yml` picks up the comment and runs Claude with Phase 2-4
- [ ] Verify `copilot-review` label manual trigger still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)