### PR TITLE
docs: add ADR-0005 and ADR-0006 for recent architectural decisions

### DIFF
--- a/docs/adr/0005-github-actions-health-scanning.md
+++ b/docs/adr/0005-github-actions-health-scanning.md
@@ -1,0 +1,62 @@
+# ADR-0005: GitHub Actions Health Scanning Architecture
+
+## Status
+
+Accepted (2026-04-03)
+
+## Context
+
+uzomuzo evaluates lifecycle health of software dependencies identified by PURLs or GitHub URLs. However, GitHub Actions — a critical part of the CI/CD supply chain — were invisible to this analysis. A repository could have all direct dependencies healthy while relying on unmaintained or EOL Actions in its workflows.
+
+Two approaches were considered for adding Actions scanning:
+
+1. **Treat Actions as dependencies**: Make the workflow parser implement `DependencyParser`, producing `ParsedDependency` values with PURLs. This would integrate seamlessly with the existing batch pipeline.
+2. **Standalone discovery, route as GitHub URLs**: Parse workflow YAML into GitHub URLs (`https://github.com/owner/repo`) and feed them through the existing `RunFromPURLs` pipeline separately.
+
+The key tension was that GitHub Actions do not have a native PURL ecosystem. Actions are identified by `owner/repo@ref` in workflow YAML, and deps.dev often misresolves them (e.g., `actions/checkout` maps to the npm package `checkout`). Forcing Actions into the PURL-centric `ParsedDependency` model would pollute the domain type with non-PURL entities.
+
+## Decision
+
+### Phase 1 (PR #93): Standalone workflow file scanning
+
+Add `--file .github/workflows/ci.yml` support via a standalone `ghaworkflow` infrastructure parser that:
+
+- Extracts `owner/repo` from `uses:` directives (standard, monorepo, reusable workflow patterns)
+- Skips `docker://` and `./local` references
+- Outputs GitHub URLs (not PURLs), routed directly to `RunFromPURLs(nil, githubURLs)`
+- Does **not** implement `DependencyParser` — preserving domain type purity
+
+### Phase 2 (PR #101): Repository-level Actions discovery
+
+Add `--include-actions` flag to `scan` that discovers Actions from a target repository's workflows:
+
+- New `actionscan.DiscoveryService` in infrastructure layer fetches `.github/workflows/*.yml` via GitHub Contents API
+- New `ActionsDiscoverer` interface in application layer decouples CLI from infrastructure
+- New `EntrySource` domain type (`"direct"` / `"actions"`) distinguishes user inputs from discovered Actions
+- New `RunFromPURLsWithActions` method (not modifying existing `RunFromPURLs`) avoids changing 4+ call sites
+- Renderers show Actions results in a separate `--- GitHub Actions ---` section
+- Opt-in (default off) because discovery multiplies API calls (1 Contents API call per workflow file + 1 analysis per Action)
+
+### Round-trip validation (PR #100)
+
+Added validation to detect and skip deps.dev misresolutions where a GitHub URL resolves to an unrelated package (e.g., `actions/checkout` → npm `checkout`). This is critical for Actions scanning because most Actions do not have corresponding registry packages.
+
+## Consequences
+
+### Positive
+
+- **Supply chain visibility**: Actions are now first-class scan targets, closing a blind spot in lifecycle analysis.
+- **Domain purity preserved**: `ParsedDependency` remains PURL-centric. Actions flow through the system as GitHub URLs.
+- **Incremental adoption**: `--include-actions` is opt-in, so existing workflows are unaffected.
+- **Composable**: `--include-actions` works with `--fail-on`, enabling CI gates on Actions health.
+
+### Negative
+
+- **No PURL ecosystem for Actions**: Actions without a corresponding registry package show "Review Needed" because deps.dev cannot resolve them. This is a fundamental limitation of the current PURL-based analysis model, not a design flaw.
+- **Additional API calls**: `--include-actions` requires Contents API calls to fetch workflow files, increasing rate limit consumption. Mitigated by being opt-in.
+- **Depth=1 only**: Phase 1-2 only discover direct Action references, not composite actions that themselves reference other Actions. Phase 3 (`--depth N`) is planned.
+
+### Neutral
+
+- ADR-0004 (scan subcommand unification) is extended — `scan` now accepts `--include-actions` alongside existing input modes.
+- The `ghaworkflow` parser from Phase 1 is reused internally by Phase 2's `DiscoveryService`.

--- a/docs/adr/0006-supply-chain-security-hardening.md
+++ b/docs/adr/0006-supply-chain-security-hardening.md
@@ -1,0 +1,59 @@
+# ADR-0006: Supply Chain Security Hardening for CI/CD and Releases
+
+## Status
+
+Accepted (2026-03-29)
+
+## Context
+
+The project aimed to improve its OpenSSF Scorecard rating and overall supply chain security posture. Several areas were identified as gaps (ref #63):
+
+1. **Release artifact integrity**: GoReleaser produced unsigned binaries. Users had no way to verify that release artifacts were built by the project's CI and not tampered with.
+2. **Workflow token permissions**: Multiple GitHub Actions workflows used default token permissions (read+write on all scopes), violating the principle of least privilege. A compromised action could access resources beyond what was needed.
+3. **Fork PR code execution**: The `claude.yml` workflow (AI-assisted code review) would check out and potentially execute code from fork PRs, enabling secret exfiltration via untrusted code.
+4. **Unpinned dependencies in CI**: `curl | sh` style installations (e.g., golangci-lint) allowed supply chain attacks via compromised install scripts.
+
+These gaps were addressed across three PRs (#68, #70, #72) as a coordinated security hardening initiative.
+
+## Decision
+
+### 1. Cosign/Sigstore keyless signing for releases (PR #70)
+
+- Add `sigstore/cosign-installer` (SHA-pinned) to the release workflow
+- After GoReleaser builds artifacts, `cosign sign-blob` signs `checksums.txt` using GitHub Actions OIDC identity (keyless — no secret management needed)
+- Signature (`.sig`) and certificate (`.pem`) are uploaded alongside release artifacts
+- Add `id-token: write` permission for Sigstore OIDC token exchange
+
+**Why keyless**: Traditional signing requires managing and rotating secret keys. Sigstore's keyless flow uses the CI's OIDC identity as the signing credential, tying artifact provenance to the specific GitHub Actions run. No secrets to leak, no keys to rotate.
+
+### 2. Least-privilege workflow token permissions (PR #68)
+
+- Add `permissions: {}` (deny-all) at the top level of `claude.yml` and `copilot-review-fix.yml`, with scoped permissions at the job level
+- Restrict `release.yml` top-level to `contents: read`, moving `contents: write` to the goreleaser job only
+- Each job declares only the permissions it actually needs
+
+### 3. Fork PR rejection and input hardening (PR #72)
+
+- Add `isCrossRepository` check in `claude.yml` before code checkout — fork PRs are rejected with a clear message
+- Restrict trigger to PR comments only (not issue comments) to prevent unintended execution
+- Replace `curl | sh` golangci-lint installation with SHA-pinned `golangci-lint-action@v7.0.1`
+
+## Consequences
+
+### Positive
+
+- **Verifiable releases**: Users can run `cosign verify-blob` to cryptographically verify artifact provenance back to a specific GitHub Actions run.
+- **Blast radius reduction**: A compromised GitHub Action in any workflow can only access the permissions explicitly granted to that job, not the default read+write scope.
+- **Fork safety**: Untrusted code from fork PRs cannot access repository secrets via the AI review workflow.
+- **Scorecard improvement**: Token-Permissions, Signed-Releases, and Pinned-Dependencies checks all improve.
+
+### Negative
+
+- **Verification friction**: Users must install cosign and run a verification command to check signatures. Mitigated by documenting the exact command in release notes.
+- **Maintenance overhead**: SHA-pinned dependencies require manual updates (or Renovate/Dependabot PRs) when new versions are released. This is an intentional trade-off — pinning prevents supply chain attacks at the cost of update friction.
+- **Fork contributor experience**: Fork PR authors cannot trigger AI review via `@claude` comments. They must wait for a maintainer to trigger it. This is the intended security boundary.
+
+### Neutral
+
+- These changes are CI-only — no impact on application code, domain logic, or user-facing CLI behavior.
+- Renovate is configured to propose updates for SHA-pinned Actions (PR #65), so the maintenance overhead is partially automated.


### PR DESCRIPTION
## Summary

- **ADR-0005**: GitHub Actions Health Scanning Architecture (PRs #93, #100, #101)
  - Documents the decision to use a standalone parser instead of `DependencyParser` for Actions
  - Explains opt-in `--include-actions` design and round-trip validation for deps.dev misresolutions
  - Covers the phased approach: workflow file scanning → repository-level discovery → recursive traversal

- **ADR-0006**: Supply Chain Security Hardening (PRs #68, #70, #72)
  - Documents cosign/Sigstore keyless signing for releases
  - Explains least-privilege token permissions across all workflows
  - Covers fork PR rejection and unpinned dependency elimination

## Test plan

- [x] ADR format matches existing ADRs (0001-0004)
- [x] No code changes — documentation only
- [x] References correct PR numbers and dates

🤖 Generated with [Claude Code](https://claude.com/claude-code)