### PR TITLE
fix: insert copilot patterns at random position to avoid conflicts

### DIFF
--- a/.github/copilot-patterns.yml
+++ b/.github/copilot-patterns.yml
@@ -1,6 +1,7 @@
 # Copilot review patterns awaiting promotion to coding rules.
 #
-# Phase 3 of /review appends new FIX-classified patterns here.
+# Phase 3 of /review inserts new entries at random positions to avoid
+# merge conflicts when multiple PRs run /review in parallel.
 # When a category reaches 2+ entries, it is promoted to a rule in
 # .github/instructions/ and the promoted entries are removed.
 #

--- a/.github/prompts/review.prompt.md
+++ b/.github/prompts/review.prompt.md
@@ -270,7 +270,10 @@ on the same PR), assign a category:
 | security | "User input not validated" |
 | dependency-pinning | "Pin dependency version for reproducibility" |
 
-Read `.github/copilot-patterns.yml` and append each new FIX comment as an entry.
+Read `.github/copilot-patterns.yml` and **insert each new entry at a random position** among existing entries (both active entries and comment lines). Do NOT append to the end — appending causes merge conflicts when multiple PRs run `/review` in parallel, because all PRs modify the same lines at the end of the file.
+
+**Insertion strategy**: Pick a random line between the first entry (after `patterns:`) and the last entry. Insert the new entry block there. If adding multiple entries, insert each at a different random position.
+
 If `--dry-run` is active, perform this step **in-memory only** — do not write to disk:
 
 ```yaml


### PR DESCRIPTION
## Summary

- **Problem**: When multiple PRs run `/review`, Phase 3 appends new entries to the END of `.github/copilot-patterns.yml`. Since all PRs modify the same lines at EOF, they always conflict on GitHub. The `.gitattributes` `merge=union` strategy is ignored by GitHub's merge button.
- **Solution**: Change the `/review` skill to insert new pattern entries at a **random position** among existing entries instead of appending to the end. When two PRs insert at different random positions, the changes are in different parts of the file and don't conflict.
- Update the header comment in `copilot-patterns.yml` to document the new strategy.

## Test plan

- [ ] Run `/review --dry-run` on a test PR and verify new entries are inserted at random positions, not appended to EOF
- [ ] Run `/review` on two separate PRs and confirm the resulting changes are in different parts of the file
- [ ] Verify the YAML remains valid after random insertion

🤖 Generated with [Claude Code](https://claude.com/claude-code)