### PR TITLE
fix: detect archived repos from Scorecard data without GITHUB_TOKEN

### DIFF
--- a/docs/data-flow.md
+++ b/docs/data-flow.md
@@ -129,6 +129,7 @@ The lifecycle assessor uses two distinct decision paths depending on `GITHUB_TOK
 │                                                                     │
 │ Capabilities:                                                       │
 │  • Publish recency + advisories → coarse classification            │
+│  • Archive detection via Scorecard "Maintained" check → EOL-Confirmed│
 │  • No commit signals → cannot detect active-but-unpublished        │
 │  • Packages with commits but no publish → misclassified as Stalled │
 └─────────────────────────────────────────────────────────────────────┘

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -493,14 +493,14 @@ uzomuzo combines data from **deps.dev** (package registry) and **GitHub API** (r
 
 | Data Source | Available Without Token | Requires `GITHUB_TOKEN` |
 |-------------|------------------------|------------------------|
-| **deps.dev** | Package versions & publish dates, Scorecard metrics, Advisory/CVE counts, Dependent counts, License info | — |
-| **GitHub API** | — | Last human commit date, Bot vs. human commit ratio, Archive/disabled status, Fork detection |
+| **deps.dev** | Package versions & publish dates, Scorecard metrics (including archive detection via "Maintained" check), Advisory/CVE counts, Dependent counts, License info | — |
+| **GitHub API** | — | Last human commit date, Bot vs. human commit ratio, Fork detection |
 
 ### How missing data affects lifecycle classification
 
 | Actual State | With Token | Without Token | Risk |
 |--------------|-----------|---------------|------|
-| Archived repository | **EOL-Confirmed** | Stalled | False negative — clear EOL signal missed |
+| Archived repository | **EOL-Confirmed** | **EOL-Confirmed** | Detected via Scorecard "Maintained" check — no token needed |
 | Unpatched CVEs + no commits for 2+ years | **EOL-Effective** | Stalled | False negative — supply chain risk missed |
 | Active Go/Composer package (commits but no registry publish) | **Active** | Stalled | False positive — healthy package flagged |
 | Frozen utility with zero advisories | **Legacy-Safe** | Stalled | False positive — safe package flagged |

--- a/internal/infrastructure/depsdev/api_types.go
+++ b/internal/infrastructure/depsdev/api_types.go
@@ -190,11 +190,10 @@ type VersionKey struct {
 // ============================================================================
 
 type ReleaseInfo struct {
-	StableVersion       Version
-	PreReleaseVersion   Version
-	MaxSemverVersion    Version
-	RequestedVersion    Version
-	IsArchivedInDepsDep bool
+	StableVersion     Version
+	PreReleaseVersion Version
+	MaxSemverVersion  Version
+	RequestedVersion  Version
 
 	Endpoint string
 	Error    error

--- a/internal/infrastructure/github/client.go
+++ b/internal/infrastructure/github/client.go
@@ -267,13 +267,14 @@ func (c *Client) FetchRepositoryStates(ctx context.Context, analyses map[string]
 				"affected_repos", repoCount,
 			)
 		}
-		// Set default values for all analyses instead of failing
+		// Set default values for all analyses instead of failing.
+		// Preserve IsArchived if already set from Scorecard data (deps.dev fallback).
 		for _, analysis := range analyses {
 			if analysis != nil {
 				if analysis.RepoState == nil {
 					analysis.RepoState = &domain.RepoState{}
 				}
-				analysis.RepoState.IsArchived = false
+				// Don't overwrite IsArchived — it may already be true via Scorecard "Maintained" check
 				analysis.RepoState.IsDisabled = false
 			}
 		}

--- a/internal/infrastructure/integration/populate_project.go
+++ b/internal/infrastructure/integration/populate_project.go
@@ -44,6 +44,18 @@ func (s *IntegrationService) populateProjectScorecard(analysis *domain.Analysis,
 		}
 		analysis.Scores = scores
 	}
+
+	// Detect archived status from Scorecard "Maintained" check reason.
+	// When GITHUB_TOKEN is unavailable, this is the only source of archive detection.
+	for _, check := range checks {
+		if check.Name == "Maintained" && strings.Contains(strings.ToLower(check.Reason), "project is archived") {
+			if analysis.RepoState == nil {
+				analysis.RepoState = &domain.RepoState{}
+			}
+			analysis.RepoState.IsArchived = true
+			break
+		}
+	}
 }
 
 // populateReleaseInfo builds domain.ReleaseInfo & related links.

--- a/internal/infrastructure/integration/populate_project_test.go
+++ b/internal/infrastructure/integration/populate_project_test.go
@@ -1,0 +1,82 @@
+package integration
+
+import (
+	"testing"
+
+	domain "github.com/future-architect/uzomuzo-oss/internal/domain/analysis"
+	"github.com/future-architect/uzomuzo-oss/internal/infrastructure/depsdev"
+)
+
+func TestPopulateProjectScorecard_ArchivedDetection(t *testing.T) {
+	tests := []struct {
+		name           string
+		checks         []depsdev.ScorecardCheckSet
+		wantIsArchived bool
+	}{
+		{
+			name: "archived repo detected from Maintained reason",
+			checks: []depsdev.ScorecardCheckSet{
+				{Name: "Maintained", Score: 0, Reason: "project is archived"},
+			},
+			wantIsArchived: true,
+		},
+		{
+			name: "archived repo detected case-insensitively",
+			checks: []depsdev.ScorecardCheckSet{
+				{Name: "Maintained", Score: 0, Reason: "Project is Archived"},
+			},
+			wantIsArchived: true,
+		},
+		{
+			name: "archived embedded in longer reason",
+			checks: []depsdev.ScorecardCheckSet{
+				{Name: "Maintained", Score: 0, Reason: "0 commit(s) and 0 issue activity found in the last 90 days -- project is archived"},
+			},
+			wantIsArchived: true,
+		},
+		{
+			name: "non-archived repo",
+			checks: []depsdev.ScorecardCheckSet{
+				{Name: "Maintained", Score: 5, Reason: "12 commit(s) and 3 issue activity found in the last 90 days"},
+			},
+			wantIsArchived: false,
+		},
+		{
+			name: "no Maintained check present",
+			checks: []depsdev.ScorecardCheckSet{
+				{Name: "Code-Review", Score: 8, Reason: "all changesets reviewed"},
+			},
+			wantIsArchived: false,
+		},
+		{
+			name: "empty checks",
+			checks: nil,
+			wantIsArchived: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := &IntegrationService{}
+			analysis := &domain.Analysis{
+				OriginalPURL:  "pkg:golang/github.com/mitchellh/copystructure@1.0.0",
+				EffectivePURL: "pkg:golang/github.com/mitchellh/copystructure@1.0.0",
+				RepoURL:       "https://github.com/mitchellh/copystructure",
+			}
+			batch := &depsdev.BatchResult{
+				Project: &depsdev.Project{
+					Scorecard: depsdev.ScorecardData{
+						Checks: tt.checks,
+					},
+				},
+			}
+
+			svc.populateProjectScorecard(analysis, batch)
+
+			gotArchived := analysis.RepoState != nil && analysis.RepoState.IsArchived
+			if gotArchived != tt.wantIsArchived {
+				t.Errorf("IsArchived = %v, want %v", gotArchived, tt.wantIsArchived)
+			}
+		})
+	}
+}

--- a/internal/interfaces/cli/batch.go
+++ b/internal/interfaces/cli/batch.go
@@ -428,7 +428,7 @@ func configureAuthentication(inputs *ProcessingInputs, cfg *domaincfg.Config, op
 	}
 
 	fmt.Fprintf(os.Stderr, "\nNOTE: GITHUB_TOKEN is not set — analysis uses deps.dev and scorecard data only.\n")
-	fmt.Fprintf(os.Stderr, "  For higher precision (commit history, archive detection): set GITHUB_TOKEN in .env or run 'gh auth login'\n\n")
+	fmt.Fprintf(os.Stderr, "  Archive detection works via Scorecard. For higher precision (commit history, fork detection): set GITHUB_TOKEN in .env or run 'gh auth login'\n\n")
 
 	return nil
 }


### PR DESCRIPTION
## Summary

- Parse Scorecard "Maintained" check reason for `"project is archived"` to detect archived repos via deps.dev, eliminating the need for `GITHUB_TOKEN`
- Preserve `IsArchived` in the no-token GitHub fallback path instead of unconditionally overwriting it with `false`
- Remove unused `IsArchivedInDepsDep` field from infra `ReleaseInfo` struct

Closes #152

## Before (without `GITHUB_TOKEN`)

All three archived repos are misclassified as **Stalled**:

```
$ GITHUB_TOKEN="" uzomuzo scan --file go.mod --format table
STATUS      PURL                                                  RELATION  LIFECYCLE  BUILD
⚠️ caution  pkg:golang/github.com/mitchellh/copystructure@v1.2.0  direct    Stalled    Moderate 4.6
⚠️ caution  pkg:golang/github.com/mitchellh/go-homedir@v1.1.0     direct    Stalled    Moderate 4.7
⚠️ caution  pkg:golang/github.com/fatih/structs@v1.1.0            direct    Stalled    Moderate 5.3

── Summary ─────────────────────────────────────────────────
│ 3 dependencies | ✅ 0 ok | ⚠️ 3 caution | 🔴 0 replace | 🔍 0 review
└───────────────────────────────────────────────────────────
```

## After (without `GITHUB_TOKEN`)

All three are correctly detected as **EOL-Confirmed**:

```
$ GITHUB_TOKEN="" uzomuzo scan --file go.mod --format table
STATUS      PURL                                                  RELATION  LIFECYCLE      BUILD
🔴 replace  pkg:golang/github.com/mitchellh/copystructure@v1.2.0  direct    EOL-Confirmed  —
🔴 replace  pkg:golang/github.com/mitchellh/go-homedir@v1.1.0     direct    EOL-Confirmed  —
🔴 replace  pkg:golang/github.com/fatih/structs@v1.1.0            direct    EOL-Confirmed  —

── Summary ─────────────────────────────────────────────────
│ 3 dependencies | ✅ 0 ok | ⚠️ 0 caution | 🔴 3 replace | 🔍 0 review
└───────────────────────────────────────────────────────────
```

## Test plan

- [x] New unit tests for `populateProjectScorecard` archived detection (6 cases: exact match, case-insensitive, embedded reason, non-archived, no Maintained check, empty checks)
- [x] All existing tests pass (`go test ./internal/...`)
- [x] Manual before/after verification with `GITHUB_TOKEN=""` using known archived packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)