### PR TITLE
docs: update output examples for left-border box format

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,26 @@ A package with zero CVEs today may have been abandoned for years — no one is w
 ### What SCA misses — EOL-Effective
 
 ```text
-📦 Package: pkg:npm/dicer@0.3.0
-⚖️  Result: 🛑 EOL-Effective
-💭 Reason: Scorecard data incomplete; open advisories (1) and no human commits > 2 yrs
-📦 Latest Stable Release: 0.3.1 (2021-12-19)
-   ↳ Stable Advisories: 1
-      • [GHSA] GHSA-wm7h-9275-46v2
-💻 Latest Commit: 2023-07-15
+── pkg:npm/dicer@0.3.1 ─────────────────────────────────────
+│ Package: pkg:npm/dicer@0.3.1
+│ Description: A very fast streaming multipart parser for node.js
+├─ Verdict ─────────────────────────────────────────────────
+│ 🔴 EOL-Effective
+│ Reason: Low maintenance score; open advisories (1, max: HIGH 7.5) on latest version, no new release in 1566 days
+├─ Health ──────────────────────────────────────────────────
+│ GitHub: Normal (188 stars)
+│ Used by: 1271 packages
+│ Score: 2.8/10  Maintained: 0.0/10
+├─ Releases ────────────────────────────────────────────────
+│ Stable: 0.3.1 (2021-12-19)  ⚠️ Advisories: 1 (max: HIGH 7.5)
+│   HIGH     (7.5)  GHSA-wm7h-9275-46v2  Crash in HeaderParser in dicer
+│   → https://deps.dev/npm/dicer/0.3.1
+├─ License ─────────────────────────────────────────────────
+│ MIT (source: depsdev-project-spdx / project-fallback)
+├─ Links ───────────────────────────────────────────────────
+│ Repository: https://github.com/mscdex/dicer
+│ deps.dev: https://deps.dev/npm/dicer
+└───────────────────────────────────────────────────────────
 ```
 
 No official deprecation, no archived repository — yet `dicer` has an unpatched ReDoS vulnerability (CVSS 7.5 — HIGH severity) with zero human commits in over two years. SCA tools report "1 CVE" and move on. uzomuzo recognizes the combination of HIGH/CRITICAL unpatched advisory + maintenance absence as **effectively end-of-life**. This package sits in the Express dependency chain (via busboy → multer), meaning millions of applications silently depend on abandoned code.
@@ -146,29 +159,51 @@ uzomuzo classifies each package into one of seven lifecycle states using a multi
 ### Active — `express` (193K dependents)
 
 ```text
-📦 Package: pkg:npm/express@4.22.1
-⚖️  Result: 🟢 Active
-💭 Reason: Recent stable package version published with recent human commits; maintenance score ≥ 3
-📊 GitHub Info: Normal (⭐ 68954 stars)
-👥 Dependents: 192926
-🏆 Overall Score: 8.3/10
-  🔧 Maintained: 10.0/10
-📦 Latest Stable Release: 5.2.1 (2025-12-01)
-💻 Latest Commit: 2026-03-01
+── pkg:npm/express@4.18.2 ──────────────────────────────────
+│ Package: pkg:npm/express@4.18.2
+│ Description: Fast, unopinionated, minimalist web framework for node.
+│   Homepage: https://expressjs.com
+│   Registry: https://www.npmjs.com/package/express
+├─ Verdict ─────────────────────────────────────────────────
+│ ✅ Active
+│ Reason: Recent stable package version published; maintenance score ≥ 3
+├─ Health ──────────────────────────────────────────────────
+│ GitHub: Normal (68892 stars)
+│ Used by: 2211 packages
+│ Depends on: 31 direct, 39 transitive
+│ Score: 8.4/10  Maintained: 10.0/10
+├─ Releases ────────────────────────────────────────────────
+│ Stable: 5.2.1 (2025-12-01)  Advisories: 0
+│ Requested: 4.18.2 (2022-10-08)
+├─ License ─────────────────────────────────────────────────
+│ MIT (source: depsdev-project-spdx / depsdev-version-spdx)
+├─ Links ───────────────────────────────────────────────────
+│ Repository: https://github.com/expressjs/express
+│ deps.dev: https://deps.dev/npm/express
+└───────────────────────────────────────────────────────────
 ```
 
 ### Legacy-Safe — `function-bind` (1M+ dependents)
 
 ```text
-📦 Package: pkg:npm/function-bind@1.1.2
-⚖️  Result: 🔵 Legacy-Safe
-💭 Reason: No known advisories; no human commits for > 2 yrs
-👥 Dependents: 1061436
-🏆 Overall Score: 4.5/10
-  🔧 Maintained: 0.0/10
-📦 Latest Stable Release: 1.1.2 (2023-10-12)
-   ↳ Stable Advisories: 0
-💻 Latest Commit: 2023-10-12
+── pkg:npm/function-bind@1.1.2 ─────────────────────────────
+│ Package: pkg:npm/function-bind@1.1.2
+├─ Verdict ─────────────────────────────────────────────────
+│ ✅ Legacy-Safe
+│ Reason: No known advisories; no human commits for > 2 yrs
+├─ Health ──────────────────────────────────────────────────
+│ GitHub: Normal (139 stars)
+│ Used by: 1077300 packages
+│ Score: 4.5/10  Maintained: 0.0/10
+│ Last Commit: 2023-10-12
+├─ Releases ────────────────────────────────────────────────
+│ Stable: 1.1.2 (2023-10-12)  Advisories: 0
+├─ License ─────────────────────────────────────────────────
+│ MIT (source: depsdev-project-spdx / depsdev-version-spdx)
+├─ Links ───────────────────────────────────────────────────
+│ Repository: https://github.com/raynos/function-bind
+│ deps.dev: https://deps.dev/npm/function-bind
+└───────────────────────────────────────────────────────────
 ```
 
 Scorecard says Maintained 0.0 — but zero advisories and does one thing perfectly. uzomuzo classifies it as **frozen and safe**.
@@ -176,14 +211,26 @@ Scorecard says Maintained 0.0 — but zero advisories and does one thing perfect
 ### Stalled — `grunt` (12K stars)
 
 ```text
-📦 Package: pkg:npm/grunt@1.6.1
-⚖️  Result: ⚪ Stalled
-💭 Reason: Recent human commits, no recent package publishing, maintenance score < 3
-📊 GitHub Info: Normal (⭐ 12253 stars)
-🏆 Overall Score: 4.0/10
-  🔧 Maintained: 0.0/10
-📦 Latest Stable Release: 1.6.1 (2023-01-31)
-💻 Latest Commit: 2025-11-05
+── pkg:npm/grunt@1.6.1 ─────────────────────────────────────
+│ Package: pkg:npm/grunt@1.6.1
+│ Description: Grunt: The JavaScript Task Runner
+│   Homepage: http://gruntjs.com/
+├─ Verdict ─────────────────────────────────────────────────
+│ ⚠️ Stalled
+│ Reason: Recent human commits, no recent package publishing, maintenance score < 3
+├─ Health ──────────────────────────────────────────────────
+│ GitHub: Normal (12244 stars)
+│ Used by: 1113 packages
+│ Score: 4.0/10  Maintained: 0.0/10
+│ Last Commit: 2025-11-05
+├─ Releases ────────────────────────────────────────────────
+│ Stable: 1.6.1 (2023-01-31)  Advisories: 0
+├─ License ─────────────────────────────────────────────────
+│ MIT (source: derived-from-version / depsdev-version-spdx)
+├─ Links ───────────────────────────────────────────────────
+│ Repository: https://github.com/gruntjs/grunt
+│ deps.dev: https://deps.dev/npm/grunt
+└───────────────────────────────────────────────────────────
 ```
 
 Still has occasional commits, but no npm release since 2023. Not dead, not active — clearly declining.
@@ -191,16 +238,29 @@ Still has occasional commits, but no npm release since 2023. Not dead, not activ
 ### EOL-Confirmed — `inflight` (556K dependents)
 
 ```text
-📦 Package: pkg:npm/inflight@1.0.6
-⚖️  Result: 🔴 EOL-Confirmed
-💭 Reason: Repository is archived or disabled on GitHub
-📚 EOL Evidence:
-   • [npmjs] Stable version is deprecated in npm registry.
-     Message: This module is not supported, and leaks memory. Do not use it.
-🔁 Successor: lru-cache
-📊 GitHub Info: 📦 Archived (⭐ 76 stars)
-👥 Dependents: 556304
-📦 Latest Stable Release: 1.0.6 (2016-10-13) [DEPRECATED]
+── pkg:npm/inflight@1.0.6 ──────────────────────────────────
+│ Package: pkg:npm/inflight@1.0.6
+│ Description: Add callbacks to requests in flight to avoid async duplication
+├─ Verdict ─────────────────────────────────────────────────
+│ 🔴 EOL-Confirmed
+│ Reason: Repository is archived or disabled on GitHub
+├─ EOL ─────────────────────────────────────────────────────
+│ ➡️ Successor: it
+│ Evidence (1):
+│   [npmjs] Stable version is deprecated in npm registry.
+├─ Health ──────────────────────────────────────────────────
+│ GitHub: 📦 Archived (76 stars)
+│ Used by: 556777 packages
+│ Score: 2.9/10  Maintained: 0.0/10
+│ Last Commit: 2024-05-23
+├─ Releases ────────────────────────────────────────────────
+│ Stable: 1.0.6 (2016-10-13)  Advisories: 0 ⚠️ [DEPRECATED]
+├─ License ─────────────────────────────────────────────────
+│ ISC (source: derived-from-version / depsdev-version-spdx)
+├─ Links ───────────────────────────────────────────────────
+│ Repository: https://github.com/npm/inflight
+│ deps.dev: https://deps.dev/npm/inflight
+└───────────────────────────────────────────────────────────
 ```
 
 556K dependents. GitHub archived, npm deprecated. Last release 2016. **Migrate immediately.**
@@ -208,17 +268,26 @@ Still has occasional commits, but no npm release since 2023. Not dead, not activ
 ### EOL-Effective — `dicer` (busboy → multer → express)
 
 ```text
-📦 Package: pkg:npm/dicer@0.3.0
-⚖️  Result: 🛑 EOL-Effective
-💭 Reason: Scorecard data incomplete; open advisories (1) and no human commits > 2 yrs
-📊 GitHub Info: Normal (⭐ 188 stars)
-👥 Dependents: 4689
-🏆 Overall Score: 2.8/10
-  🔧 Maintained: 0.0/10
-📦 Latest Stable Release: 0.3.1 (2021-12-19)
-   ↳ Stable Advisories: 1
-      • [GHSA] GHSA-wm7h-9275-46v2
-💻 Latest Commit: 2023-07-15
+── pkg:npm/dicer@0.3.1 ─────────────────────────────────────
+│ Package: pkg:npm/dicer@0.3.1
+│ Description: A very fast streaming multipart parser for node.js
+├─ Verdict ─────────────────────────────────────────────────
+│ 🔴 EOL-Effective
+│ Reason: Low maintenance score; open advisories (1, max: HIGH 7.5) on latest version, no new release in 1566 days
+├─ Health ──────────────────────────────────────────────────
+│ GitHub: Normal (188 stars)
+│ Used by: 1271 packages
+│ Score: 2.8/10  Maintained: 0.0/10
+├─ Releases ────────────────────────────────────────────────
+│ Stable: 0.3.1 (2021-12-19)  ⚠️ Advisories: 1 (max: HIGH 7.5)
+│   HIGH     (7.5)  GHSA-wm7h-9275-46v2  Crash in HeaderParser in dicer
+│   → https://deps.dev/npm/dicer/0.3.1
+├─ License ─────────────────────────────────────────────────
+│ MIT (source: depsdev-project-spdx / project-fallback)
+├─ Links ───────────────────────────────────────────────────
+│ Repository: https://github.com/mscdex/dicer
+│ deps.dev: https://deps.dev/npm/dicer
+└───────────────────────────────────────────────────────────
 ```
 
 No deprecation, no archive — but unpatched ReDoS + zero maintenance. **SCA blind spot.**

--- a/docs/adr/0008-transitive-composite-action-scanning.md
+++ b/docs/adr/0008-transitive-composite-action-scanning.md
@@ -83,30 +83,32 @@ The existing section-based separation (`--- GitHub Actions ---`) is replaced wit
 **Table format**: A `SOURCE` column is added to the verdict table. The following example uses actual CLI output format with full GitHub URLs. The `transitive` source for library dependencies is a future extension; currently only `action-transitive` is implemented.
 
 ```
-VERDICT  SOURCE              PURL                                              LIFECYCLE   EOL
-ok       direct              https://github.com/future-architect/uzomuzo-oss   Active      Not EOL
-ok       action              https://github.com/actions/checkout               Active      Not EOL
-ok       action-transitive   https://github.com/actions/cache                  Active      Not EOL
+STATUS      SOURCE              PURL                                              LIFECYCLE   EOL
+✅ ok        direct              https://github.com/future-architect/uzomuzo-oss   Active      Not EOL
+✅ ok        action              https://github.com/actions/checkout               Active      Not EOL
+✅ ok        action-transitive   https://github.com/actions/cache                  Active      Not EOL
 ```
 
 **Detailed format**: The summary table at the top includes the `SOURCE` column. Per-entry headers include source annotation when entries have multiple source types (e.g., `--- PURL 1 (direct) ---`, `--- PURL 6 (action) ---`, `--- PURL 12 (action-transitive) ---`).
 
 ```
 --- Summary Table ---
-VERDICT  SOURCE              PURL                                              LIFECYCLE   EOL
-ok       direct              https://github.com/future-architect/uzomuzo-oss   Active      Not EOL
-ok       action              https://github.com/actions/checkout               Active      Not EOL
-ok       action-transitive   https://github.com/actions/cache                  Active      Not EOL
+STATUS      SOURCE              PURL                                              LIFECYCLE   EOL
+✅ ok        direct              https://github.com/future-architect/uzomuzo-oss   Active      Not EOL
+✅ ok        action              https://github.com/actions/checkout               Active      Not EOL
+✅ ok        action-transitive   https://github.com/actions/cache                  Active      Not EOL
 
---- PURL 1 (direct) ---
-📦 Package: https://github.com/future-architect/uzomuzo-oss
-⚖️  Result: Active
+── https://github.com/future-architect/uzomuzo-oss (direct) ──
+│ Package: https://github.com/future-architect/uzomuzo-oss
+├─ Verdict ─────────────────────────────────────────────────
+│ ✅ Active
 ...
 
---- PURL 6 (action-transitive) ---
-📦 Package: https://github.com/actions/cache
-🔗 Via: https://github.com/aquasecurity/trivy-action
-⚖️  Result: Active
+── https://github.com/actions/cache (action-transitive) ────
+│ Package: https://github.com/actions/cache
+│ Via: https://github.com/aquasecurity/trivy-action
+├─ Verdict ─────────────────────────────────────────────────
+│ ✅ Active
 ...
 ```
 

--- a/docs/adr/0009-sbom-dependency-relation-detection.md
+++ b/docs/adr/0009-sbom-dependency-relation-detection.md
@@ -42,24 +42,24 @@ A `RELATION` column is added to output when SBOM input is used:
 **Table format:**
 
 ```
-VERDICT  RELATION                  PURL                        LIFECYCLE   EOL
-ok       direct                    pkg:npm/express@4.18.2      Active      Not EOL
-ok       transitive (express)      pkg:npm/accepts@1.3.8       Active      Not EOL
+STATUS      RELATION                  PURL                        LIFECYCLE   EOL
+✅ ok        direct                    pkg:npm/express@4.18.2      Active      Not EOL
+✅ ok        transitive (express)      pkg:npm/accepts@1.3.8       Active      Not EOL
 ```
 
 **Detailed format** includes a `Relation:` line per entry:
 
 ```
---- PURL 1 ---
-📦 Package: pkg:npm/express@4.18.2
-🔗 Relation: direct
-⚖️  Result: 🟢 Active
+── pkg:npm/express@4.18.2 (direct) ─────────────────────────
+│ Package: pkg:npm/express@4.18.2
+├─ Verdict ─────────────────────────────────────────────────
+│ ✅ Active
 ...
 
---- PURL 2 ---
-📦 Package: pkg:npm/accepts@1.3.8
-🔗 Relation: transitive (express)
-⚖️  Result: 🟢 Active
+── pkg:npm/accepts@1.3.8 (transitive via express) ──────────
+│ Package: pkg:npm/accepts@1.3.8
+├─ Verdict ─────────────────────────────────────────────────
+│ ✅ Active
 ...
 ```
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -32,25 +32,28 @@
 ```text
 $ uzomuzo scan pkg:npm/express@4.18.2
 
---- PURL 1 ---
-📦 Package: pkg:npm/express@4.18.2
-🧾 Description: Fast, unopinionated, minimalist web framework for node.
-   🔗 Homepage: https://expressjs.com
-   🗃 Registry: https://www.npmjs.com/package/express
-⚖️  Result: 🟢 Active
-💭 Reason: Recent stable package version published; maintenance score ≥ 3
-📊 GitHub Info: Normal (⭐ 68886 stars)
-👥 Used by: 2210 packages
-📦 Depends on: 31 direct, 39 transitive
-🏆 Overall Score: 8.4/10
-  🔧 Maintained: 10.0/10
-📦 Latest Stable Release: 5.2.1 (2025-12-01)
-   ↳ Stable Advisories: 0
-📦 Highest Version (SemVer): 5.2.1 (2025-12-01)
-📋 Requested Version: 4.18.2 (2022-10-08)
-📄 License: MIT (source: depsdev-project-spdx / depsdev-version-spdx)
-🔗 Repository: https://github.com/expressjs/express
-🔗 Scorecard: https://scorecard.dev/viewer/?uri=github.com%2Fexpressjs%2Fexpress
+── pkg:npm/express@4.18.2 ──────────────────────────────────
+│ Package: pkg:npm/express@4.18.2
+│ Description: Fast, unopinionated, minimalist web framework for node.
+│   Homepage: https://expressjs.com
+│   Registry: https://www.npmjs.com/package/express
+├─ Verdict ─────────────────────────────────────────────────
+│ ✅ Active
+│ Reason: Recent stable package version published; maintenance score ≥ 3
+├─ Health ──────────────────────────────────────────────────
+│ GitHub: Normal (68892 stars)
+│ Used by: 2211 packages
+│ Depends on: 31 direct, 39 transitive
+│ Score: 8.4/10  Maintained: 10.0/10
+├─ Releases ────────────────────────────────────────────────
+│ Stable: 5.2.1 (2025-12-01)  Advisories: 0
+│ Requested: 4.18.2 (2022-10-08)
+├─ License ─────────────────────────────────────────────────
+│ MIT (source: depsdev-project-spdx / depsdev-version-spdx)
+├─ Links ───────────────────────────────────────────────────
+│ Repository: https://github.com/expressjs/express
+│ deps.dev: https://deps.dev/npm/express
+└───────────────────────────────────────────────────────────
 ```
 
 For ≤3 inputs, the `detailed` format is used automatically. Use `--format detailed` to force it for larger inputs.
@@ -112,7 +115,7 @@ When scanning GitHub URLs, `--include-actions` automatically fetches the target 
 ./uzomuzo scan https://github.com/owner/repo --include-actions --fail-on stalled
 ```
 
-Output includes a `--- GitHub Actions ---` separator between direct results and discovered Actions. JSON and CSV formats include a `source` field (`"actions"` for discovered entries).
+Output includes a `SOURCE` column to distinguish direct results from discovered Actions. JSON and CSV formats include a `source` field (`"actions"` for discovered entries).
 
 > **Note:** `--include-actions` is opt-in because it makes additional GitHub API calls to fetch workflow files. It requires `GITHUB_TOKEN` to be set (the Contents API is used to fetch workflow YAML). It is only supported for GitHub URL inputs (not `--sbom` or `--file go.mod`).
 
@@ -189,11 +192,13 @@ Rules:
 
 ```text
 $ uzomuzo scan pkg:npm/request@2.88.2 pkg:npm/express@4.18.2 --format table
-VERDICT  PURL                    LIFECYCLE  EOL
-replace  pkg:npm/request@2.88.2  EOL        EOL
-ok       pkg:npm/express@4.18.2  Active     Not EOL
+STATUS      PURL                    LIFECYCLE  EOL
+🔴 replace   pkg:npm/request@2.88.2  EOL        EOL
+✅ ok        pkg:npm/express@4.18.2  Active     Not EOL
 
-Summary: 2 dependencies | 1 ok | 0 caution | 1 replace | 0 review
+── Summary ─────────────────────────────────────────────────
+│ 2 dependencies | ✅ 1 ok | ⚠️ 0 caution | 🔴 1 replace | 🔍 0 review
+└───────────────────────────────────────────────────────────
 ```
 
 </details>
@@ -205,12 +210,14 @@ When scanning an SBOM that includes dependency graph information, a `RELATION` c
 
 ```text
 $ trivy fs . --format cyclonedx | uzomuzo scan --sbom - --show-transitive --format table
-VERDICT  RELATION                  PURL                        LIFECYCLE  EOL
-ok       direct                    pkg:npm/express@4.18.2      Active     Not EOL
-ok       transitive (express)      pkg:npm/accepts@1.3.8       Active     Not EOL
-replace  transitive (express)      pkg:npm/inflight@1.0.6      EOL        EOL
+STATUS      RELATION                  PURL                        LIFECYCLE  EOL
+✅ ok        direct                    pkg:npm/express@4.18.2      Active     Not EOL
+✅ ok        transitive (express)      pkg:npm/accepts@1.3.8       Active     Not EOL
+🔴 replace   transitive (express)      pkg:npm/inflight@1.0.6      EOL        EOL
 
-Summary: 3 dependencies | 2 ok | 0 caution | 1 replace | 0 review
+── Summary ─────────────────────────────────────────────────
+│ 3 dependencies | ✅ 2 ok | ⚠️ 0 caution | 🔴 1 replace | 🔍 0 review
+└───────────────────────────────────────────────────────────
 ```
 
 Without `--show-transitive`, only `direct` entries are displayed — transitive issues are addressed by updating the direct dependency that introduces them.
@@ -286,10 +293,12 @@ Without `--fail-on`, exit code is always 0 regardless of scan results.
 
 ```text
 $ uzomuzo scan pkg:npm/request@2.88.2 --fail-on eol-confirmed --format table
-VERDICT  PURL                    LIFECYCLE  EOL
-replace  pkg:npm/request@2.88.2  EOL        EOL
+STATUS      PURL                    LIFECYCLE  EOL
+🔴 replace   pkg:npm/request@2.88.2  EOL        EOL
 
-Summary: 1 dependencies | 0 ok | 0 caution | 1 replace | 0 review
+── Summary ─────────────────────────────────────────────────
+│ 1 dependencies | ✅ 0 ok | ⚠️ 0 caution | 🔴 1 replace | 🔍 0 review
+└───────────────────────────────────────────────────────────
 # exit code: 1  (request is EOL-Confirmed → matches --fail-on eol-confirmed)
 ```
 
@@ -297,10 +306,12 @@ Summary: 1 dependencies | 0 ok | 0 caution | 1 replace | 0 review
 
 ```text
 $ uzomuzo scan pkg:npm/request@2.88.2 --fail-on eol-effective --format table
-VERDICT  PURL                    LIFECYCLE  EOL
-replace  pkg:npm/request@2.88.2  EOL        EOL
+STATUS      PURL                    LIFECYCLE  EOL
+🔴 replace   pkg:npm/request@2.88.2  EOL        EOL
 
-Summary: 1 dependencies | 0 ok | 0 caution | 1 replace | 0 review
+── Summary ─────────────────────────────────────────────────
+│ 1 dependencies | ✅ 0 ok | ⚠️ 0 caution | 🔴 1 replace | 🔍 0 review
+└───────────────────────────────────────────────────────────
 # exit code: 0  (request is EOL-Confirmed, not EOL-Effective → no match)
 ```
 
@@ -308,11 +319,13 @@ Summary: 1 dependencies | 0 ok | 0 caution | 1 replace | 0 review
 
 ```text
 $ uzomuzo scan pkg:npm/request@2.88.2 pkg:npm/express@4.18.2 --fail-on eol-confirmed,stalled --format table
-VERDICT  PURL                    LIFECYCLE  EOL
-replace  pkg:npm/request@2.88.2  EOL        EOL
-ok       pkg:npm/express@4.18.2  Active     Not EOL
+STATUS      PURL                    LIFECYCLE  EOL
+🔴 replace   pkg:npm/request@2.88.2  EOL        EOL
+✅ ok        pkg:npm/express@4.18.2  Active     Not EOL
 
-Summary: 2 dependencies | 1 ok | 0 caution | 1 replace | 0 review
+── Summary ─────────────────────────────────────────────────
+│ 2 dependencies | ✅ 1 ok | ⚠️ 0 caution | 🔴 1 replace | 🔍 0 review
+└───────────────────────────────────────────────────────────
 # exit code: 1  (request matches eol-confirmed)
 ```
 


### PR DESCRIPTION
## Summary

Update all documentation output examples to match the new left-border box drawing format from #115.

## Changes

| File | Updates |
|------|---------|
| `README.md` | 6 output examples replaced (dicer intro + 5 lifecycle state samples) |
| `docs/usage.md` | Detailed output example, 4 table examples (VERDICT→STATUS, emoji, box summary), `--include-actions` description |
| `docs/adr/0008-transitive-composite-action-scanning.md` | Table + detailed format examples |
| `docs/adr/0009-sbom-dependency-relation-detection.md` | Table + detailed format examples |

## Not changed

- `docs/assets/juice-shop-eol-result.txt` — historical snapshot, left as-is
- Juice Shop batch summary in README — uses legacy batch path format (separate scope)

## Test plan

- [x] All output examples use real `uzomuzo scan` output
- [x] VERDICT→STATUS rename applied consistently
- [x] Box-style summary line in all table examples
- [x] No broken markdown links

🤖 Generated with [Claude Code](https://claude.com/claude-code)
