### PR TITLE
fix: enforce minimumReleaseAge per manager in Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,12 +7,14 @@
     {
       "matchManagers": ["gomod"],
       "groupName": "Go modules",
-      "groupSlug": "gomod"
+      "groupSlug": "gomod",
+      "minimumReleaseAge": "21 days"
     },
     {
       "matchManagers": ["github-actions"],
       "groupName": "GitHub Actions",
-      "groupSlug": "github-actions"
+      "groupSlug": "github-actions",
+      "minimumReleaseAge": "21 days"
     },
     {
       "matchUpdateTypes": ["minor", "patch", "digest", "pin"],


### PR DESCRIPTION
## Summary
- PR #221 (`actions/setup-go` v6.4.0) was auto-merged only 8 days after release, despite `minimumReleaseAge: "21 days"` being set at the top level
- Add explicit `minimumReleaseAge: "21 days"` to both `gomod` and `github-actions` package rules to ensure the 21-day waiting period is enforced per manager

## Test plan
- [ ] Verify Renovate validates the updated config (check Renovate dashboard or logs)
- [ ] Confirm next GitHub Actions update PR is not created until 21 days after release

🤖 Generated with [Claude Code](https://claude.com/claude-code)