### PR TITLE
chore: add merge=union for copilot-patterns.yml to prevent parallel PR conflicts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,6 @@
+# Append-only files — auto-merge both sides to avoid conflicts in parallel PRs
+.github/copilot-patterns.yml merge=union
+
 # Generated files — auto-collapsed in GitHub PR diffs
 .claude/rules/coding-standards.md linguist-generated=true
 .claude/rules/error-handling.md linguist-generated=true


### PR DESCRIPTION
## Summary
- Add `merge=union` gitattribute for `.github/copilot-patterns.yml`
- This tells git to keep lines from both sides when merging, eliminating conflicts on this append-only file
- Every parallel PR currently conflicts on this file because they all append to the same tail

## How it works
`merge=union` is a built-in git merge strategy for line-based append-only files. On merge/rebase, git keeps all unique lines from both sides instead of marking a conflict.

## Test plan
- [ ] Verify `.gitattributes` contains the new `merge=union` line
- [ ] Create two branches that both append to `copilot-patterns.yml`, merge one, rebase the other — no conflict expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)