### PR TITLE
chore: add issue templates (bug report, feature request)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,37 @@
+---
+name: Bug Report
+about: Report a bug in uzomuzo
+title: ""
+labels: bug
+assignees: ""
+---
+
+## Describe the bug
+
+A clear and concise description of what the bug is.
+
+## To Reproduce
+
+Steps to reproduce the behavior:
+
+1. Run `uzomuzo ...`
+2. ...
+
+## Expected behavior
+
+A clear and concise description of what you expected to happen.
+
+## Actual behavior
+
+What actually happened. Include error messages or output if applicable.
+
+## Environment
+
+- uzomuzo version: [e.g., v0.1.0]
+- OS: [e.g., macOS 14.0, Ubuntu 22.04]
+- Go version (if building from source): [e.g., 1.26.1]
+- GITHUB_TOKEN set: [yes/no]
+
+## Additional context
+
+Add any other context about the problem here (e.g., SBOM format, PURL input).

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature Request
+about: Suggest a new feature or improvement
+title: ""
+labels: enhancement
+assignees: ""
+---
+
+## Problem
+
+A clear and concise description of the problem or use case this feature addresses.
+
+## Proposed Solution
+
+Describe the solution you'd like.
+
+## Alternatives Considered
+
+Describe any alternative solutions or features you've considered.
+
+## Additional Context
+
+Add any other context, examples, or screenshots about the feature request.


### PR DESCRIPTION
## Summary

- Add bug report issue template (`.github/ISSUE_TEMPLATE/bug_report.md`) with sections for reproduction steps, expected/actual behavior, and environment details
- Add feature request issue template (`.github/ISSUE_TEMPLATE/feature_request.md`) with sections for problem description, proposed solution, and alternatives

Refs #20

## Test plan

- [ ] Verify templates appear when creating a new issue on GitHub (Settings > Issues > Templates)
- [ ] Confirm bug report template includes all required fields (description, reproduce, expected, actual, environment)
- [ ] Confirm feature request template includes all required fields (problem, solution, alternatives, context)
- [ ] Verify `labels` frontmatter applies correct labels (`bug` and `enhancement` respectively)

🤖 Generated with [Claude Code](https://claude.com/claude-code)