### PR TITLE
fix: show Quick Wins line in diet summary even when count is 0

### DIFF
--- a/internal/interfaces/cli/diet_render.go
+++ b/internal/interfaces/cli/diet_render.go
@@ -133,9 +133,7 @@ func renderDietTable(w io.Writer, plan *domaindiet.DietPlan) error {
 	if plan.Summary.UnusedDirect > 0 {
 		p.printf("  Unused (0 imports):  %d\n", plan.Summary.UnusedDirect)
 	}
-	if plan.Summary.EasyWins > 0 {
-		p.printf("  Quick wins:          %d  (trivial/easy + high impact)\n", plan.Summary.EasyWins)
-	}
+	p.printf("  Quick wins:          %d  (trivial/easy + high impact)\n", plan.Summary.EasyWins)
 
 	if p.err != nil {
 		return p.err


### PR DESCRIPTION
## Summary

- Always display the "Quick wins" line in the diet plan summary header, even when the count is 0
- Explicitly showing "Quick wins: 0" tells users no low-effort, high-impact removals were found, rather than silently omitting the line

Closes #168

## Test plan

- [ ] Run `uzomuzo diet` on a project with no quick wins — verify "Quick wins: 0" appears
- [ ] Run `uzomuzo diet` on a project with quick wins — verify count is shown as before
- [ ] Verify JSON output still includes `easy_wins: 0` (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)