### PR TITLE
ci: restrict workflow token permissions to least privilege

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -6,6 +6,8 @@ on:
   pull_request_review_comment:
     types: [created]
 
+permissions: {}
+
 concurrency:
   group: claude-${{ github.event.issue.number || github.event.pull_request.number }}
   cancel-in-progress: true

--- a/.github/workflows/copilot-review-fix.yml
+++ b/.github/workflows/copilot-review-fix.yml
@@ -8,6 +8,8 @@ on:
   pull_request:
     types: [labeled]
 
+permissions: {}
+
 concurrency:
   group: copilot-review-${{ github.event.pull_request.number }}
   cancel-in-progress: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,11 +6,13 @@ on:
       - "v*"
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
## Summary
- **claude.yml**: Add top-level `permissions: {}` (job already has scoped perms)
- **copilot-review-fix.yml**: Add top-level `permissions: {}` (job already has scoped perms)
- **release.yml**: Restrict top-level to `contents: read`, move `contents: write` to job level

This applies the principle of least privilege to all workflows that were missing restrictive top-level permissions, improving the OpenSSF Scorecard **Token-Permissions** check (ref #63).

## Test plan
- [ ] Verify `claude.yml` still triggers correctly on `@claude` comments
- [ ] Verify `copilot-review-fix.yml` still triggers on Copilot review submission
- [ ] Verify `release.yml` goreleaser job can still create releases on tag push

🤖 Generated with [Claude Code](https://claude.com/claude-code)