### PR TITLE
feat: add monthly dependency scan workflow

### DIFF
--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -54,12 +54,6 @@ jobs:
           format: 'cyclonedx'
           output: 'sbom.json'
 
-      # TEMPORARY: Inject EOL dependency for testing (revert before merge)
-      - name: Inject test EOL dependency
-        run: |
-          jq '.components += [{"type":"library","name":"python","version":"2.7.18","purl":"pkg:pypi/python@2.7.18","bom-ref":"test-eol-python2"}]' sbom.json > sbom-test.json
-          mv sbom-test.json sbom.json
-
       - name: Run scan
         id: scan
         env:


### PR DESCRIPTION
## Summary

- Add GitHub Actions workflow for monthly dependency lifecycle scanning (closes #84)
- Uses Trivy to generate CycloneDX SBOM, then runs `uzomuzo scan --sbom` with `--fail-on`
- Supports `workflow_dispatch` with configurable inputs (fail-on, format, extra-args) for manual debugging
- Uploads SBOM as artifact (90-day retention)

## Test plan

- [ ] Trigger workflow manually via Actions tab with default inputs
- [ ] Verify Trivy SBOM generation succeeds
- [ ] Verify `uzomuzo scan --sbom sbom.json` runs and produces output
- [ ] Test with `fail-on` empty to confirm exit 0
- [ ] Test with `format: json` to verify JSON output


🤖 Generated with [Claude Code](https://claude.com/claude-code)