### PR TITLE
fix: add Maven package overrides for Jackson family and javax.inject

### DIFF
--- a/internal/application/diet/service.go
+++ b/internal/application/diet/service.go
@@ -440,6 +440,21 @@ var mavenPackageOverrides = map[string][]string{
 	"commons-logging/commons-logging":         {"org.apache.commons.logging"},
 	"junit/junit":                             {"junit", "org.junit"},
 	"log4j/log4j":                             {"org.apache.log4j"},
+
+	// Jackson family: Maven groupId (e.g. com.fasterxml.jackson.core) does not
+	// match the actual Java package name (e.g. com.fasterxml.jackson.annotation).
+	"com.fasterxml.jackson.core/jackson-annotations":          {"com.fasterxml.jackson.annotation"},
+	"com.fasterxml.jackson.core/jackson-databind":             {"com.fasterxml.jackson.databind"},
+	"com.fasterxml.jackson.dataformat/jackson-dataformat-csv": {"com.fasterxml.jackson.dataformat.csv"},
+	"com.fasterxml.jackson.dataformat/jackson-dataformat-xml": {"com.fasterxml.jackson.dataformat.xml"},
+	"com.fasterxml.jackson.dataformat/jackson-dataformat-yaml": {"com.fasterxml.jackson.dataformat.yaml"},
+	"com.fasterxml.jackson.datatype/jackson-datatype-jsr310":  {"com.fasterxml.jackson.datatype.jsr310"},
+	"com.fasterxml.jackson.module/jackson-module-kotlin":      {"com.fasterxml.jackson.module.kotlin"},
+
+	// javax.inject: groupId and artifactId both equal "javax.inject", so the
+	// heuristic already produces the correct candidate, but an explicit override
+	// ensures stability.
+	"javax.inject/javax.inject": {"javax.inject"},
 }
 
 // buildMavenImportPaths generates candidate import path prefixes for a Maven PURL.

--- a/internal/application/diet/service_test.go
+++ b/internal/application/diet/service_test.go
@@ -186,6 +186,46 @@ func TestBuildMavenImportPaths(t *testing.T) {
 			purl: "pkg:maven/my-company/mylib@1.0.0",
 			want: []string{"mylib"},
 		},
+		{
+			name: "override: jackson-annotations groupId differs from package",
+			purl: "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.17.0",
+			want: []string{"com.fasterxml.jackson.annotation", "com.fasterxml.jackson.core"},
+		},
+		{
+			name: "override: jackson-databind groupId differs from package",
+			purl: "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.17.0",
+			want: []string{"com.fasterxml.jackson.databind", "com.fasterxml.jackson.core"},
+		},
+		{
+			name: "override: jackson-dataformat-yaml",
+			purl: "pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml@2.17.0",
+			want: []string{"com.fasterxml.jackson.dataformat.yaml", "com.fasterxml.jackson.dataformat"},
+		},
+		{
+			name: "override: jackson-dataformat-xml",
+			purl: "pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-xml@2.17.0",
+			want: []string{"com.fasterxml.jackson.dataformat.xml", "com.fasterxml.jackson.dataformat"},
+		},
+		{
+			name: "override: jackson-dataformat-csv",
+			purl: "pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-csv@2.17.0",
+			want: []string{"com.fasterxml.jackson.dataformat.csv", "com.fasterxml.jackson.dataformat"},
+		},
+		{
+			name: "override: jackson-datatype-jsr310",
+			purl: "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.17.0",
+			want: []string{"com.fasterxml.jackson.datatype.jsr310", "com.fasterxml.jackson.datatype"},
+		},
+		{
+			name: "override: jackson-module-kotlin",
+			purl: "pkg:maven/com.fasterxml.jackson.module/jackson-module-kotlin@2.17.0",
+			want: []string{"com.fasterxml.jackson.module.kotlin", "com.fasterxml.jackson.module"},
+		},
+		{
+			name: "override: javax.inject groupId matches package",
+			purl: "pkg:maven/javax.inject/javax.inject@1",
+			want: []string{"javax.inject"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add `mavenPackageOverrides` entries for 7 Jackson family libraries and `javax.inject` where Maven groupId does not match the actual Java package name
- Fixes coupling analysis misclassifying `jackson-annotations` (and similar) as trivial/unused despite being imported in source code
- Add 8 new test cases covering each override

## Before
```
=== RUN   TestBuildMavenImportPaths/override:_jackson-annotations_groupId_differs_from_package
    service_test.go:244: buildImportPaths(pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.17.0) = [com.fasterxml.jackson.core], want [com.fasterxml.jackson.annotation com.fasterxml.jackson.core]
--- FAIL
```
Only `com.fasterxml.jackson.core` was generated as a candidate, which does not match `import com.fasterxml.jackson.annotation.*`.

## After
```
--- PASS: TestBuildMavenImportPaths/override:_jackson-annotations_groupId_differs_from_package (0.00s)
--- PASS: TestBuildMavenImportPaths/override:_jackson-databind_groupId_differs_from_package (0.00s)
--- PASS: TestBuildMavenImportPaths/override:_jackson-dataformat-yaml (0.00s)
--- PASS: TestBuildMavenImportPaths/override:_jackson-dataformat-xml (0.00s)
--- PASS: TestBuildMavenImportPaths/override:_jackson-dataformat-csv (0.00s)
--- PASS: TestBuildMavenImportPaths/override:_jackson-datatype-jsr310 (0.00s)
--- PASS: TestBuildMavenImportPaths/override:_jackson-module-kotlin (0.00s)
--- PASS: TestBuildMavenImportPaths/override:_javax.inject_groupId_matches_package (0.00s)
```
All 21 Maven import path tests pass. Full diet package tests pass. `go vet` and `golangci-lint` clean.

## Test plan
- [x] Reproduction test fails before fix
- [x] All 8 new test cases pass after fix
- [x] All existing `TestBuildMavenImportPaths` cases still pass
- [x] Full `internal/application/diet/...` test suite passes
- [x] `go vet` clean
- [x] `golangci-lint` clean

Closes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)