### PR TITLE
fix: show Quick Wins line in diet summary even when count is 0

### DIFF
--- a/internal/interfaces/cli/diet_render.go
+++ b/internal/interfaces/cli/diet_render.go
@@ -133,9 +133,7 @@ func renderDietTable(w io.Writer, plan *domaindiet.DietPlan) error {
 	if plan.Summary.UnusedDirect > 0 {
 		p.printf("  Unused (0 imports):  %d\n", plan.Summary.UnusedDirect)
 	}
-	if plan.Summary.EasyWins > 0 {
-		p.printf("  Quick wins:          %d  (trivial/easy + high impact)\n", plan.Summary.EasyWins)
-	}
+	p.printf("  Quick wins:          %d  (trivial/easy + high impact)\n", plan.Summary.EasyWins)
 
 	if p.err != nil {
 		return p.err

--- a/internal/interfaces/cli/diet_render_test.go
+++ b/internal/interfaces/cli/diet_render_test.go
@@ -1,0 +1,37 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	domaindiet "github.com/future-architect/uzomuzo-oss/internal/domain/diet"
+)
+
+func TestRenderDietTable_QuickWinsAlwaysShown(t *testing.T) {
+	tests := []struct {
+		name     string
+		easyWins int
+		want     string
+	}{
+		{"zero quick wins", 0, "Quick wins:          0"},
+		{"nonzero quick wins", 3, "Quick wins:          3"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plan := &domaindiet.DietPlan{
+				Summary: domaindiet.DietSummary{
+					TotalDirect: 10,
+					EasyWins:    tt.easyWins,
+				},
+			}
+			var buf bytes.Buffer
+			if err := renderDietTable(&buf, plan); err != nil {
+				t.Fatalf("renderDietTable() error: %v", err)
+			}
+			if !strings.Contains(buf.String(), tt.want) {
+				t.Errorf("output does not contain %q\ngot:\n%s", tt.want, buf.String())
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Remove conditional guard on Quick Wins line in the diet table header so it always displays, even when `EasyWins == 0`
- Add `diet_render_test.go` with table-driven test covering both zero and nonzero quick wins

Closes #168

## Test plan

- [x] `TestRenderDietTable_QuickWinsAlwaysShown/zero_quick_wins` — verifies "Quick wins: 0" appears
- [x] `TestRenderDietTable_QuickWinsAlwaysShown/nonzero_quick_wins` — verifies "Quick wins: 3" appears
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)