### PR TITLE
fix: add PyPI-to-import name override table for well-known packages

### DIFF
--- a/internal/application/diet/service.go
+++ b/internal/application/diet/service.go
@@ -344,6 +344,22 @@ func buildImportPaths(purls []string) map[string][]string {
 	return result
 }
 
+// pypiImportOverrides maps lowercased PyPI distribution names to their actual
+// Python import module names for well-known packages where the distribution
+// name cannot be derived from simple heuristics (prefix stripping, hyphen
+// normalization).  Add entries as real-world mismatches are discovered.
+var pypiImportOverrides = map[string][]string{
+	"attrs":           {"attr"},
+	"beautifulsoup4":  {"bs4"},
+	"opencv-python":   {"cv2"},
+	"pillow":          {"PIL"},
+	"protobuf":        {"google.protobuf"},
+	"pyyaml":          {"yaml"},
+	"python-dateutil": {"dateutil"},
+	"python-dotenv":   {"dotenv"},
+	"scikit-learn":    {"sklearn"},
+}
+
 // pypiPrefixes lists common PyPI distribution name prefixes that are not part
 // of the actual Python import module name (e.g., "python-multipart" is imported
 // as "multipart").
@@ -353,10 +369,11 @@ var pypiPrefixes = []string{
 }
 
 // buildPyPIImportPaths generates candidate Python import module names for a
-// PyPI distribution name. The canonical candidate (hyphen→underscore, lowered)
-// is added first when it passes validation. Additional candidates are produced
-// by stripping well-known prefixes (e.g., "python-", "py-"). Each candidate
-// is validated against Python identifier rules before inclusion.
+// PyPI distribution name. Override entries from pypiImportOverrides are added
+// first as highest-priority candidates. The canonical candidate
+// (hyphen→underscore, lowered) and prefix-stripped variants follow as
+// fallbacks. Each candidate is validated against Python identifier rules
+// before inclusion.
 func buildPyPIImportPaths(name string) []string {
 	seen := make(map[string]struct{})
 	var paths []string
@@ -375,13 +392,20 @@ func buildPyPIImportPaths(name string) []string {
 		paths = append(paths, p)
 	}
 
-	// 1. Canonical: replace hyphens with underscores and lowercase.
+	lower := strings.ToLower(name)
+
+	// 1. Well-known overrides take highest priority.
+	if overrides, ok := pypiImportOverrides[lower]; ok {
+		for _, o := range overrides {
+			add(o)
+		}
+	}
+
+	// 2. Canonical: replace hyphens with underscores and lowercase.
 	canonical := strings.ToLower(strings.ReplaceAll(name, "-", "_"))
 	add(canonical)
 
-	lower := strings.ToLower(name)
-
-	// 2. Strip well-known prefixes (e.g., "python-multipart" → "multipart").
+	// 3. Strip well-known prefixes (e.g., "python-multipart" → "multipart").
 	for _, prefix := range pypiPrefixes {
 		if after, ok := strings.CutPrefix(lower, prefix); ok && after != "" {
 			add(strings.ReplaceAll(after, "-", "_"))

--- a/internal/application/diet/service_test.go
+++ b/internal/application/diet/service_test.go
@@ -224,9 +224,9 @@ func TestBuildPyPIImportPaths(t *testing.T) {
 			want: []string{"email_validator"},
 		},
 		{
-			name: "case normalization: PyYAML",
+			name: "override: PyYAML -> yaml",
 			purl: "pkg:pypi/PyYAML@6.0.1",
-			want: []string{"pyyaml"},
+			want: []string{"yaml", "pyyaml"},
 		},
 		{
 			name: "no hyphens: requests",
@@ -252,6 +252,46 @@ func TestBuildPyPIImportPaths(t *testing.T) {
 			name: "dotted name: zope.interface",
 			purl: "pkg:pypi/zope.interface@6.0",
 			want: []string{"zope.interface"},
+		},
+		{
+			name: "override: Pillow -> PIL",
+			purl: "pkg:pypi/Pillow@10.0.0",
+			want: []string{"PIL", "pillow"},
+		},
+		{
+			name: "override: scikit-learn -> sklearn",
+			purl: "pkg:pypi/scikit-learn@1.3.0",
+			want: []string{"sklearn", "scikit_learn"},
+		},
+		{
+			name: "override: beautifulsoup4 -> bs4",
+			purl: "pkg:pypi/beautifulsoup4@4.12.0",
+			want: []string{"bs4", "beautifulsoup4"},
+		},
+		{
+			name: "override: python-dateutil -> dateutil",
+			purl: "pkg:pypi/python-dateutil@2.8.2",
+			want: []string{"dateutil", "python_dateutil"},
+		},
+		{
+			name: "override: attrs -> attr",
+			purl: "pkg:pypi/attrs@23.1.0",
+			want: []string{"attr", "attrs"},
+		},
+		{
+			name: "override: protobuf -> google.protobuf",
+			purl: "pkg:pypi/protobuf@4.24.0",
+			want: []string{"google.protobuf", "protobuf"},
+		},
+		{
+			name: "override: opencv-python -> cv2",
+			purl: "pkg:pypi/opencv-python@4.8.0",
+			want: []string{"cv2", "opencv_python"},
+		},
+		{
+			name: "override: python-dotenv -> dotenv",
+			purl: "pkg:pypi/python-dotenv@1.0.0",
+			want: []string{"dotenv", "python_dotenv"},
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- Add `pypiImportOverrides` static mapping for well-known PyPI packages where distribution name != import name
- Covers pyyaml, pillow, scikit-learn, beautifulsoup4, python-dateutil, attrs, protobuf, opencv-python, python-dotenv
- Follows same pattern as existing `mavenPackageOverrides`

## Before (reproduction test output)
```
=== RUN   TestBuildPyPIImportPaths/override:_PyYAML_->_yaml
    service_test.go:311: buildImportPaths(pkg:pypi/PyYAML@6.0.1) = [pyyaml], want [yaml pyyaml]
=== RUN   TestBuildPyPIImportPaths/override:_Pillow_->_PIL
    service_test.go:311: buildImportPaths(pkg:pypi/Pillow@10.0.0) = [pillow], want [PIL pillow]
=== RUN   TestBuildPyPIImportPaths/override:_scikit-learn_->_sklearn
    service_test.go:311: buildImportPaths(pkg:pypi/scikit-learn@1.3.0) = [scikit_learn], want [sklearn scikit_learn]
=== RUN   TestBuildPyPIImportPaths/override:_beautifulsoup4_->_bs4
    service_test.go:311: buildImportPaths(pkg:pypi/beautifulsoup4@4.12.0) = [beautifulsoup4], want [bs4 beautifulsoup4]
=== RUN   TestBuildPyPIImportPaths/override:_python-dateutil_->_dateutil
    service_test.go:311: buildImportPaths(pkg:pypi/python-dateutil@2.8.2) = [python_dateutil dateutil], want [dateutil python_dateutil]
=== RUN   TestBuildPyPIImportPaths/override:_attrs_->_attr
    service_test.go:311: buildImportPaths(pkg:pypi/attrs@23.1.0) = [attrs], want [attr attrs]
=== RUN   TestBuildPyPIImportPaths/override:_protobuf_->_google.protobuf
    service_test.go:311: buildImportPaths(pkg:pypi/protobuf@4.24.0) = [protobuf], want [google.protobuf protobuf]
=== RUN   TestBuildPyPIImportPaths/override:_opencv-python_->_cv2
    service_test.go:311: buildImportPaths(pkg:pypi/opencv-python@4.8.0) = [opencv_python], want [cv2 opencv_python]
=== RUN   TestBuildPyPIImportPaths/override:_python-dotenv_->_dotenv
    service_test.go:311: buildImportPaths(pkg:pypi/python-dotenv@1.0.0) = [python_dotenv dotenv], want [dotenv python_dotenv]
--- FAIL: TestBuildPyPIImportPaths (0.00s)
```

## After (verification test output)
```
=== RUN   TestBuildPyPIImportPaths
--- PASS: TestBuildPyPIImportPaths (0.00s)
    --- PASS: TestBuildPyPIImportPaths/python-prefix_stripped:_python-multipart (0.00s)
    --- PASS: TestBuildPyPIImportPaths/simple_hyphenated_name:_email-validator (0.00s)
    --- PASS: TestBuildPyPIImportPaths/override:_PyYAML_->_yaml (0.00s)
    --- PASS: TestBuildPyPIImportPaths/no_hyphens:_requests (0.00s)
    --- PASS: TestBuildPyPIImportPaths/py-prefix_stripped:_py-cpuinfo (0.00s)
    --- PASS: TestBuildPyPIImportPaths/multiple_hyphens:_python-jose-cryptodome (0.00s)
    --- PASS: TestBuildPyPIImportPaths/simple_name:_flask (0.00s)
    --- PASS: TestBuildPyPIImportPaths/dotted_name:_zope.interface (0.00s)
    --- PASS: TestBuildPyPIImportPaths/override:_Pillow_->_PIL (0.00s)
    --- PASS: TestBuildPyPIImportPaths/override:_scikit-learn_->_sklearn (0.00s)
    --- PASS: TestBuildPyPIImportPaths/override:_beautifulsoup4_->_bs4 (0.00s)
    --- PASS: TestBuildPyPIImportPaths/override:_python-dateutil_->_dateutil (0.00s)
    --- PASS: TestBuildPyPIImportPaths/override:_attrs_->_attr (0.00s)
    --- PASS: TestBuildPyPIImportPaths/override:_protobuf_->_google.protobuf (0.00s)
    --- PASS: TestBuildPyPIImportPaths/override:_opencv-python_->_cv2 (0.00s)
    --- PASS: TestBuildPyPIImportPaths/override:_python-dotenv_->_dotenv (0.00s)
PASS
ok  	github.com/future-architect/uzomuzo-oss/internal/application/diet	0.005s
```

Closes #246

## Test plan
- [x] Table-driven tests for all 9 override entries
- [x] Existing tests still pass (all 17 subtests green)
- [x] `go vet ./...` clean
- [x] `golangci-lint run` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)