### PR TITLE
fix: use PAT for workflow_dispatch doc update PRs to trigger CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,12 +81,14 @@ jobs:
       - name: Create PR with updated doc examples (manual trigger)
         if: github.event_name == 'workflow_dispatch'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # PAT required — GITHUB_TOKEN push does not trigger CI on the new branch.
+          GH_TOKEN: ${{ secrets.GH_ACTIONS_TOKEN }}
         run: |
           git diff --quiet README.md docs/usage.md docs/assets/juice-shop-eol-result.txt && echo "No changes" && exit 0
           BRANCH="docs/update-examples-$(date +%Y%m%d-%H%M%S)"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
           git checkout -b "$BRANCH"
           git add README.md docs/usage.md docs/assets/juice-shop-eol-result.txt
           git commit -m "docs: update output examples"


### PR DESCRIPTION
## Summary

Switch `workflow_dispatch` doc-update path from `secrets.GITHUB_TOKEN` to `secrets.GH_ACTIONS_TOKEN` (PAT) and set the remote URL to use it. GitHub does not trigger CI checks for pushes authenticated with `GITHUB_TOKEN` (to prevent recursive workflow runs), so the PAT is required for the auto-created PR to have CI checks run.

## Changes

- Replace `GH_TOKEN: secrets.GITHUB_TOKEN` → `GH_TOKEN: secrets.GH_ACTIONS_TOKEN` in the `doc-examples` job
- Add `git remote set-url origin` to authenticate the push with the PAT
- Add inline comment explaining why the PAT is needed

## Test plan

- [ ] Run workflow_dispatch after merge → auto-generated PR should have CI checks running

🤖 Generated with [Claude Code](https://claude.com/claude-code)