### PR TITLE
fix: exclude testdata from Renovate dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
   "minimumReleaseAge": "21 days",
+  "ignorePaths": ["**/testdata/**"],
   "packageRules": [
     {
       "matchManagers": ["gomod"],


### PR DESCRIPTION
## Summary
- Add `"ignorePaths": ["**/testdata/**"]` to `renovate.json`
- Prevents Renovate from updating `go.mod` files inside `testdata/` directories, which broke tests in PR #61 (gin `v1.10.0` → `v1.12.0` in test fixture)

## Context
PR #61 (Renovate Go modules update) failed CI because Renovate updated `internal/infrastructure/depparser/gomod/testdata/go.mod`, changing dependency versions that tests assert against. Test fixtures should be stable and only updated intentionally.

## Test plan
- [ ] Verify next Renovate PR does not touch `**/testdata/**` files
- [ ] Confirm existing CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)