### PR TITLE
chore: add Dependabot configuration for Go modules and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## Summary

- Add `.github/dependabot.yml` (version 2) to enable automated dependency update PRs
- Configure **Go modules** (`gomod`) ecosystem: weekly on Monday, limit 10 open PRs
- Configure **GitHub Actions** ecosystem: weekly on Monday, limit 10 open PRs

Closes #20 (partial)

## Test plan

- [ ] Verify `.github/dependabot.yml` is valid YAML and recognized by GitHub
- [ ] Confirm Dependabot begins creating PRs for outdated Go modules after merge
- [ ] Confirm Dependabot begins creating PRs for outdated GitHub Actions after merge
- [ ] Verify open-pull-requests-limit of 10 is respected for each ecosystem

🤖 Generated with [Claude Code](https://claude.com/claude-code)