### PR TITLE
chore: add Renovate configuration with 21-day release age gate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "minimumReleaseAge": "21 days",
+  "packageRules": [
+    {
+      "matchManagers": ["gomod"],
+      "groupName": "Go modules",
+      "groupSlug": "gomod"
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "groupName": "GitHub Actions",
+      "groupSlug": "github-actions"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Add `renovate.json` with `config:recommended` preset
- Set `minimumReleaseAge` to **21 days** to mitigate supply chain attacks from newly published malicious packages
- Group **Go modules** and **GitHub Actions** updates into single PRs to reduce review burden

Supersedes #50 (Dependabot config) — Renovate provides native release age gating that Dependabot lacks.

## Setup

After merging, install the [Renovate GitHub App](https://github.com/apps/renovate) on this repository for PRs to start appearing.

## Test plan

- [ ] Verify `renovate.json` is valid (schema validation)
- [ ] Confirm Renovate GitHub App is installed on the repo
- [ ] Verify Renovate creates a "Dependency Dashboard" issue after activation
- [ ] Confirm PRs are only created for versions released 21+ days ago
- [ ] Verify Go module updates are grouped into a single PR
- [ ] Verify GitHub Actions updates are grouped into a single PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)