### PR TITLE
fix: normalize JS/TS and Java import path case for PURL matching

### DIFF
--- a/internal/infrastructure/treesitter/analyzer.go
+++ b/internal/infrastructure/treesitter/analyzer.go
@@ -615,12 +615,16 @@ func (a *Analyzer) handleJavaImport(
 	importToPURL map[string]string,
 	aliasMap map[string]string,
 ) {
+	// Lowercase the import path for matching — importToPURL keys are already lowercased
+	// to handle PURL case-insensitivity (see AnalyzeCoupling).
+	lowerPath := strings.ToLower(importPath)
+
 	// Pick the longest matching prefix to handle overlapping groupIds
 	// (e.g., prefer "org.apache.commons" over "org.apache").
 	bestIP := ""
 	bestPURL := ""
 	for ip, purl := range importToPURL {
-		if (importPath == ip || strings.HasPrefix(importPath, ip+".")) && len(ip) > len(bestIP) {
+		if (lowerPath == ip || strings.HasPrefix(lowerPath, ip+".")) && len(ip) > len(bestIP) {
 			bestIP = ip
 			bestPURL = purl
 		}
@@ -648,13 +652,16 @@ func (a *Analyzer) handleJSImport(
 	aliasMap map[string]string,
 	cfg *langConfig,
 ) {
-	purl, ok := importToPURL[importPath]
+	// Lowercase the import path for matching — importToPURL keys are already lowercased
+	// to handle PURL case-insensitivity (see AnalyzeCoupling).
+	lowerPath := strings.ToLower(importPath)
+	purl, ok := importToPURL[lowerPath]
 	if !ok {
 		// Pick the longest matching prefix to handle scoped packages
 		// (e.g., prefer "@scope/pkg/sub" over "@scope/pkg").
 		bestLen := 0
 		for ip, p := range importToPURL {
-			if strings.HasPrefix(importPath, ip+"/") && len(ip) > bestLen {
+			if strings.HasPrefix(lowerPath, ip+"/") && len(ip) > bestLen {
 				purl = p
 				ok = true
 				bestLen = len(ip)

--- a/internal/infrastructure/treesitter/analyzer_test.go
+++ b/internal/infrastructure/treesitter/analyzer_test.go
@@ -462,6 +462,80 @@ func main() {
 	}
 }
 
+func TestAnalyzer_JSCaseInsensitivePURL(t *testing.T) {
+	dir := t.TempDir()
+	// Source code uses mixed-case import path, but PURL (and hence importToPURL key)
+	// is lowercased. The lookup must be case-insensitive.
+	err := os.WriteFile(filepath.Join(dir, "index.ts"), []byte(`import MyLib from "MyLib";
+
+MyLib.doSomething();
+MyLib.doOther();
+`), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	analyzer := NewAnalyzer()
+	importPaths := map[string][]string{
+		"pkg:npm/mylib@1.0.0": {"mylib"},
+	}
+	result, err := analyzer.AnalyzeCoupling(context.Background(), dir, importPaths)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ca, ok := result["pkg:npm/mylib@1.0.0"]
+	if !ok {
+		t.Fatal("expected coupling analysis for case-mismatched JS import")
+	}
+
+	if ca.ImportFileCount != 1 {
+		t.Errorf("ImportFileCount = %d, want 1", ca.ImportFileCount)
+	}
+	if ca.CallSiteCount != 2 {
+		t.Errorf("CallSiteCount = %d, want 2", ca.CallSiteCount)
+	}
+	if ca.IsUnused {
+		t.Error("IsUnused = true, want false")
+	}
+}
+
+func TestAnalyzer_JavaCaseInsensitivePURL(t *testing.T) {
+	dir := t.TempDir()
+	// Java import paths are case-sensitive, but the PURL-derived importToPURL
+	// keys are lowercased. Lookup must be case-insensitive.
+	err := os.WriteFile(filepath.Join(dir, "Main.java"), []byte(`import com.Google.Gson.Gson;
+
+public class Main {
+    public static void main(String[] args) {
+        Gson g = new Gson();
+        g.toJson("test");
+    }
+}
+`), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	analyzer := NewAnalyzer()
+	importPaths := map[string][]string{
+		"pkg:maven/com.google.code.gson/gson@2.10": {"com.google.gson"},
+	}
+	result, err := analyzer.AnalyzeCoupling(context.Background(), dir, importPaths)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ca, ok := result["pkg:maven/com.google.code.gson/gson@2.10"]
+	if !ok {
+		t.Fatal("expected coupling analysis for case-mismatched Java import")
+	}
+
+	if ca.ImportFileCount != 1 {
+		t.Errorf("ImportFileCount = %d, want 1", ca.ImportFileCount)
+	}
+}
+
 func TestAnalyzer_JavaScriptScopedDefaultImport(t *testing.T) {
 	dir := t.TempDir()
 	err := os.WriteFile(filepath.Join(dir, "index.js"), []byte(`import cloud from "@strapi/plugin-cloud";


### PR DESCRIPTION
## Summary

- Lowercase import paths before `importToPURL` lookup in `handleJSImport` and `handleJavaImport`
- Matches the pattern already used by `handleGoImport` and `resolvePythonPURL`
- Fixes case mismatch when source uses different casing than SBOM PURL

Closes #184

## Before / After

**Before** (`imports=0, calls=0` — case mismatch causes lookup failure):
```
RANK  SCORE  EFFORT  PURL                 IMPORTS  CALLS  STATUS
1     0.04   easy    pkg:npm/mylib@1.0.0  0        0      Legacy-Safe
```

**After** (`imports=1, calls=2` — case-insensitive match succeeds):
```
RANK  SCORE  EFFORT  PURL                 IMPORTS  CALLS  STATUS
1     0.04   easy    pkg:npm/mylib@1.0.0  1        2      Legacy-Safe
```

## Test plan

- [x] `TestAnalyzer_JSCaseInsensitivePURL` — mixed-case JS import against lowercase PURL
- [x] `TestAnalyzer_JavaCaseInsensitivePURL` — mixed-case Java import against lowercase PURL
- [x] Existing tests pass (no regression for case-matched imports)
- [x] Full `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)