### PR TITLE
fix: merge main before Phase 3 rule edits to prevent overwriting

### DIFF
--- a/.github/prompts/review.prompt.md
+++ b/.github/prompts/review.prompt.md
@@ -236,6 +236,25 @@ that the project's coding rules should prevent in the future.
 This phase uses `.github/copilot-patterns.yml` as a **cross-PR pattern accumulator**.
 Patterns are recorded per-PR and promoted to coding rules once a category reaches 2+ entries.
 
+#### Step 3.0: Sync Rule Files with Main (REQUIRED)
+
+Phase 3 modifies shared files (`.github/copilot-patterns.yml`, `.github/instructions/*.instructions.md`)
+that may have been updated on `main` by other PRs since this branch diverged. To avoid overwriting
+those updates, **merge main into the PR branch before editing any rule files**:
+
+```bash
+git fetch origin main
+git merge origin/main --no-edit
+```
+
+If the merge has conflicts:
+- If conflicts are **only in rule files** (`.github/copilot-patterns.yml`, `.github/instructions/`,
+  `.claude/rules/`): resolve them by keeping both sides (accept all additions from both branches),
+  then continue with Phase 3.
+- If conflicts touch **source code**: abort the merge (`git merge --abort`), skip Phase 3 entirely,
+  and report "Phase 3 skipped: PR branch has merge conflicts with main. Rebase manually before
+  re-running."
+
 #### Step 3.1: Record Current Patterns
 
 For each FIX-classified comment (from the current run AND from already-resolved Copilot threads


### PR DESCRIPTION
## Summary

- Add **Step 3.0** to `review.prompt.md` requiring `git merge origin/main` before Phase 3 edits
- Prevents Copilot auto-fix commits from silently overwriting rules added by other merged PRs
- Includes conflict handling guidance (rule-only conflicts → resolve both sides; source conflicts → abort and report)

## Root Cause

PR #111's Copilot auto-fix commit (`c7f63e6`) edited `.github/instructions/coding-standards.instructions.md` on a branch that was behind `main`. The branch's copy was missing two rules added by PR #107, so the auto-fix commit overwrote the file and deleted them:
- `Consistent Conditional Columns Across Output Formats`
- `Nil vs Empty Map Semantics for Sentinel-Checked Maps`

## Test plan

- [ ] Verify that on the next Copilot review run, Phase 3 merges main before editing rule files
- [ ] Verify that if merge conflicts occur in rule files only, they are resolved by keeping both sides
- [ ] Verify that if merge conflicts touch source code, Phase 3 is skipped with a clear message

🤖 Generated with [Claude Code](https://claude.com/claude-code)