### PR TITLE
ci: remove automatic doc-examples from PR triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,16 +30,12 @@ jobs:
 
   doc-examples:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch'
     permissions:
       contents: write
       pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          # PR: checkout head branch for pushback. Manual: checkout default ref.
-          ref: ${{ github.head_ref || github.ref }}
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
@@ -48,38 +44,19 @@ jobs:
       - name: Check doc example markers
         run: make check-doc-examples
 
-      - name: Update doc examples (PR — skip juice-shop, no trivy)
-        if: github.event_name == 'pull_request'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: make update-doc-examples
-
-      - name: Install trivy (manual trigger only)
-        if: github.event_name == 'workflow_dispatch'
+      - name: Install trivy
         run: |
           curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/75c4dc0f45c5d7ffd05ae26df1e0c666787bdf2a/contrib/install.sh \
             | sh -s -- -b /usr/local/bin v0.69.3
 
-      - name: Update doc examples (manual — including juice-shop)
-        if: github.event_name == 'workflow_dispatch'
+      - name: Update doc examples
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           go build -o uzomuzo ./cmd/uzomuzo
           go run ./scripts/update-doc-examples --skip-build
 
-      - name: Commit updated doc examples (PR)
-        if: github.event_name == 'pull_request'
-        run: |
-          git diff --quiet README.md docs/usage.md && exit 0
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add README.md docs/usage.md
-          git commit -m "docs: update output examples"
-          git push
-
-      - name: Create PR with updated doc examples (manual trigger)
-        if: github.event_name == 'workflow_dispatch'
+      - name: Create PR with updated doc examples
         env:
           # PAT required — GITHUB_TOKEN push does not trigger CI on the new branch.
           GH_TOKEN: ${{ secrets.GH_ACTIONS_TOKEN }}


### PR DESCRIPTION
## Summary
- Remove `doc-examples` job from `pull_request` trigger — restrict to `workflow_dispatch` only
- Consolidate the previously split PR/manual paths into a single `workflow_dispatch` flow

## Problem
The `doc-examples` job pushed commits using `GITHUB_TOKEN`, which does not trigger new workflow runs (GitHub anti-loop policy). This left required checks (`lint`, `test`) permanently pending on the auto-pushed HEAD commit, blocking PR merges (#143, #144).

Additionally, live API data (star counts etc.) caused spurious doc diffs on every PR run.

## Test plan
- [ ] Verify `lint` and `test` checks pass on this PR (no `doc-examples` interference)
- [ ] Verify `workflow_dispatch` still works for manual doc refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)