### PR TITLE
docs: add Actions scanning to Technical Novelty, fix flag docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,12 +116,15 @@ uzomuzo scan --format json       # JSON output for CI integration
 # CI gate: exit 1 if any EOL dependency found
 uzomuzo scan --sbom bom.json --fail-on eol-confirmed
 
-# Batch from Trivy SBOM
+# Batch from Trivy SBOM (show only packages that need replacement)
 trivy image --format cyclonedx bkimminich/juice-shop:v14.5.1 \
-  | uzomuzo scan --sbom - --fail-on eol-confirmed,eol-effective
+  | uzomuzo scan --sbom - --fail-on eol-confirmed,eol-effective --show-only replace
 
 # Scan a repo's GitHub Actions dependencies
 uzomuzo scan https://github.com/owner/repo --include-actions
+
+# Scan a workflow YAML directly
+uzomuzo scan --file .github/workflows/ci.yml
 
 # File input (one PURL per line)
 uzomuzo scan --file input_purls.txt --sample 500
@@ -167,6 +170,7 @@ uzomuzo classifies each package into one of seven lifecycle states using a multi
 | **Ecosystem-aware delivery model** | Go modules deliver via VCS-direct; npm via registry publish. The same "commits without publish" signal means different things per ecosystem. |
 | **Evidence trails** | Every label includes a reason string and decision trace, so security teams can audit *why* a package was flagged. |
 | **Graduated precision** | Works without GitHub token (deps.dev only); adding a token unlocks commit history and Scorecard for high-precision assessment. |
+| **GitHub Actions supply chain scanning** | CI/CD workflows depend on third-party Actions that are themselves OSS. uzomuzo extracts `uses:` directives, recursively resolves composite actions (including local `./` references), and evaluates each Action's lifecycle. |
 
 <details>
 <summary><strong>Sample Output — All lifecycle states (detailed format)</strong></summary>

--- a/cmd/uzomuzo/commands.go
+++ b/cmd/uzomuzo/commands.go
@@ -43,7 +43,7 @@ func scanFlags() []urfcli.Flag {
 		&urfcli.BoolFlag{Name: "include-actions", Usage: "Also scan GitHub Actions referenced in target repositories' workflows"},
 
 		// Transitive dependency display
-		&urfcli.BoolFlag{Name: "show-transitive", Usage: "Include transitive dependencies in output (requires --include-actions; e.g., composite action deps)"},
+		&urfcli.BoolFlag{Name: "show-transitive", Usage: "Include transitive dependencies in output (SBOM/go.mod: transitive deps; --include-actions: composite action deps)"},
 
 		// Output filtering
 		&urfcli.StringFlag{Name: "show-only", Usage: "Show only entries with specified verdicts (comma-separated: ok,caution,replace,review)"},

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -200,6 +200,20 @@ Output includes a `SOURCE` column to distinguish direct results from discovered 
 
 > **Note:** `--include-actions` is opt-in because it makes additional GitHub API calls to fetch workflow files. It requires `GITHUB_TOKEN` to be set (the Contents API is used to fetch workflow YAML). It is only supported for GitHub URL inputs (not `--sbom` or `--file go.mod`).
 
+#### Transitive Composite Action Scanning
+
+When combined with `--show-transitive`, `--include-actions` recursively resolves composite actions referenced by the discovered workflows. This includes:
+
+- **Remote composite actions**: Actions that reference other Actions via `uses:` in their `action.yml`
+- **Local composite actions**: `./` references resolved via the GitHub Contents API relative to the repository root
+
+```bash
+# Include transitive composite action dependencies
+./uzomuzo scan https://github.com/owner/repo --include-actions --show-transitive
+```
+
+Cycle detection prevents infinite recursion when composite actions reference each other.
+
 ### File Input (PURL/URL list)
 
 List one identifier per line (PURL or GitHub URL) in a text file:
@@ -458,43 +472,6 @@ Use `uzomuzo --help` for the full list, or `uzomuzo scan --help` for scan-specif
 |------------|-------------|
 | `scan` | Scan dependencies for lifecycle health (PURL, GitHub URL, SBOM, go.mod, file, pipe) |
 | `update-spdx` | Update and regenerate the embedded SPDX license list from upstream |
-
-## License CSV Column Reference (`--export-license-csv`)
-
-1 row = 1 PURL (`Analysis`). Version-side licenses are aggregated with **semicolon separators** without adding rows.
-
-| Column | Type | Source / Mapping | Purpose |
-|--------|------|------------------|---------|
-| original_purl | string | `Analysis.OriginalPURL` | Exact user input. Key for matching in reproduction tests / audit logs. |
-| effective_purl | string | `Analysis.EffectivePURL` | Final identifier after resolution. Used for re-fetching and cache keys. |
-| version_resolved | bool(string) | `IsVersionResolved()` | true = version identified. false rows are "latest dependency" with change risk. |
-| project_license_identifier | string | `ProjectLicense.Identifier` | Confirmed project SPDX / normalized identifier. Empty if undetermined. |
-| project_license_raw | string | `ProjectLicense.Raw` | Upstream raw string. Primary source for non-SPDX / notation variation investigation. |
-| project_license_source | string | `ProjectLicense.Source` | License acquisition path. For trust level / improvement priority analysis by source. |
-| project_license_is_spdx | bool | `ProjectLicense.IsSPDX` | true = official SPDX. false with raw present = normalization improvement candidate. |
-| project_license_is_zero | bool | `ProjectLicense.IsZero()` | true = project license absent. Starting point for fallback/promotion decisions. |
-| version_license_identifiers | string(list) | Version slice.Identifier | Version-side SPDX/normalized identifiers (`;` separated). Multi-license overview. |
-| version_license_raws | string(list) | Version slice.Raw | Version-side raw strings (`;`). For checking composite expressions and notation variations. |
-| version_license_sources | string(list) | Version slice.Source | Source list (`;`). For SPDX / non-SPDX ratio analysis. |
-| version_license_count | int | len(slice) | Version-side license count. Dual/multi-license detection. |
-| version_licenses_all_non_spdx | bool | derived | true = all non-SPDX. Priority extraction target for normalization. |
-| version_licenses_any_composite_expr | bool | AND/OR/() detection | true = contains composite conditions (AND/OR). Raises legal review priority. |
-| project_vs_version_mismatch | bool | derived | true = Project SPDX not found in Version set, indicating divergence. |
-| licenses_all_missing_or_nonstandard | bool | derived | true = no confirmed SPDX. Coverage KPI denominator & improvement tracking. |
-| fallback_applied | bool | version source==`project-fallback` | true = Project SPDX copied to Version. Indicates original data gap. |
-| derived_from_version | bool | project source==`derived-from-version` | true = single Version SPDX promoted. Suggests missing Project metadata. |
-| github_override_applied | bool | GitHub override sources | true = GitHub info used preferentially. Override logic triggered. |
-| license_resolution_scenario | string | classifier | License state tag. Filter/pivot starting point. Unknown values can be safely ignored. |
-| error | string | `Analysis.Error` | Analysis failure reason. Non-empty rows should not trust other columns; re-run candidates. |
-| registry_url | string | `PackageLinks.RegistryURL` | Official registry page. Shortcut to original source. |
-| repository_url | string | `RepoURL` | Source repository. Entry point for LICENSE file / update re-fetch. |
-
-Legend:
-
-- `string(list)` uses `;` separator. No in-element `;` expected (escape spec will be added if needed)
-- bool columns output as string `true` / `false`. Convert to boolean on the consumer side
-- "derived" flags (fallback_applied / derived_from_version) indicate algorithm intervention
-- `license_resolution_scenario` may have new labels added in the future. Ignore unknown values or bucket as "other"
 
 ## Analysis Precision and `GITHUB_TOKEN`
 


### PR DESCRIPTION
## Summary
- Add **GitHub Actions supply chain scanning** to Technical Novelty table in README
- Add `--show-only` and workflow YAML direct scan examples to README Quick Start
- Fix `--show-transitive` flag description — it works with SBOM/go.mod too, not just `--include-actions`
- Remove undocumented `--export-license-csv` section from docs/usage.md (CLI flag not wired up)
- Document transitive composite action scanning (recursive resolution + local `./` refs) in docs/usage.md

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Verify `uzomuzo scan --help` shows updated `--show-transitive` description
- [ ] Verify docs/usage.md no longer references `--export-license-csv`

🤖 Generated with [Claude Code](https://claude.com/claude-code)