### PR TITLE
chore: ignore case study raw data and bom.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@ scorecard.csv
 # Temporary plans
 docs/plans/
 
+# Case study raw data (SBOMs, diet results)
+docs/case-studies/uzomuzo-diet/
+bom.json
+


### PR DESCRIPTION
## Summary
- Add `docs/case-studies/uzomuzo-diet/` and `bom.json` to `.gitignore`
- Prevents committing generated SBOMs and case study raw data produced during diet-trial runs

## Test plan
- [ ] Verify `bom.json` files are ignored by git
- [ ] Verify `docs/case-studies/uzomuzo-diet/` directory is ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)