### PR TITLE
fix: clamp normalizeGraphImpact to upper bound of 1.0

### DIFF
--- a/internal/domain/diet/scoring.go
+++ b/internal/domain/diet/scoring.go
@@ -99,7 +99,7 @@ func normalizeGraphImpact(g GraphMetrics, maxExclusive int) float64 {
 	}
 	raw := float64(g.ExclusiveTransitiveCount) / float64(maxExclusive)
 	// Scale to [0.1, 1.0] so even zero-exclusive deps retain a small base score.
-	return 0.1 + 0.9*raw
+	return math.Min(0.1+0.9*raw, 1.0)
 }
 
 func normalizeCouplingEffort(c CouplingAnalysis) float64 {

--- a/internal/domain/diet/scoring_test.go
+++ b/internal/domain/diet/scoring_test.go
@@ -145,6 +145,7 @@ func TestNormalizeGraphImpact(t *testing.T) {
 		{"half exclusive, max=50", 25, 50, 0.55},
 		{"small exclusive, max=50", 1, 50, 0.118},
 		{"zero maxExclusive", 5, 0, 0.1},
+		{"exclusive exceeds max (defensive)", 100, 47, 1.0},
 	}
 	const tolerance = 0.001
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- Add `math.Min(..., 1.0)` clamp to `normalizeGraphImpact` to prevent `GraphImpact` from exceeding 1.0 when `ExclusiveTransitiveCount > maxExclusive`
- Add defensive test case for `exclusive > max` scenario

Closes #179

## Test plan
- [x] Existing `TestNormalizeGraphImpact` cases still pass
- [x] New test case `exclusive exceeds max (defensive)` verifies clamp to 1.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)