### PR TITLE
fix: include tool name in diet-trial output filenames

### DIFF
--- a/.github/prompts/diet-trial.prompt.md
+++ b/.github/prompts/diet-trial.prompt.md
@@ -402,21 +402,21 @@ All output types share the same base name, differentiated only by extension:
 | Type | Extension | Description |
 |------|-----------|-------------|
 | Report | `.md` | Markdown analysis report |
+| Diet result | `.json` | uzomuzo diet analysis result |
 | SBOM | `.sbom.json` | SBOM data (CycloneDX JSON) |
-| Diet result | `.diet.json` | uzomuzo diet analysis result |
 
 Example paths (for `flask` with `trivy` on `2026-04-07`):
 - `case-studies/uzomuzo-diet/python/flask-trivy-2026-04-07.md`
+- `case-studies/uzomuzo-diet/python/flask-trivy-2026-04-07.json`
 - `case-studies/uzomuzo-diet/python/flask-trivy-2026-04-07.sbom.json`
-- `case-studies/uzomuzo-diet/python/flask-trivy-2026-04-07.diet.json`
 
 Save all three files together. Copy the SBOM and diet JSON from their `/tmp/` locations:
 
 ```bash
 DEST="<case-studies-dir>/<language-subdir>"
 BASE="<repo>-<tool>-<YYYY-MM-DD>"
+cp /tmp/diet-trial-<repo>-<tool>-diet.json "${DEST}/${BASE}.json"
 cp /tmp/diet-trial-<repo>-<tool>-sbom.json "${DEST}/${BASE}.sbom.json"
-cp /tmp/diet-trial-<repo>-<tool>-diet.json "${DEST}/${BASE}.diet.json"
 # Report (.md) is written directly by the agent
 ```
 


### PR DESCRIPTION
## Summary

- Include SBOM tool name (trivy/syft) in `/diet-trial` output filenames to prevent overwrites
- Change pattern from `diet-trial-<repo>-sbom.json` to `diet-trial-<repo>-<tool>-sbom.json` for all outputs (sbom, diet, logs)
- Add instructions to auto-save SBOM/diet JSON alongside the markdown report in case-studies
- Naming convention: `{project}-{tool}-{date}.{json|md|sbom.json}`

**Why**: Running `--compare` or sequential runs with different tools overwrites the first run's JSON files, causing data loss

## Test plan

- [ ] `/diet-trial <repo> --tool syft` outputs to `/tmp/diet-trial-<repo>-syft-sbom.json`
- [ ] `/diet-trial <repo> --tool trivy` outputs to `/tmp/diet-trial-<repo>-trivy-sbom.json`
- [ ] Sequential runs do not overwrite each other
- [ ] Case study saves `.json`, `.sbom.json`, and `.md` with consistent naming

🤖 Generated with [Claude Code](https://claude.com/claude-code)