### PR TITLE
fix: detect TypeScript side-effect imports and verify default import calls

### DIFF
--- a/.claude/rules/copilot-learned-coding.md
+++ b/.claude/rules/copilot-learned-coding.md
@@ -83,6 +83,11 @@ pending_patterns:
     pr: 236
     file: "internal/infrastructure/eolevaluator/evaluator_npm_test.go"
     date: "2026-04-08"
+  - category: "comment-doc-drift"
+    summary: "Doc comments must not make absolute claims about external system behavior — scope claims to what the current function actually handles"
+    pr: 253
+    file: "internal/infrastructure/treesitter/analyzer.go"
+    date: "2026-04-09"
   - category: "testing"
     summary: "Accept interface types in test-setter methods (e.g., SetXxxClient) so fakes can be injected via public API instead of unexported fields"
     pr: 236

--- a/.github/instructions/copilot-learned-coding.instructions.md
+++ b/.github/instructions/copilot-learned-coding.instructions.md
@@ -81,6 +81,11 @@ pending_patterns:
     pr: 236
     file: "internal/infrastructure/eolevaluator/evaluator_npm_test.go"
     date: "2026-04-08"
+  - category: "comment-doc-drift"
+    summary: "Doc comments must not make absolute claims about external system behavior — scope claims to what the current function actually handles"
+    pr: 253
+    file: "internal/infrastructure/treesitter/analyzer.go"
+    date: "2026-04-09"
   - category: "testing"
     summary: "Accept interface types in test-setter methods (e.g., SetXxxClient) so fakes can be injected via public API instead of unexported fields"
     pr: 236

--- a/internal/infrastructure/treesitter/analyzer.go
+++ b/internal/infrastructure/treesitter/analyzer.go
@@ -826,9 +826,19 @@ func (a *Analyzer) handleJSImport(
 		return
 	}
 
+	// Side-effect imports (`import 'reflect-metadata'`) have no import_clause,
+	// meaning no bindings are introduced. Treat them like Go blank imports:
+	// record the import file so the dep is not misclassified as "unused", but
+	// skip call-site counting.
+	if isSideEffectImport(node) {
+		key := blankImportAlias + importPath
+		aliasMap[key] = appendUniquePURLs(aliasMap[key], purls)
+		return
+	}
+
 	// Extract the JS/TS binding names from the AST (e.g., "cloud" from
 	// `import cloud from '@strapi/plugin-cloud'`). Falls back to aliasFromPkg
-	// for side-effect imports or patterns we cannot resolve.
+	// for patterns we cannot resolve from the AST.
 	aliases := extractJSBindings(node, src)
 	if len(aliases) == 0 {
 		aliases = []string{cfg.aliasFromPkg(importPath)}
@@ -986,6 +996,23 @@ func isTypeOnlyImport(node *sitter.Node) bool {
 		}
 	}
 	return false
+}
+
+// isSideEffectImport checks if a JS/TS import is a bare side-effect import
+// with no bindings (e.g., `import 'reflect-metadata'`). These imports have an
+// import_statement parent but no import_clause child — only the source string.
+// CJS require() calls are never side-effect imports (they always bind a value).
+func isSideEffectImport(node *sitter.Node) bool {
+	parent := node.Parent()
+	if parent == nil || parent.Type() != "import_statement" {
+		return false
+	}
+	for i := 0; i < int(parent.ChildCount()); i++ {
+		if parent.Child(i).Type() == "import_clause" {
+			return false
+		}
+	}
+	return true
 }
 
 // countCallSites counts selector/member expressions matching known aliases.

--- a/internal/infrastructure/treesitter/analyzer.go
+++ b/internal/infrastructure/treesitter/analyzer.go
@@ -1001,7 +1001,8 @@ func isTypeOnlyImport(node *sitter.Node) bool {
 // isSideEffectImport checks if a JS/TS import is a bare side-effect import
 // with no bindings (e.g., `import 'reflect-metadata'`). These imports have an
 // import_statement parent but no import_clause child — only the source string.
-// CJS require() calls are never side-effect imports (they always bind a value).
+// This helper only classifies bare ESM `import "x"` statements as side-effect
+// imports; it does not attempt to classify CommonJS `require()` usage.
 func isSideEffectImport(node *sitter.Node) bool {
 	parent := node.Parent()
 	if parent == nil || parent.Type() != "import_statement" {

--- a/internal/infrastructure/treesitter/analyzer_test.go
+++ b/internal/infrastructure/treesitter/analyzer_test.go
@@ -2019,3 +2019,100 @@ const data = Readable.from([1, 2, 3]);
 		})
 	}
 }
+
+// TestAnalyzer_TypeScriptDefaultImportCall verifies that a default import binding
+// used as a direct function call is detected as a call site.
+// e.g., `import _generate from '@babel/generator'; _generate(ast);`
+func TestAnalyzer_TypeScriptDefaultImportCall(t *testing.T) {
+	dir := t.TempDir()
+	err := os.WriteFile(filepath.Join(dir, "codegen.ts"), []byte(`import _generate from '@babel/generator';
+
+const result = _generate(ast, { comments: true });
+`), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	analyzer := NewAnalyzer()
+	importPaths := map[string][]string{
+		"pkg:npm/%40babel/generator@7.0.0": {"@babel/generator"},
+	}
+	result, err := analyzer.AnalyzeCoupling(context.Background(), dir, importPaths)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ca, ok := result["pkg:npm/%40babel/generator@7.0.0"]
+	if !ok {
+		t.Fatal("expected coupling analysis for @babel/generator")
+	}
+	if ca.ImportFileCount != 1 {
+		t.Errorf("ImportFileCount = %d, want 1", ca.ImportFileCount)
+	}
+	if ca.CallSiteCount < 1 {
+		t.Errorf("CallSiteCount = %d, want >= 1", ca.CallSiteCount)
+	}
+}
+
+// TestAnalyzer_TypeScriptSideEffectImport verifies that a bare side-effect import
+// (`import 'reflect-metadata'`) is tracked as used (not classified as unused).
+func TestAnalyzer_TypeScriptSideEffectImport(t *testing.T) {
+	dir := t.TempDir()
+	err := os.WriteFile(filepath.Join(dir, "bootstrap.ts"), []byte(`import 'reflect-metadata';
+
+// No bindings — this is a side-effect-only import (polyfill registration).
+`), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	analyzer := NewAnalyzer()
+	importPaths := map[string][]string{
+		"pkg:npm/reflect-metadata@0.1.13": {"reflect-metadata"},
+	}
+	result, err := analyzer.AnalyzeCoupling(context.Background(), dir, importPaths)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ca, ok := result["pkg:npm/reflect-metadata@0.1.13"]
+	if !ok {
+		t.Fatal("expected coupling analysis for reflect-metadata")
+	}
+	if ca.ImportFileCount != 1 {
+		t.Errorf("ImportFileCount = %d, want 1", ca.ImportFileCount)
+	}
+	if ca.IsUnused {
+		t.Error("IsUnused = true, want false (side-effect import should not be classified as unused)")
+	}
+	if !ca.HasBlankImport {
+		t.Error("HasBlankImport = false, want true (side-effect import analogous to Go blank import)")
+	}
+}
+
+// TestAnalyzer_TypeScriptTypeOnlyImportExclusion verifies that `import type { ... }`
+// in a .ts file (not just .tsx) is excluded from coupling analysis.
+func TestAnalyzer_TypeScriptTypeOnlyImportExclusion(t *testing.T) {
+	dir := t.TempDir()
+	err := os.WriteFile(filepath.Join(dir, "types.ts"), []byte(`import type { Foo, Bar } from "some-lib";
+
+// Type-only import — no runtime coupling.
+const x: Foo = {} as any;
+`), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	analyzer := NewAnalyzer()
+	importPaths := map[string][]string{
+		"pkg:npm/some-lib@1.0.0": {"some-lib"},
+	}
+	result, err := analyzer.AnalyzeCoupling(context.Background(), dir, importPaths)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(result) != 0 {
+		t.Errorf("expected no coupling for type-only import in .ts file, got %d results", len(result))
+	}
+}


### PR DESCRIPTION
## Summary

- Detect bare side-effect imports (`import 'reflect-metadata'`) in JS/TS/TSX and route them through the `blankImportAlias` sentinel path, matching Go's `import _ "pkg"` behavior. Previously these imports were tracked via `aliasFromPkg` fallback, which set `ImportFileCount` correctly but left `HasBlankImport = false`.
- Added `isSideEffectImport()` helper that checks whether an `import_statement` has no `import_clause` child (bare import with no bindings).
- Added regression tests confirming default import calls and `import type` exclusion already work correctly.

Closes #245

## Before / After

**Before** (side-effect import test fails -- tests applied to pre-fix code):
```
=== RUN   TestAnalyzer_TypeScriptDefaultImportCall
--- PASS: TestAnalyzer_TypeScriptDefaultImportCall (0.04s)
=== RUN   TestAnalyzer_TypeScriptSideEffectImport
    analyzer_test.go:2089: HasBlankImport = false, want true (side-effect import analogous to Go blank import)
--- FAIL: TestAnalyzer_TypeScriptSideEffectImport (0.03s)
=== RUN   TestAnalyzer_TypeScriptTypeOnlyImportExclusion
--- PASS: TestAnalyzer_TypeScriptTypeOnlyImportExclusion (0.03s)
FAIL
```

**After** (all pass with the fix):
```
=== RUN   TestAnalyzer_TypeScriptDefaultImportCall
--- PASS: TestAnalyzer_TypeScriptDefaultImportCall (0.03s)
=== RUN   TestAnalyzer_TypeScriptSideEffectImport
--- PASS: TestAnalyzer_TypeScriptSideEffectImport (0.03s)
=== RUN   TestAnalyzer_TypeScriptTypeOnlyImportExclusion
--- PASS: TestAnalyzer_TypeScriptTypeOnlyImportExclusion (0.03s)
PASS
ok  	github.com/future-architect/uzomuzo-oss/internal/infrastructure/treesitter	0.099s
```

Full test suite (83 tests, including subtests): all pass.
```
PASS
ok  	github.com/future-architect/uzomuzo-oss/internal/infrastructure/treesitter	1.952s
```

## Test plan

- [x] `TestAnalyzer_TypeScriptDefaultImportCall` -- default import binding used as function call detected (regression)
- [x] `TestAnalyzer_TypeScriptSideEffectImport` -- bare `import 'x'` sets `HasBlankImport=true`, `IsUnused=false`
- [x] `TestAnalyzer_TypeScriptTypeOnlyImportExclusion` -- `import type` in `.ts` excluded (regression)
- [x] Full treesitter test suite passes (83/83)
- [x] `go vet ./...` clean
- [x] `golangci-lint run` clean (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)