### PR TITLE
fix: use cosign --bundle flag for keyless signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,8 +35,7 @@ jobs:
       - name: Sign checksums with cosign (keyless)
         run: |
           cosign sign-blob --yes \
-            --output-signature dist/checksums.txt.sig \
-            --output-certificate dist/checksums.txt.pem \
+            --bundle dist/checksums.txt.bundle \
             dist/checksums.txt
 
       - name: Upload signatures to release
@@ -44,5 +43,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release upload "${{ github.ref_name }}" \
-            dist/checksums.txt.sig \
-            dist/checksums.txt.pem
+            dist/checksums.txt.bundle


### PR DESCRIPTION
## Summary

- Replace deprecated `--output-signature` / `--output-certificate` flags with `--bundle`
- cosign v4.1+ ignores the old flags under new bundle format, causing release workflow failure

## Context

v0.0.2 release failed at the signing step: `create bundle file: open : no such file or directory`

## Test plan

- [ ] Merge and re-tag v0.0.2 to verify signing succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)