### PR TITLE
docs: base worktree creation on origin/main to reduce push conflicts

### DIFF
--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -41,10 +41,13 @@ Multiple Claude Code sessions or terminals may run concurrently in the same repo
 
 Stale worktrees accumulate disk clutter, but **deleting an active worktree breaks another session**. Use `git worktree lock` to guard active worktrees.
 
-#### Creating a worktree (ALWAYS lock immediately)
+#### Creating a worktree (ALWAYS fetch + lock immediately)
+
+**Always base new worktrees on `origin/main`**, not the local `main` branch. A stale local `main` causes all worktrees to diverge from the remote, increasing conflict probability on push — especially when multiple sessions run in parallel.
 
 ```bash
-git worktree add .claude/worktrees/<name> -b <branch-name>
+git fetch origin main
+git worktree add .claude/worktrees/<name> -b <branch-name> origin/main
 git worktree lock .claude/worktrees/<name> --reason "session active: $(date -Iseconds)"
 ```
 

--- a/.github/instructions/git-workflow.instructions.md
+++ b/.github/instructions/git-workflow.instructions.md
@@ -39,10 +39,13 @@ Multiple Claude Code sessions or terminals may run concurrently in the same repo
 
 Stale worktrees accumulate disk clutter, but **deleting an active worktree breaks another session**. Use `git worktree lock` to guard active worktrees.
 
-#### Creating a worktree (ALWAYS lock immediately)
+#### Creating a worktree (ALWAYS fetch + lock immediately)
+
+**Always base new worktrees on `origin/main`**, not the local `main` branch. A stale local `main` causes all worktrees to diverge from the remote, increasing conflict probability on push — especially when multiple sessions run in parallel.
 
 ```bash
-git worktree add .claude/worktrees/<name> -b <branch-name>
+git fetch origin main
+git worktree add .claude/worktrees/<name> -b <branch-name> origin/main
 git worktree lock .claude/worktrees/<name> --reason "session active: $(date -Iseconds)"
 ```
 


### PR DESCRIPTION
## Summary
- Worktree creation rule now requires `git fetch origin main` before `git worktree add`
- Base branch changed from local `main` to `origin/main` to ensure worktrees always start from the latest remote state
- Prevents stale-base conflicts when multiple Claude sessions create worktrees in parallel

## Test plan
- [ ] Verify `make sync-instructions` output matches canonical source
- [ ] Confirm new worktree creation instructions work: `git fetch origin main && git worktree add .claude/worktrees/test -b test-branch origin/main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)