### PR TITLE
fix: detect Java interface inheritance and constructor calls as call sites

### DIFF
--- a/internal/application/diet/coupling_integration_test.go
+++ b/internal/application/diet/coupling_integration_test.go
@@ -40,7 +40,7 @@ public class Main {
 }
 `,
 			wantImportCount: 1,
-			wantCallSites:   2,
+			wantCallSites:   3,
 			wantUnused:      false,
 		},
 		{

--- a/internal/infrastructure/treesitter/analyzer.go
+++ b/internal/infrastructure/treesitter/analyzer.go
@@ -187,6 +187,9 @@ func NewAnalyzer() *Analyzer {
 			`(method_invocation !object name: (identifier) @func)`,
 			`(marker_annotation name: (identifier) @func)`,
 			`(annotation name: (identifier) @func)`,
+			`(object_creation_expression type: (type_identifier) @func)`,
+			`(super_interfaces (type_list (type_identifier) @func))`,
+			`(superclass (type_identifier) @func)`,
 		}, "\n"),
 		stripQuotes: false,
 		aliasFromPkg: func(importPath string) string {

--- a/internal/infrastructure/treesitter/analyzer_test.go
+++ b/internal/infrastructure/treesitter/analyzer_test.go
@@ -577,11 +577,11 @@ public class Main {
 	if ca.ImportFileCount != 1 {
 		t.Errorf("ImportFileCount = %d, want 1", ca.ImportFileCount)
 	}
-	if ca.CallSiteCount != 2 {
-		t.Errorf("CallSiteCount = %d, want 2", ca.CallSiteCount)
+	if ca.CallSiteCount != 3 {
+		t.Errorf("CallSiteCount = %d, want 3 (new Gson, toJson, fromJson)", ca.CallSiteCount)
 	}
-	if ca.APIBreadth != 2 {
-		t.Errorf("APIBreadth = %d, want 2 (toJson, fromJson)", ca.APIBreadth)
+	if ca.APIBreadth != 3 {
+		t.Errorf("APIBreadth = %d, want 3 (Gson, toJson, fromJson)", ca.APIBreadth)
 	}
 	if ca.IsUnused {
 		t.Error("IsUnused = true, want false")
@@ -1257,8 +1257,8 @@ public class Main {
 		if ca.ImportFileCount != 1 {
 			t.Errorf("%s: ImportFileCount = %d, want 1", purl, ca.ImportFileCount)
 		}
-		if ca.CallSiteCount != 1 {
-			t.Errorf("%s: CallSiteCount = %d, want 1", purl, ca.CallSiteCount)
+		if ca.CallSiteCount != 2 {
+			t.Errorf("%s: CallSiteCount = %d, want 2 (new Gson, toJson)", purl, ca.CallSiteCount)
 		}
 	}
 }
@@ -2020,6 +2020,147 @@ const data = Readable.from([1, 2, 3]);
 	}
 }
 
+func TestAnalyzer_JavaImplementsExtends(t *testing.T) {
+	dir := t.TempDir()
+	// Interface inheritance (implements/extends) should count as call sites.
+	// These are type references that indicate coupling to the dependency.
+	err := os.WriteFile(filepath.Join(dir, "MyPublisher.java"), []byte(`import org.reactivestreams.Publisher;
+import junit.framework.TestCase;
+
+public class MyPublisher implements Publisher {
+    public void subscribe(Object subscriber) {}
+}
+
+class MyTest extends TestCase {
+    public void testSomething() {}
+}
+`), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	analyzer := NewAnalyzer()
+	importPaths := map[string][]string{
+		"pkg:maven/org.reactivestreams/reactive-streams@1.0.4": {"org.reactivestreams"},
+		"pkg:maven/junit/junit@4.13.2":                         {"junit.framework"},
+	}
+	result, err := analyzer.AnalyzeCoupling(context.Background(), dir, importPaths)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name          string
+		purl          string
+		wantImports   int
+		wantCallSites int
+		wantBreadth   int
+	}{
+		{
+			name:          "implements Publisher",
+			purl:          "pkg:maven/org.reactivestreams/reactive-streams@1.0.4",
+			wantImports:   1,
+			wantCallSites: 1,
+			wantBreadth:   1,
+		},
+		{
+			name:          "extends TestCase",
+			purl:          "pkg:maven/junit/junit@4.13.2",
+			wantImports:   1,
+			wantCallSites: 1,
+			wantBreadth:   1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ca, ok := result[tt.purl]
+			if !ok {
+				t.Fatalf("expected coupling analysis for %s", tt.purl)
+			}
+			if ca.ImportFileCount != tt.wantImports {
+				t.Errorf("ImportFileCount = %d, want %d", ca.ImportFileCount, tt.wantImports)
+			}
+			if ca.CallSiteCount != tt.wantCallSites {
+				t.Errorf("CallSiteCount = %d, want %d", ca.CallSiteCount, tt.wantCallSites)
+			}
+			if ca.APIBreadth != tt.wantBreadth {
+				t.Errorf("APIBreadth = %d, want %d", ca.APIBreadth, tt.wantBreadth)
+			}
+			if ca.IsUnused {
+				t.Error("IsUnused = true, want false")
+			}
+		})
+	}
+}
+
+func TestAnalyzer_JavaConstructorCall(t *testing.T) {
+	dir := t.TempDir()
+	// Constructor calls (new Type()) should count as call sites.
+	// This captures usage like "new Gson()", "new ObjectMapper()" where the
+	// class name is used directly without a method_invocation on an alias.
+	err := os.WriteFile(filepath.Join(dir, "Main.java"), []byte(`import com.google.gson.Gson;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class Main {
+    public static void main(String[] args) {
+        Gson gson = new Gson();
+        ObjectMapper mapper = new ObjectMapper();
+    }
+}
+`), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	analyzer := NewAnalyzer()
+	importPaths := map[string][]string{
+		"pkg:maven/com.google.code.gson/gson@2.10":                     {"com.google.gson"},
+		"pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.15.2": {"com.fasterxml.jackson.databind"},
+	}
+	result, err := analyzer.AnalyzeCoupling(context.Background(), dir, importPaths)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name           string
+		purl           string
+		wantMinCalls   int
+		wantMinBreadth int
+	}{
+		{
+			name:           "new Gson() constructor",
+			purl:           "pkg:maven/com.google.code.gson/gson@2.10",
+			wantMinCalls:   1,
+			wantMinBreadth: 1,
+		},
+		{
+			name:           "new ObjectMapper() constructor",
+			purl:           "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.15.2",
+			wantMinCalls:   1,
+			wantMinBreadth: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ca, ok := result[tt.purl]
+			if !ok {
+				t.Fatalf("expected coupling analysis for %s", tt.purl)
+			}
+			if ca.CallSiteCount < tt.wantMinCalls {
+				t.Errorf("CallSiteCount = %d, want >= %d", ca.CallSiteCount, tt.wantMinCalls)
+			}
+			if ca.APIBreadth < tt.wantMinBreadth {
+				t.Errorf("APIBreadth = %d, want >= %d", ca.APIBreadth, tt.wantMinBreadth)
+			}
+			if ca.IsUnused {
+				t.Error("IsUnused = true, want false")
+			}
+		})
+	}
+}
 // TestAnalyzer_TypeScriptDefaultImportCall verifies that a default import binding
 // used as a direct function call is detected as a call site.
 // e.g., `import _generate from '@babel/generator'; _generate(ast);`
@@ -2053,7 +2194,6 @@ const result = _generate(ast, { comments: true });
 		t.Errorf("CallSiteCount = %d, want >= 1", ca.CallSiteCount)
 	}
 }
-
 // TestAnalyzer_TypeScriptSideEffectImport verifies that a bare side-effect import
 // (`import 'reflect-metadata'`) is tracked as used (not classified as unused).
 func TestAnalyzer_TypeScriptSideEffectImport(t *testing.T) {
@@ -2089,7 +2229,6 @@ func TestAnalyzer_TypeScriptSideEffectImport(t *testing.T) {
 		t.Error("HasBlankImport = false, want true (side-effect import analogous to Go blank import)")
 	}
 }
-
 // TestAnalyzer_TypeScriptTypeOnlyImportExclusion verifies that `import type { ... }`
 // in a .ts file (not just .tsx) is excluded from coupling analysis.
 func TestAnalyzer_TypeScriptTypeOnlyImportExclusion(t *testing.T) {
@@ -2116,7 +2255,6 @@ const x: Foo = {} as any;
 		t.Errorf("expected no coupling for type-only import in .ts file, got %d results", len(result))
 	}
 }
-
 func TestAnalyzer_PythonTryExceptImport(t *testing.T) {
 	tests := []struct {
 		name            string
@@ -2301,7 +2439,6 @@ except (ValueError, TypeError):
 		})
 	}
 }
-
 func TestAnalyzer_JSInlineRequireCallSites(t *testing.T) {
 	tests := []struct {
 		name         string


### PR DESCRIPTION
## Summary

- Add three tree-sitter query patterns to the Java `callQuery` in `analyzer.go`:
  - `(object_creation_expression type: (type_identifier) @func)` -- detects `new Gson()`, `new ObjectMapper()` etc.
  - `(super_interfaces (type_list (type_identifier) @func))` -- detects `implements Publisher`, `implements Serializable` etc.
  - `(superclass (type_identifier) @func)` -- detects `extends TestCase`, `extends AbstractProcessor` etc.
- These patterns were previously undetected, causing dependencies used via type hierarchy or construction to show 0 call sites despite being imported.
- Existing annotation patterns (`marker_annotation`, `annotation`) were already working correctly.

## Before

**`TestAnalyzer_Java` on `main` (36 tests, no implements/extends/constructor detection):**

```
$ GOWORK=off go test -run 'TestAnalyzer_Java$' -v -tags cgo ./internal/infrastructure/treesitter/...
=== RUN   TestAnalyzer_Java
--- PASS: TestAnalyzer_Java (0.04s)
PASS
ok  	github.com/future-architect/uzomuzo-oss/internal/infrastructure/treesitter	0.040s
```

On `main`, `TestAnalyzer_Java` expects:
- Gson: `CallSiteCount = 2` (`toJson`, `fromJson`), `APIBreadth = 2`
- `implements Publisher` / `extends TestCase` / `new Gson()` / `new ObjectMapper()`: **not detected** (0 call sites)

## After

**New test: `TestAnalyzer_JavaImplementsExtends` -- detects `implements` and `extends` type references:**

```
$ GOWORK=off go test -run 'TestAnalyzer_JavaImplementsExtends' -v -tags cgo ./internal/infrastructure/treesitter/...
=== RUN   TestAnalyzer_JavaImplementsExtends
=== RUN   TestAnalyzer_JavaImplementsExtends/implements_Publisher
=== RUN   TestAnalyzer_JavaImplementsExtends/extends_TestCase
--- PASS: TestAnalyzer_JavaImplementsExtends (0.04s)
    --- PASS: TestAnalyzer_JavaImplementsExtends/implements_Publisher (0.00s)
    --- PASS: TestAnalyzer_JavaImplementsExtends/extends_TestCase (0.00s)
PASS
ok  	github.com/future-architect/uzomuzo-oss/internal/infrastructure/treesitter	0.042s
```

**New test: `TestAnalyzer_JavaConstructorCall` -- detects `new Type()` constructor calls:**

```
$ GOWORK=off go test -run 'TestAnalyzer_JavaConstructorCall' -v -tags cgo ./internal/infrastructure/treesitter/...
=== RUN   TestAnalyzer_JavaConstructorCall
=== RUN   TestAnalyzer_JavaConstructorCall/new_Gson()_constructor
=== RUN   TestAnalyzer_JavaConstructorCall/new_ObjectMapper()_constructor
--- PASS: TestAnalyzer_JavaConstructorCall (0.03s)
    --- PASS: TestAnalyzer_JavaConstructorCall/new_Gson()_constructor (0.00s)
    --- PASS: TestAnalyzer_JavaConstructorCall/new_ObjectMapper()_constructor (0.00s)
PASS
ok  	github.com/future-architect/uzomuzo-oss/internal/infrastructure/treesitter	0.041s
```

**Updated `TestAnalyzer_Java` expectations (Gson now includes `new Gson()`):**

```
$ GOWORK=off go test -run 'TestAnalyzer_Java$' -v -tags cgo ./internal/infrastructure/treesitter/...
=== RUN   TestAnalyzer_Java
--- PASS: TestAnalyzer_Java (0.04s)
PASS
ok  	github.com/future-architect/uzomuzo-oss/internal/infrastructure/treesitter	0.039s
```

**Integration test also passes with updated expectations (Gson: 2 -> 3 call sites):**

```
$ GOWORK=off CGO_ENABLED=1 go test -run 'TestBuildImportPaths_AnalyzeCoupling_Integration' -v -tags cgo ./internal/application/diet/...
=== RUN   TestBuildImportPaths_AnalyzeCoupling_Integration
=== RUN   TestBuildImportPaths_AnalyzeCoupling_Integration/gson_via_override_mapping
=== RUN   TestBuildImportPaths_AnalyzeCoupling_Integration/commons-lang3_via_groupId_heuristic
=== RUN   TestBuildImportPaths_AnalyzeCoupling_Integration/unused_dependency_alongside_used_dependency
--- PASS: TestBuildImportPaths_AnalyzeCoupling_Integration (0.10s)
    --- PASS: TestBuildImportPaths_AnalyzeCoupling_Integration/gson_via_override_mapping (0.04s)
    --- PASS: TestBuildImportPaths_AnalyzeCoupling_Integration/commons-lang3_via_groupId_heuristic (0.03s)
    --- PASS: TestBuildImportPaths_AnalyzeCoupling_Integration/unused_dependency_alongside_used_dependency (0.03s)
PASS
ok  	github.com/future-architect/uzomuzo-oss/internal/application/diet	0.106s
```

**Full treesitter test suite: 36 tests (main) -> 38 tests (this PR), all passing.**

## Before / After Summary

| Pattern | Before | After |
|---------|--------|-------|
| `@Nullable` (annotation) | Detected | Detected (unchanged) |
| `implements Publisher` | 0 call sites | 1 call site |
| `extends TestCase` | 0 call sites | 1 call site |
| `new Gson()` | 0 call sites | 1 call site |
| `new ObjectMapper()` | 0 call sites | 1 call site |
| Gson total (existing test) | 2 calls, 2 breadth | 3 calls, 3 breadth |

## Test plan

- [x] `TestAnalyzer_JavaImplementsExtends` -- verifies `implements` and `extends` type references are counted
- [x] `TestAnalyzer_JavaConstructorCall` -- verifies `new Type()` constructor calls are counted
- [x] Updated `TestAnalyzer_Java` expectations (Gson test now counts `new Gson()` as a call site: 2->3 calls, 2->3 breadth)
- [x] Updated `TestAnalyzer_ImportToPURLCollision` expectations (1->2 call sites due to `new Gson()`)
- [x] `TestBuildImportPaths_AnalyzeCoupling_Integration` passes (Gson: 2->3 call sites)
- [x] All existing tests pass (38/38)
- [x] `go vet ./...` clean
- [x] `golangci-lint run` clean

Closes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)