### PR TITLE
docs: exclude Markdown files from Copilot code review

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -17,6 +17,10 @@ See `.github/instructions/` for detailed rules.
 | [security](instructions/security.instructions.md) | Prompt injection defense, credentials, Go security |
 | [agent-orchestration](instructions/agent-orchestration.instructions.md) | Available agents, usage rules, parallel execution |
 
+## Review Scope
+
+When performing code review on pull requests, **do not review or comment on Markdown files (`*.md`)**. Focus code review on Go source files, YAML workflows, and configuration files only.
+
 ## Quick Reference
 
 - **Language**: Source code = English only. Docs = English (`README.md`, `docs/*.md`). Respond in the user's language.


### PR DESCRIPTION
## Summary
- Add "Review Scope" section to `.github/copilot-instructions.md` instructing Copilot to skip `*.md` files during PR code reviews

## Test plan
- [ ] Open a PR with `.md` changes and verify Copilot does not comment on them
- [ ] Open a PR with `.go` changes and verify Copilot still reviews them

🤖 Generated with [Claude Code](https://claude.com/claude-code)