### PR TITLE
fix: detect Python try/except ImportError as feature-detection import

### DIFF
--- a/internal/infrastructure/treesitter/analyzer.go
+++ b/internal/infrastructure/treesitter/analyzer.go
@@ -695,14 +695,29 @@ func hasPythonImportErrorHandler(tryStmt *sitter.Node, src []byte) bool {
 		}
 
 		// Check each child of the except_clause for exception type identifiers.
+		// Exception types may appear as direct identifier children (single type)
+		// or inside a tuple child (multiple types, e.g., "except (ImportError, ValueError)").
 		hasExceptionType := false
 		for j := 0; j < int(child.ChildCount()); j++ {
 			gc := child.Child(j)
-			if gc.Type() == "identifier" {
+			switch gc.Type() {
+			case "identifier":
 				hasExceptionType = true
 				name := gc.Content(src)
 				if name == "ImportError" || name == "ModuleNotFoundError" {
 					return true
+				}
+			case "tuple":
+				// except (ExcA, ExcB): — identifiers are inside the tuple node.
+				for k := 0; k < int(gc.ChildCount()); k++ {
+					tc := gc.Child(k)
+					if tc.Type() == "identifier" {
+						hasExceptionType = true
+						name := tc.Content(src)
+						if name == "ImportError" || name == "ModuleNotFoundError" {
+							return true
+						}
+					}
 				}
 			}
 		}

--- a/internal/infrastructure/treesitter/analyzer.go
+++ b/internal/infrastructure/treesitter/analyzer.go
@@ -618,13 +618,13 @@ func (a *Analyzer) handlePythonImport(
 	}
 
 	// Check if this import is inside a try/except ImportError block.
-	// This is a Python feature-detection pattern where the import itself is
-	// the usage (checking if the package is installed). Treat like a Go blank
-	// import: record the import file but skip call-site counting.
+	// This is often a Python feature-detection pattern where the import itself
+	// signals optional dependency detection. Record that fact like a Go blank
+	// import, but still register the actual binding so later call-site counting
+	// can attribute usage such as "cryptography.*" or "fernet()".
 	if isPythonTryExceptImport(parent, src) {
 		key := blankImportAlias + importPath
 		aliasMap[key] = appendUniquePURLs(aliasMap[key], purls)
-		return
 	}
 
 	switch parent.Type() {
@@ -655,22 +655,31 @@ func (a *Analyzer) handlePythonImport(
 	}
 }
 
-// isPythonTryExceptImport checks if a Python import statement is inside a
-// try/except block that catches ImportError or ModuleNotFoundError.
-// This is a common feature-detection pattern where the import itself is the
-// usage (checking if the package is installed).
+// isPythonTryExceptImport checks if a Python import-related node is inside the
+// try body of a try/except block that catches ImportError or
+// ModuleNotFoundError. This is a common feature-detection pattern where the
+// import itself is the usage (checking if the package is installed).
 //
-// importStmt is the import_statement or import_from_statement node (the parent
-// of the captured dotted_name). src is the file source for reading node content.
+// importStmt may be an import_statement, import_from_statement, aliased_import,
+// or another import-related descendant node. src is the file source for
+// reading node content.
 func isPythonTryExceptImport(importStmt *sitter.Node, src []byte) bool {
-	// Walk up from the import statement to find a try_statement ancestor.
-	// Expected AST: import_statement -> block -> try_statement (depth 2).
-	// Limit walk depth to avoid false matches in deeply nested code.
+	// Walk up from the import statement to find the nearest enclosing
+	// try_statement while tracking the child path. Only imports contained in the
+	// try_statement's body field should be treated as feature-detection imports;
+	// imports in except/else/finally blocks are fallback or cleanup logic and
+	// must not be classified as blank imports.
+	child := importStmt
 	current := importStmt.Parent()
 	for depth := 0; current != nil && depth < maxAncestorWalkDepth; depth++ {
 		if current.Type() == "try_statement" {
+			tryBody := current.ChildByFieldName("body")
+			if tryBody == nil || tryBody != child {
+				return false
+			}
 			return hasPythonImportErrorHandler(current, src)
 		}
+		child = current
 		current = current.Parent()
 	}
 	return false
@@ -959,9 +968,10 @@ var jsExpressionTypes = map[string]bool{
 	"assignment_expression":    true,
 }
 
-// maxAncestorWalkDepth limits how far findAncestorVariableDeclarator walks up
-// the AST. Prevents false matches against distant, unrelated variable_declarators
-// in pathological nesting (e.g., deeply nested ternary chains).
+// maxAncestorWalkDepth limits how far ancestor-walking functions (e.g.,
+// findAncestorVariableDeclarator, isPythonTryExceptImport) traverse the AST.
+// Prevents false matches against distant, unrelated ancestors in pathological
+// nesting.
 const maxAncestorWalkDepth = 5
 
 // findAncestorVariableDeclarator walks up from node looking for a variable_declarator,

--- a/internal/infrastructure/treesitter/analyzer.go
+++ b/internal/infrastructure/treesitter/analyzer.go
@@ -617,6 +617,16 @@ func (a *Analyzer) handlePythonImport(
 		return
 	}
 
+	// Check if this import is inside a try/except ImportError block.
+	// This is a Python feature-detection pattern where the import itself is
+	// the usage (checking if the package is installed). Treat like a Go blank
+	// import: record the import file but skip call-site counting.
+	if isPythonTryExceptImport(parent, src) {
+		key := blankImportAlias + importPath
+		aliasMap[key] = appendUniquePURLs(aliasMap[key], purls)
+		return
+	}
+
 	switch parent.Type() {
 	case "import_statement":
 		// Regular import (e.g., "import requests") — register module name as alias.
@@ -643,6 +653,58 @@ func (a *Analyzer) handlePythonImport(
 		// so we only register the individual imported names.
 		a.registerFromImportNames(node, src, purls, aliasMap)
 	}
+}
+
+// isPythonTryExceptImport checks if a Python import statement is inside a
+// try/except block that catches ImportError or ModuleNotFoundError.
+// This is a common feature-detection pattern where the import itself is the
+// usage (checking if the package is installed).
+//
+// importStmt is the import_statement or import_from_statement node (the parent
+// of the captured dotted_name). src is the file source for reading node content.
+func isPythonTryExceptImport(importStmt *sitter.Node, src []byte) bool {
+	// Walk up from the import statement to find a try_statement ancestor.
+	// Expected AST: import_statement -> block -> try_statement (depth 2).
+	// Limit walk depth to avoid false matches in deeply nested code.
+	current := importStmt.Parent()
+	for depth := 0; current != nil && depth < maxAncestorWalkDepth; depth++ {
+		if current.Type() == "try_statement" {
+			return hasPythonImportErrorHandler(current, src)
+		}
+		current = current.Parent()
+	}
+	return false
+}
+
+// hasPythonImportErrorHandler checks whether a try_statement has an except_clause
+// that catches ImportError, ModuleNotFoundError, or is a bare except (no type).
+func hasPythonImportErrorHandler(tryStmt *sitter.Node, src []byte) bool {
+	for i := 0; i < int(tryStmt.ChildCount()); i++ {
+		child := tryStmt.Child(i)
+		if child.Type() != "except_clause" {
+			continue
+		}
+
+		// Check each child of the except_clause for exception type identifiers.
+		hasExceptionType := false
+		for j := 0; j < int(child.ChildCount()); j++ {
+			gc := child.Child(j)
+			if gc.Type() == "identifier" {
+				hasExceptionType = true
+				name := gc.Content(src)
+				if name == "ImportError" || name == "ModuleNotFoundError" {
+					return true
+				}
+			}
+		}
+
+		// Bare except (no exception type specified) catches everything
+		// including ImportError.
+		if !hasExceptionType {
+			return true
+		}
+	}
+	return false
 }
 
 // resolvePythonPURLs resolves a Python import path to its PURLs.

--- a/internal/infrastructure/treesitter/analyzer_test.go
+++ b/internal/infrastructure/treesitter/analyzer_test.go
@@ -2116,3 +2116,122 @@ const x: Foo = {} as any;
 		t.Errorf("expected no coupling for type-only import in .ts file, got %d results", len(result))
 	}
 }
+
+func TestAnalyzer_PythonTryExceptImport(t *testing.T) {
+	tests := []struct {
+		name            string
+		code            string
+		wantBlankImport bool
+		wantUnused      bool
+		wantImportCount int
+		wantCallSites   int
+	}{
+		{
+			name: "try/except ImportError bare import",
+			code: `try:
+    import cryptography
+except ImportError:
+    pass
+`,
+			wantBlankImport: true,
+			wantUnused:      false,
+			wantImportCount: 1,
+			wantCallSites:   0,
+		},
+		{
+			name: "try/except ModuleNotFoundError",
+			code: `try:
+    import cryptography
+except ModuleNotFoundError:
+    raise RuntimeError("missing")
+`,
+			wantBlankImport: true,
+			wantUnused:      false,
+			wantImportCount: 1,
+			wantCallSites:   0,
+		},
+		{
+			name: "try/except bare except",
+			code: `try:
+    import cryptography
+except:
+    pass
+`,
+			wantBlankImport: true,
+			wantUnused:      false,
+			wantImportCount: 1,
+			wantCallSites:   0,
+		},
+		{
+			name: "try/except with from-import",
+			code: `try:
+    from cryptography import fernet
+except ImportError:
+    fernet = None
+`,
+			wantBlankImport: true,
+			wantUnused:      false,
+			wantImportCount: 1,
+			wantCallSites:   0,
+		},
+		{
+			name: "regular import not in try/except",
+			code: `import cryptography
+cryptography.fernet.Fernet("key")
+`,
+			wantBlankImport: false,
+			wantUnused:      false,
+			wantImportCount: 1,
+			wantCallSites:   1,
+		},
+		{
+			name: "try/except with unrelated exception type",
+			code: `try:
+    import cryptography
+except ValueError:
+    pass
+`,
+			wantBlankImport: false,
+			wantUnused:      false,
+			wantImportCount: 1,
+			wantCallSites:   0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			err := os.WriteFile(filepath.Join(dir, "main.py"), []byte(tt.code), 0644)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			analyzer := NewAnalyzer()
+			importPaths := map[string][]string{
+				"pkg:pypi/cryptography@41.0.0": {"cryptography"},
+			}
+			result, err := analyzer.AnalyzeCoupling(context.Background(), dir, importPaths)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			ca, ok := result["pkg:pypi/cryptography@41.0.0"]
+			if !ok {
+				t.Fatal("expected coupling analysis for cryptography")
+			}
+
+			if ca.HasBlankImport != tt.wantBlankImport {
+				t.Errorf("HasBlankImport = %v, want %v", ca.HasBlankImport, tt.wantBlankImport)
+			}
+			if ca.IsUnused != tt.wantUnused {
+				t.Errorf("IsUnused = %v, want %v", ca.IsUnused, tt.wantUnused)
+			}
+			if ca.ImportFileCount != tt.wantImportCount {
+				t.Errorf("ImportFileCount = %d, want %d", ca.ImportFileCount, tt.wantImportCount)
+			}
+			if ca.CallSiteCount != tt.wantCallSites {
+				t.Errorf("CallSiteCount = %d, want %d", ca.CallSiteCount, tt.wantCallSites)
+			}
+		})
+	}
+}

--- a/internal/infrastructure/treesitter/analyzer_test.go
+++ b/internal/infrastructure/treesitter/analyzer_test.go
@@ -1849,8 +1849,8 @@ public class Main {
 
 	analyzer := NewAnalyzer()
 	importPaths := map[string][]string{
-		"pkg:maven/com.google.code.findbugs/jsr305@3.0.2":              {"javax.annotation"},
-		"pkg:maven/com.google.inject/guice@5.1":                       {"com.google.inject"},
+		"pkg:maven/com.google.code.findbugs/jsr305@3.0.2":               {"javax.annotation"},
+		"pkg:maven/com.google.inject/guice@5.1":                         {"com.google.inject"},
 		"pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.15": {"com.fasterxml.jackson.annotation"},
 	}
 	result, err := analyzer.AnalyzeCoupling(context.Background(), dir, importPaths)
@@ -2195,6 +2195,48 @@ except ValueError:
 			wantUnused:      false,
 			wantImportCount: 1,
 			wantCallSites:   0,
+		},
+		{
+			name: "import inside except ImportError is not feature detection",
+			code: `try:
+    import unavailable_module
+except ImportError:
+    import cryptography
+
+cryptography.fernet.Fernet("key")
+`,
+			wantBlankImport: false,
+			wantUnused:      false,
+			wantImportCount: 1,
+			wantCallSites:   1,
+		},
+		{
+			name: "try/except ImportError import used via module attribute",
+			code: `try:
+    import cryptography
+except ImportError:
+    pass
+
+cryptography.fernet.Fernet("key")
+`,
+			wantBlankImport: true,
+			wantUnused:      false,
+			wantImportCount: 1,
+			wantCallSites:   1,
+		},
+		{
+			name: "try/except ImportError from import used via imported name",
+			code: `try:
+    from cryptography.fernet import Fernet
+except ImportError:
+    pass
+
+Fernet("key")
+`,
+			wantBlankImport: true,
+			wantUnused:      false,
+			wantImportCount: 1,
+			wantCallSites:   1,
 		},
 	}
 

--- a/internal/infrastructure/treesitter/analyzer_test.go
+++ b/internal/infrastructure/treesitter/analyzer_test.go
@@ -2238,6 +2238,30 @@ Fernet("key")
 			wantImportCount: 1,
 			wantCallSites:   1,
 		},
+		{
+			name: "try/except with tuple containing ImportError",
+			code: `try:
+    import cryptography
+except (ImportError, ValueError):
+    pass
+`,
+			wantBlankImport: true,
+			wantUnused:      false,
+			wantImportCount: 1,
+			wantCallSites:   0,
+		},
+		{
+			name: "try/except with tuple of unrelated exceptions",
+			code: `try:
+    import cryptography
+except (ValueError, TypeError):
+    pass
+`,
+			wantBlankImport: false,
+			wantUnused:      false,
+			wantImportCount: 1,
+			wantCallSites:   0,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- Detect Python `try/except ImportError` (and `ModuleNotFoundError`) blocks as feature-detection imports, where the `import` itself is the usage (checking if the package is installed)
- Treat these imports like Go blank imports (`import _ "pkg"`) using the existing `blankImportAlias` sentinel, so the dependency is not misclassified as unused
- Handle bare `except:` clauses (which catch everything including `ImportError`) as well

## Before
```
=== RUN   TestAnalyzer_PythonTryExceptImport/try/except_ImportError_bare_import
    analyzer_test.go:2127: HasBlankImport = false, want true
--- FAIL: TestAnalyzer_PythonTryExceptImport/try/except_ImportError_bare_import (0.04s)
--- FAIL: TestAnalyzer_PythonTryExceptImport/try/except_ModuleNotFoundError (0.03s)
--- FAIL: TestAnalyzer_PythonTryExceptImport/try/except_bare_except (0.03s)
--- FAIL: TestAnalyzer_PythonTryExceptImport/try/except_with_from-import (0.03s)
```

## After
```
--- PASS: TestAnalyzer_PythonTryExceptImport (0.20s)
    --- PASS: TestAnalyzer_PythonTryExceptImport/try/except_ImportError_bare_import (0.04s)
    --- PASS: TestAnalyzer_PythonTryExceptImport/try/except_ModuleNotFoundError (0.03s)
    --- PASS: TestAnalyzer_PythonTryExceptImport/try/except_bare_except (0.03s)
    --- PASS: TestAnalyzer_PythonTryExceptImport/try/except_with_from-import (0.03s)
    --- PASS: TestAnalyzer_PythonTryExceptImport/regular_import_not_in_try/except (0.03s)
    --- PASS: TestAnalyzer_PythonTryExceptImport/try/except_with_unrelated_exception_type (0.03s)
```

## Test plan
- [x] New test `TestAnalyzer_PythonTryExceptImport` with 6 sub-cases covering:
  - `try/except ImportError` with bare `import`
  - `try/except ModuleNotFoundError`
  - Bare `except:` (no exception type)
  - `try/except ImportError` with `from ... import`
  - Regular import (not in try/except) -- negative test
  - `try/except ValueError` (unrelated exception) -- negative test
- [x] Full treesitter test suite passes (all existing tests unaffected)
- [x] `go vet` clean
- [x] `golangci-lint` clean (0 issues)

Closes #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)