### PR TITLE
fix: clamp normalizeGraphImpact to upper bound of 1.0

### DIFF
--- a/internal/domain/diet/scoring.go
+++ b/internal/domain/diet/scoring.go
@@ -99,7 +99,8 @@ func normalizeGraphImpact(g GraphMetrics, maxExclusive int) float64 {
 	}
 	raw := float64(g.ExclusiveTransitiveCount) / float64(maxExclusive)
 	// Scale to [0.1, 1.0] so even zero-exclusive deps retain a small base score.
-	return 0.1 + 0.9*raw
+	// Clamp to 1.0 defensively in case exclusive > maxExclusive.
+	return math.Min(0.1+0.9*raw, 1.0)
 }
 
 func normalizeCouplingEffort(c CouplingAnalysis) float64 {

--- a/internal/domain/diet/scoring_test.go
+++ b/internal/domain/diet/scoring_test.go
@@ -145,6 +145,7 @@ func TestNormalizeGraphImpact(t *testing.T) {
 		{"half exclusive, max=50", 25, 50, 0.55},
 		{"small exclusive, max=50", 1, 50, 0.118},
 		{"zero maxExclusive", 5, 0, 0.1},
+		{"exclusive exceeds max (defensive)", 100, 47, 1.0},
 	}
 	const tolerance = 0.001
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- Add `math.Min(..., 1.0)` defensive clamp to `normalizeGraphImpact` to enforce the documented `[0.1, 1.0]` range
- Add test case for `exclusive > maxExclusive` overflow scenario

Closes #179

## Test plan

- [x] Existing `TestNormalizeGraphImpact` passes (all 6 cases including new overflow case)
- [x] `TestComputeImpactScore_LargeProject` passes
- [x] Full `internal/domain/diet/` test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)