### PR TITLE
fix: review policy to fix all severity levels before push

### DIFF
--- a/.github/agents/code-reviewer.agent.md
+++ b/.github/agents/code-reviewer.agent.md
@@ -135,9 +135,8 @@ Fix: Move parallel processing to internal/infrastructure/integration/
 
 ## Approval Criteria
 
-- APPROVE: No CRITICAL or HIGH issues
-- WARNING: MEDIUM issues only (can merge with caution)
-- BLOCK: CRITICAL or HIGH issues found
+- APPROVE: No issues at any severity level
+- BLOCK: Any unresolved issues found (CRITICAL, HIGH, MEDIUM, or LOW)
 
 ## Quick Checks via Bash
 

--- a/.github/prompts/review.prompt.md
+++ b/.github/prompts/review.prompt.md
@@ -39,7 +39,7 @@ Wait for both agents to complete.
 
 #### Step 1.2: Apply Fixes
 
-After collecting findings from both agents, **directly fix** all CRITICAL and HIGH issues **within the diff under review**. For MEDIUM and LOW issues, fix them if the fix is straightforward and low-risk **and can be done entirely within the diff**. Any findings that would require changes outside the diff must be treated as skipped/unfixable for Phase 1 and only reported, not edited.
+After collecting findings from both agents, **directly fix all issues regardless of severity** (CRITICAL, HIGH, MEDIUM, and LOW) **within the diff under review**. The goal is to eliminate all findings before push so that Copilot has nothing to flag. Any findings that would require changes outside the diff must be treated as skipped/unfixable for Phase 1 and only reported, not edited.
 
 **Do NOT post review comments to the PR.** The goal is to fix the code, not to leave comments.
 


### PR DESCRIPTION
## Summary

- **review.prompt.md**: Phase 1 now fixes **all findings regardless of severity** (CRITICAL, HIGH, MEDIUM, and LOW), not just CRITICAL/HIGH
- **code-reviewer.agent.md**: Approval criteria simplified — APPROVE requires zero issues at any severity, otherwise BLOCK

## Motivation

Copilot reviews flag issues at all severity levels. The CI fix loop (Copilot flags → auto-fix → re-push → re-review) takes several minutes per iteration. Fixing everything locally before push is far more efficient for faster merges.

## Test plan

- [ ] Run `/review` on a branch with MEDIUM/LOW findings and verify they are all fixed
- [ ] Confirm code-reviewer agent blocks on any unresolved finding

🤖 Generated with [Claude Code](https://claude.com/claude-code)