### PR TITLE
docs: add README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Uzomuzo
 
+[![CI](https://github.com/future-architect/uzomuzo-oss/actions/workflows/ci.yml/badge.svg)](https://github.com/future-architect/uzomuzo-oss/actions/workflows/ci.yml) [![Go Report Card](https://goreportcard.com/badge/github.com/future-architect/uzomuzo-oss)](https://goreportcard.com/report/github.com/future-architect/uzomuzo-oss) [![Go Reference](https://pkg.go.dev/badge/github.com/future-architect/uzomuzo-oss.svg)](https://pkg.go.dev/github.com/future-architect/uzomuzo-oss) [![Release](https://img.shields.io/github/v/release/future-architect/uzomuzo-oss)](https://github.com/future-architect/uzomuzo-oss/releases/latest) [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
+
 **Proactive lifecycle governance for OSS supply chains.** Detects abandoned, stalled, and effectively dead dependencies that traditional SCA tools report as "0 vulnerabilities — safe."
 
 ![uzomuzo demo](docs/assets/demo.gif)


### PR DESCRIPTION
## Summary
- Add project badges to README.md header: CI status, Go Report Card, Go Reference (GoDoc), Release version, and License
- Badges appear on line 3, between the heading and the project description

Relates to #20

## Test plan
- [ ] Verify badge images render correctly on the GitHub PR preview
- [ ] Confirm each badge links to the correct target (CI workflow, goreportcard, pkg.go.dev, releases, LICENSE file)
- [ ] Ensure no other README content was modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)