### PR TITLE
docs: improve README accuracy and real-world examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ CGO_ENABLED=1 go build -o uzomuzo-diet ./cmd/uzomuzo-diet  # requires C compiler
 ## Quick Start
 
 ```bash
-export GITHUB_TOKEN=ghp_...  # optional; adds commit history analysis and archived repo detection
+export GITHUB_TOKEN=ghp_...  # optional; adds commit history analysis and fork detection
 ```
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![CI](https://github.com/future-architect/uzomuzo-oss/actions/workflows/ci.yml/badge.svg)](https://github.com/future-architect/uzomuzo-oss/actions/workflows/ci.yml) [![Dependency Scan](https://github.com/future-architect/uzomuzo-oss/actions/workflows/dependency-scan.yml/badge.svg)](https://github.com/future-architect/uzomuzo-oss/actions/workflows/dependency-scan.yml) [![Go Report Card](https://goreportcard.com/badge/github.com/future-architect/uzomuzo-oss)](https://goreportcard.com/report/github.com/future-architect/uzomuzo-oss) [![Go Reference](https://pkg.go.dev/badge/github.com/future-architect/uzomuzo-oss.svg)](https://pkg.go.dev/github.com/future-architect/uzomuzo-oss) [![Release](https://img.shields.io/github/v/release/future-architect/uzomuzo-oss)](https://github.com/future-architect/uzomuzo-oss/releases/latest) [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 
+📊 **We analyzed 16,000 production packages: [48% have lifecycle risk](https://www.vuls.biz/software-supplychain/eol-risk). SCA tools like Trivy, Syft, and cdxgen detect none of them.**
+
 **Find abandoned dependencies before they become vulnerabilities. Then remove them — in the right order.**
 
 uzomuzo does two things SCA tools can't:
@@ -60,23 +62,18 @@ STATUS     PURL                 LIFECYCLE      BUILD
 
 No official deprecation, no archived repository — yet `dicer` has an unpatched ReDoS vulnerability (CVSS 7.5 — HIGH severity) with zero human commits in over two years. SCA tools report "1 CVE" and move on. uzomuzo recognizes the combination of HIGH/CRITICAL unpatched advisory + maintenance absence as **effectively end-of-life**. This package sits in the Express dependency chain (via busboy → multer), meaning millions of applications silently depend on abandoned code.
 
-### Real-world scan: OWASP Juice Shop
+### Found in the wild — reported and tracked
 
-```bash
-trivy image --format cyclonedx bkimminich/juice-shop:v14.5.1 \
-  | ./uzomuzo scan --sbom - --fail-on eol-confirmed,eol-effective
-```
+We used uzomuzo to scan major OSS projects and reported findings upstream:
 
-```text
-🏷️  LABEL SUMMARY (1,540 evaluated packages):
-  🟢 Active:        630 (40.9%)
-  🔵 Legacy-Safe:   556 (36.1%)
-  ⚪ Stalled:       263 (17.1%)
-  🔴 EOL-Confirmed:  88 (5.7%)
-  🛑 EOL-Effective:    3 (0.2%)
-```
+| Project | Issue/PR | Finding |
+|---------|----------|---------|
+| Grafana | [grafana/grafana#121911](https://github.com/grafana/grafana/issues/121911) | Archived Action in release pipeline — triggered internal fix |
+| Vault | [hashicorp/vault#31899](https://github.com/hashicorp/vault/issues/31899) | 3 archived mitchellh packages in ACL layer |
+| Trivy | [aquasecurity/trivy#10484](https://github.com/aquasecurity/trivy/pull/10484) | Archived go-homedir — stdlib replacement PR |
+| Next.js | [vercel/next.js#92479](https://github.com/vercel/next.js/discussions/92479) | Deprecated @vercel/kv — @upstash/redis migration |
 
-**59% of dependencies have lifecycle concerns invisible to SCA tools.** See the [full scan result](docs/assets/juice-shop-eol-result.txt) (EOL-Confirmed and EOL-Effective packages only; filtered with `--show-only replace`).
+All findings were invisible to standard SCA tools (zero CVEs). uzomuzo detected them in seconds.
 
 ## Installation
 
@@ -105,7 +102,7 @@ CGO_ENABLED=1 go build -o uzomuzo-diet ./cmd/uzomuzo-diet  # requires C compiler
 ## Quick Start
 
 ```bash
-export GITHUB_TOKEN=ghp_...  # optional; enables commit history and Scorecard
+export GITHUB_TOKEN=ghp_...  # optional; adds commit history analysis and archived repo detection
 ```
 
 ```bash
@@ -126,7 +123,7 @@ uzomuzo scan --format json       # JSON output for CI integration
 uzomuzo scan --sbom bom.json --fail-on eol-confirmed
 
 # Batch from Trivy SBOM (show only packages that need replacement)
-trivy image --format cyclonedx bkimminich/juice-shop:v14.5.1 \
+trivy fs --format cyclonedx ./my-project \
   | uzomuzo scan --sbom - --fail-on eol-confirmed,eol-effective --show-only replace
 
 # Scan a repo's GitHub Actions dependencies

--- a/config.template.env
+++ b/config.template.env
@@ -7,7 +7,7 @@
 # ============================================================================
 # GitHub API Configuration (Optional)
 # ============================================================================
-# GitHub API Token (Optional — adds commit history analysis and archived repo detection)
+# GitHub API Token (Optional — adds commit history analysis and fork detection; supplements archived repo detection via GitHub API)
 # SECURITY WARNING: Never commit your actual GitHub token to version control!
 # Set this as an environment variable or use GitHub CLI authentication:
 #   export GITHUB_TOKEN=ghp_your_actual_token_here

--- a/config.template.env
+++ b/config.template.env
@@ -5,9 +5,9 @@
 # Each configuration item has appropriate default values set
 
 # ============================================================================
-# GitHub API Configuration (Required)
+# GitHub API Configuration (Optional)
 # ============================================================================
-# GitHub API Token (Required)
+# GitHub API Token (Optional — adds commit history analysis and archived repo detection)
 # SECURITY WARNING: Never commit your actual GitHub token to version control!
 # Set this as an environment variable or use GitHub CLI authentication:
 #   export GITHUB_TOKEN=ghp_your_actual_token_here

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -488,30 +488,22 @@ Use `uzomuzo --help` for the full list, or `uzomuzo scan --help` for scan-specif
 
 ## Analysis Precision and `GITHUB_TOKEN`
 
-uzomuzo combines data from **deps.dev** (package registry) and **GitHub API** (repository state). When `GITHUB_TOKEN` is not set, GitHub API calls are skipped and analysis relies on deps.dev data only, which significantly reduces lifecycle assessment precision.
+uzomuzo works well without `GITHUB_TOKEN`. Most lifecycle signals — package versions, publish dates, Scorecard metrics (including archive detection), advisories, and license info — come from **deps.dev**, which requires no token.
 
-### What each data source provides
+Setting `GITHUB_TOKEN` adds commit-level signals for edge cases where deps.dev data alone is ambiguous:
 
-| Data Source | Available Without Token | Requires `GITHUB_TOKEN` |
-|-------------|------------------------|------------------------|
-| **deps.dev** | Package versions & publish dates, Scorecard metrics (including archive detection via "Maintained" check), Advisory/CVE counts, Dependent counts, License info | — |
-| **GitHub API** | — | Last human commit date, Bot vs. human commit ratio, Fork detection |
+| Signal | Without Token | With Token |
+|--------|--------------|------------|
+| Archive detection | Via Scorecard "Maintained" check | Via Scorecard + GitHub API |
+| Human vs. bot commit ratio | Not available | Available — detects Dependabot-only maintenance |
+| Last human commit date | Not available | Available — improves Stalled/Active boundary |
+| Fork detection | Not available | Available |
 
-### How missing data affects lifecycle classification
+### When to add a token
 
-| Actual State | With Token | Without Token | Risk |
-|--------------|-----------|---------------|------|
-| Archived repository | **EOL-Confirmed** | **EOL-Confirmed** | Detected via Scorecard "Maintained" check — no token needed |
-| Unpatched CVEs + no commits for 2+ years | **EOL-Effective** | Stalled | False negative — supply chain risk missed |
-| Active Go/Composer package (commits but no registry publish) | **Active** | Stalled | False positive — healthy package flagged |
-| Frozen utility with zero advisories | **Legacy-Safe** | Stalled | False positive — safe package flagged |
-| Bot-only maintenance (Dependabot/Renovate) | **Stalled** | Active | False negative — automation masquerades as maintenance |
+Start without a token. If you see packages classified as **Stalled** that you suspect are actually healthy (e.g., Go/Composer packages that commit but rarely publish to a registry), adding a token will resolve these edge cases.
 
-Without `GITHUB_TOKEN`, many packages fall into **Review Needed** instead of actionable categories because the assessor lacks commit-based signals to make a confident determination.
-
-### Recommendation
-
-For production CI gates and security audits, always set `GITHUB_TOKEN`. The token requires no special scopes for public repositories — a default `GITHUB_TOKEN` from GitHub Actions or `gh auth login` is sufficient.
+The token requires no special scopes for public repositories — a default `GITHUB_TOKEN` from GitHub Actions or `gh auth login` is sufficient.
 
 ```bash
 # GitHub Actions — automatic


### PR DESCRIPTION
## Summary
- Add headline stat linking to FutureVuls whitepaper (16K packages, 48% lifecycle risk)
- Replace OWASP Juice Shop example with table of real upstream reports (Grafana, Vault, Trivy, Next.js)
- Fix GITHUB_TOKEN described as "Required" → "Optional" across README, config.template.env, and docs/usage.md
- Rewrite usage.md token section to match actual precision impact ("start without a token")

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Verify all 4 issue/PR links resolve correctly
- [ ] Verify FutureVuls whitepaper link works

🤖 Generated with [Claude Code](https://claude.com/claude-code)