### PR TITLE
fix: show Quick Wins line in diet summary even when count is 0

### DIFF
--- a/internal/interfaces/cli/diet_render.go
+++ b/internal/interfaces/cli/diet_render.go
@@ -133,9 +133,7 @@ func renderDietTable(w io.Writer, plan *domaindiet.DietPlan) error {
 	if plan.Summary.UnusedDirect > 0 {
 		p.printf("  Unused (0 imports):  %d\n", plan.Summary.UnusedDirect)
 	}
-	if plan.Summary.EasyWins > 0 {
-		p.printf("  Quick wins:          %d  (trivial/easy + high impact)\n", plan.Summary.EasyWins)
-	}
+	p.printf("  Quick wins:          %d  (trivial/easy + high impact)\n", plan.Summary.EasyWins)
 
 	if p.err != nil {
 		return p.err

--- a/internal/interfaces/cli/diet_render_test.go
+++ b/internal/interfaces/cli/diet_render_test.go
@@ -1,0 +1,38 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	domaindiet "github.com/future-architect/uzomuzo-oss/internal/domain/diet"
+)
+
+func TestRenderDietTable_QuickWinsAlwaysShown(t *testing.T) {
+	tests := []struct {
+		name     string
+		easyWins int
+		want     string
+	}{
+		{"zero quick wins", 0, "Quick wins:          0"},
+		{"nonzero quick wins", 3, "Quick wins:          3"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plan := &domaindiet.DietPlan{
+				Summary: domaindiet.DietSummary{
+					TotalDirect: 10,
+					EasyWins:    tt.easyWins,
+				},
+			}
+			var buf bytes.Buffer
+			if err := renderDietTable(&buf, plan); err != nil {
+				t.Fatalf("renderDietTable() error: %v", err)
+			}
+			output := buf.String()
+			if !strings.Contains(output, tt.want) {
+				t.Errorf("expected output to contain %q, got:\n%s", tt.want, output)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Display `Quick wins: 0` unconditionally in the diet table summary header, so users always see whether low-effort high-impact removals exist
- Previously the line was omitted when `EasyWins == 0`, which could confuse users into thinking the metric wasn't computed

## Changes

- `internal/interfaces/cli/diet_render.go`: Remove `if plan.Summary.EasyWins > 0` guard around the Quick wins line
- `internal/interfaces/cli/diet_render_test.go`: Add test verifying Quick wins is shown for both zero and nonzero counts

Closes #168

## Test plan

- [x] `TestRenderDietTable_QuickWinsAlwaysShown/zero_quick_wins` — verifies "Quick wins: 0" appears in output
- [x] `TestRenderDietTable_QuickWinsAlwaysShown/nonzero_quick_wins` — verifies "Quick wins: 3" appears in output
- [x] `go test ./internal/interfaces/cli/ -run TestRenderDietTable` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)