### PR TITLE
docs: enforce English for Copilot PR review comments

### DIFF
--- a/.claude/rules/language-policy.md
+++ b/.claude/rules/language-policy.md
@@ -33,10 +33,5 @@ Source code and documentation are both in English for tooling compatibility and 
 
 ## Copilot Response Language Policy
 
-**GitHub Copilot Chat and Inline Chat responses must be in the same language as the user's question.**
-
-- **If the user asks in Japanese**: Respond in Japanese
-- **If the user asks in English**: Respond in English
-- **Match the user's communication language**: Always adapt to the language used in the user's question or comment
-
-This ensures natural communication and avoids language confusion during development.
+- **PR review comments**: Always in **English**. Automated PR reviews are public-facing project content and must follow the English-only documentation policy.
+- **Chat / Inline Chat**: Respond in the same language as the user's question (Japanese → Japanese, English → English).

--- a/.github/instructions/language-policy.instructions.md
+++ b/.github/instructions/language-policy.instructions.md
@@ -31,10 +31,5 @@ Source code and documentation are both in English for tooling compatibility and 
 
 ## Copilot Response Language Policy
 
-**GitHub Copilot Chat and Inline Chat responses must be in the same language as the user's question.**
-
-- **If the user asks in Japanese**: Respond in Japanese
-- **If the user asks in English**: Respond in English
-- **Match the user's communication language**: Always adapt to the language used in the user's question or comment
-
-This ensures natural communication and avoids language confusion during development.
+- **PR review comments**: Always in **English**. Automated PR reviews are public-facing project content and must follow the English-only documentation policy.
+- **Chat / Inline Chat**: Respond in the same language as the user's question (Japanese → Japanese, English → English).


### PR DESCRIPTION
## Summary
- Split Copilot response language policy: **PR review comments → always English**, Chat/Inline Chat → match user's language
- Fixes Japanese output in automated Copilot PR reviews (e.g., #76)

## Background
Copilot PR reviewer was generating Japanese comments because the language policy only said "match the user's language" without distinguishing automated reviews from interactive chat. Since PR reviews are public-facing project content, they should follow the English-only documentation policy.

## Test plan
- [ ] Verify next Copilot PR review generates English comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)