### PR TITLE
ci: add OpenSSF Scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,49 @@
+# OpenSSF Scorecard — measures supply-chain security posture.
+# Eat our own dog food: uzomuzo leverages Scorecard data, so we run it on ourselves.
+# https://github.com/ossf/scorecard-action
+
+name: OpenSSF Scorecard
+
+on:
+  branch_protection_rule:
+  schedule:
+    # Weekly: Monday 01:30 UTC
+    - cron: "30 1 * * 1"
+  push:
+    branches: [main]
+
+permissions: read-all
+
+jobs:
+  scorecard:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write  # upload SARIF results
+      id-token: write         # OIDC token for Scorecard API
+      contents: read
+      actions: read           # read workflow details for token-permissions check
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run OpenSSF Scorecard
+        uses: ossf/scorecard-action@05b42c624433fc40578a4040d5cf5e36ddca94b7 # v2.4.0
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload SARIF to code scanning
+        uses: github/codeql-action/upload-sarif@ff0a06e83cb2de871e5a09832bc6a81e7276941f # v3.28.18
+        with:
+          sarif_file: results.sarif
+
+      - name: Upload Scorecard results artifact
+        uses: actions/upload-artifact@ea165f8d65b6db9a8b71b5e51b26d3a7e05d0f30 # v4.6.2
+        with:
+          name: scorecard-results
+          path: results.sarif
+          retention-days: 5


### PR DESCRIPTION
## Summary

- Add OpenSSF Scorecard GitHub Action workflow (`.github/workflows/scorecard.yml`)
- Runs weekly (Monday 01:30 UTC), on push to main, and on branch protection rule changes
- Uploads SARIF results to GitHub code scanning and stores them as an artifact
- Publishes results to the OpenSSF Scorecard API

Since uzomuzo leverages Scorecard data to assess open-source projects, we should run it on ourselves ("eat our own dog food").

Closes #20 (partial)

## Test plan

- [ ] Verify workflow syntax is valid (Actions tab shows no parse errors)
- [ ] Confirm Scorecard run succeeds on the first push to main after merge
- [ ] Check that SARIF results appear under Security > Code scanning
- [ ] Verify results artifact is uploaded successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)