### PR TITLE
feat: add wheel-based fallback for PyPI package-to-import name resolution

### DIFF
--- a/.claude/rules/copilot-learned-coding.md
+++ b/.claude/rules/copilot-learned-coding.md
@@ -85,6 +85,11 @@ pending_patterns:
     pr: 236
     file: "internal/infrastructure/eolevaluator/evaluator_npm_test.go"
     date: "2026-04-08"
+  - category: "security"
+    summary: "Validate URL host non-empty alongside scheme check — hostless URLs like https:///path pass scheme validation but fail later in uncontrolled ways"
+    pr: 276
+    file: "internal/infrastructure/pypi/wheel.go"
+    date: "2026-04-11"
   - category: "defensive-coding"
     summary: "Gate fallback/retry logic on the error value, not result nilness — a nil result with nil error is a valid success case (e.g., zero matches) and should still trigger fallback behavior"
     pr: 276
@@ -100,6 +105,11 @@ pending_patterns:
     pr: 237
     file: "internal/application/diet/coupling_integration_test.go"
     date: "2026-04-08"
+  - category: "defensive-coding"
+    summary: "Use spec-compliant parsers (e.g., encoding/csv) instead of naive string splitting for standardized file formats — naive splits misparse quoted or escaped fields"
+    pr: 276
+    file: "internal/infrastructure/pypi/wheel.go"
+    date: "2026-04-11"
   - category: "whitespace-agnostic-matching"
     summary: "Use bytes.Fields tokenization instead of fixed-separator prefix checks when matching directives — tabs and multiple spaces are valid separators"
     pr: 140

--- a/.claude/rules/copilot-learned-coding.md
+++ b/.claude/rules/copilot-learned-coding.md
@@ -85,6 +85,11 @@ pending_patterns:
     pr: 236
     file: "internal/infrastructure/eolevaluator/evaluator_npm_test.go"
     date: "2026-04-08"
+  - category: "security"
+    summary: "Cap HTTP response body sizes with io.LimitReader before decoding — uncapped reads from overridden base URLs or mirrors can cause excessive memory usage"
+    pr: 276
+    file: "internal/infrastructure/pypi/client.go"
+    date: "2026-04-11"
   - category: "testing"
     summary: "When code merges results into a map that may be nil (e.g., initialized only on non-empty results), add a test where the initial map is nil and the merge path still executes — catches nil map assignment panics"
     pr: 276

--- a/.claude/rules/copilot-learned-coding.md
+++ b/.claude/rules/copilot-learned-coding.md
@@ -14,6 +14,7 @@ Rules extracted from recurring Copilot review patterns on coding-standards topic
 - **Reject Flags That Silently Have No Effect**: When a CLI flag only applies to a specific input mode (e.g., `--sample` for PURL list files), explicitly reject it with a clear error when the input is a different mode (e.g., go.mod or SBOM). Do not silently ignore the flag — users assume their flags take effect.
 - **Deduplicate Inputs Before Batch API Calls**: When accepting user-provided input lists (PURLs, URLs) that feed into batch API calls, deduplicate them while preserving first-seen order before processing. Duplicates cause redundant external calls, skew logging/counts, and waste resources.
 - **Normalize User-Provided Enum Values**: When accepting string values for format selectors, mode switches, or other enums from CLI flags, normalize with `strings.TrimSpace(strings.ToLower(...))` before validation. Case-sensitive matching rejects common inputs like `--format JSON` or `--format "json "`.
+- **Interface Contract Documentation Must Match Signature Semantics**: When documenting an interface method, the doc comment must accurately reflect the method's full signature — including error returns, nil semantics, and parameter constraints. If the signature returns `(T, error)`, do not document it as "returns nil/empty on failure" — state that errors may be returned and describe the caller's expected handling (e.g., non-fatal/graceful degradation). Mismatched contract documentation misleads implementers and callers.
 - **GitHub Actions `||` Treats Empty as Falsy**: When a workflow input documents "empty = X behavior", do not use `${{ inputs.foo || 'default' }}` — the `||` operator treats empty string as falsy and applies the default, preventing users from intentionally selecting the empty option. Instead, pass the raw input via an env var and apply defaults conditionally (e.g., only for scheduled triggers).
 - **Guard Downstream Jobs Against Missing Outputs**: When a CI job produces outputs that downstream jobs depend on (exit codes, flags), gate downstream jobs on `needs.<job>.outputs.<key> != ''` to prevent execution when the upstream job fails before setting outputs. Otherwise, empty values may be misinterpreted (e.g., empty exit code `""` compared with `!= "0"` evaluates to true, creating misleading reports).
 - **CI Job Gating — Key on Outputs, Not Job Result**: When a CI job intentionally exits non-zero for a primary use case (e.g., policy violations), downstream jobs must not gate on `needs.<job>.result == 'success'`. Use explicit output variables (exit codes, flags) to control downstream behavior, so jobs run in the scenarios they are designed for.
@@ -30,6 +31,7 @@ Rules extracted from recurring Copilot review patterns on coding-standards topic
 - **Nil vs Empty Map Semantics for Sentinel-Checked Maps**: When a function returns a map that callers check for `nil` as a sentinel (e.g., "no data available" vs "data resolved but empty"), return `nil` when the resolved set is empty rather than an empty non-nil map. An empty non-nil map can cause callers to misinterpret "no results found" as "all items excluded", leading to incorrect classification or silent data loss.
 - **Normalize Repo-Scoped Paths with `path.Clean`**: When accepting user- or YAML-supplied paths that are scoped within a repository (e.g., local action `./` references), normalize with `path.Clean` (not `filepath.Clean`) and reject results that equal `"."` or start with `".."`. Also reject backslashes. This prevents traversal beyond the repository root via the Contents API without blocking valid intra-repo `..` segments (e.g., `./foo/../bar` → `bar`).
 - **Accurate Error Map Keys**: When recording errors in a `map[string]error` keyed by file path, use the actual resolved path — not a hardcoded filename. If a fetch tries `action.yml` then falls back to `action.yaml`, the error key must reflect which file was attempted, or use the parent path without a filename assumption.
+- **Handle All Valid Input Forms in Format Parsers**: When parsing a structured format (ZIP entries, RECORD files, manifests), handle all valid representations defined by the spec — not just the common case. For example, Python wheel RECORD files contain both package directories (`pkg/__init__.py`) and root-level modules (`six.py`); skipping root-level entries silently drops valid import names for single-module packages.
 - **Explicit Fallback for Unknown Enum Values**: When mapping external values (API responses, YAML fields) to internal enums or display strings, map unrecognized values to an explicit fallback (e.g., `"unknown(X)"`) rather than silently defaulting to a valid enum member. Silent defaults hide data quality issues and make debugging harder.
 - **Machine-Readable Columns Must Contain Single Values**: When adding columns to machine-readable output (CSV, JSON), each column must contain exactly one data type — do not combine a label and a number in a single field (e.g., `"HIGH (7.5)"`). Split compound values into separate columns (e.g., `max_advisory_severity` + `max_cvss3_score`). Mixed-format cells break downstream parsing and sorting.
 - **Use Domain Constants for Domain-Defined String Values**: When display or mapping logic switches on string values that are defined as domain constants (e.g., `LicenseSource*`), reference the constants — not duplicated raw strings. Duplicating values causes silent drift when constants are renamed or new values are added.
@@ -83,16 +85,6 @@ pending_patterns:
     pr: 236
     file: "internal/infrastructure/eolevaluator/evaluator_npm_test.go"
     date: "2026-04-08"
-  - category: "comment-doc-drift"
-    summary: "Doc comments must not make absolute claims about external system behavior — scope claims to what the current function actually handles"
-    pr: 253
-    file: "internal/infrastructure/treesitter/analyzer.go"
-    date: "2026-04-09"
-  - category: "defensive-coding"
-    summary: "Use utf8.DecodeRuneInString + unicode.ToLower for first-character case conversion — byte slicing alias[:1] produces invalid UTF-8 for non-ASCII identifiers"
-    pr: 277
-    file: "internal/infrastructure/treesitter/lang_java.go"
-    date: "2026-04-11"
   - category: "testing"
     summary: "Accept interface types in test-setter methods (e.g., SetXxxClient) so fakes can be injected via public API instead of unexported fields"
     pr: 236
@@ -121,6 +113,8 @@ pending_patterns:
 ```
 
 <!-- Promotion history (kept for audit trail):
+  # comment-doc-drift: promoted to copilot-learned-coding.instructions.md (PRs #253, #276 — interface contract doc must match signature semantics)
+  # defensive-coding: promoted to copilot-learned-coding.instructions.md (PRs #277, #276 — handle all valid input forms in format parsers)
   # error-handling: promoted to error-handling.instructions.md (PRs #87, #159 — surface initialization errors instead of silent degradation)
   # defensive-coding: already covered by promoted rules (PR #159, analyzer.go:382 — filter tree-sitter captures by name to skip non-import captures)
   # deterministic-output: already covered by promoted rule (PR #159, analyzer.go:315 — sort ImportFiles for deterministic JSON output)

--- a/.claude/rules/copilot-learned-coding.md
+++ b/.claude/rules/copilot-learned-coding.md
@@ -85,6 +85,11 @@ pending_patterns:
     pr: 236
     file: "internal/infrastructure/eolevaluator/evaluator_npm_test.go"
     date: "2026-04-08"
+  - category: "testing"
+    summary: "When code merges results into a map that may be nil (e.g., initialized only on non-empty results), add a test where the initial map is nil and the merge path still executes — catches nil map assignment panics"
+    pr: 276
+    file: "internal/application/diet/service_test.go"
+    date: "2026-04-11"
   - category: "security"
     summary: "Validate URL host non-empty alongside scheme check — hostless URLs like https:///path pass scheme validation but fail later in uncontrolled ways"
     pr: 276

--- a/.claude/rules/copilot-learned-coding.md
+++ b/.claude/rules/copilot-learned-coding.md
@@ -85,6 +85,11 @@ pending_patterns:
     pr: 236
     file: "internal/infrastructure/eolevaluator/evaluator_npm_test.go"
     date: "2026-04-08"
+  - category: "defensive-coding"
+    summary: "Gate fallback/retry logic on the error value, not result nilness — a nil result with nil error is a valid success case (e.g., zero matches) and should still trigger fallback behavior"
+    pr: 276
+    file: "internal/application/diet/service.go"
+    date: "2026-04-11"
   - category: "testing"
     summary: "Accept interface types in test-setter methods (e.g., SetXxxClient) so fakes can be injected via public API instead of unexported fields"
     pr: 236

--- a/.claude/rules/copilot-learned-coding.md
+++ b/.claude/rules/copilot-learned-coding.md
@@ -85,6 +85,16 @@ pending_patterns:
     pr: 236
     file: "internal/infrastructure/eolevaluator/evaluator_npm_test.go"
     date: "2026-04-08"
+  - category: "defensive-coding"
+    summary: "When retrying a subset of inputs through an analyzer that tracks collisions, rerun with the combined input set (original + retry) to preserve attribution consistency — subset reruns misattribute shared matches"
+    pr: 276
+    file: "internal/application/diet/service.go"
+    date: "2026-04-11"
+  - category: "security"
+    summary: "When using io.LimitReader to cap entry reads, read maxSize+1 and reject if oversized — plain LimitReader silently truncates, causing downstream parsers to operate on partial/corrupt data"
+    pr: 276
+    file: "internal/infrastructure/pypi/wheel.go"
+    date: "2026-04-11"
   - category: "security"
     summary: "Cap HTTP response body sizes with io.LimitReader before decoding — uncapped reads from overridden base URLs or mirrors can cause excessive memory usage"
     pr: 276

--- a/.github/instructions/copilot-learned-coding.instructions.md
+++ b/.github/instructions/copilot-learned-coding.instructions.md
@@ -83,6 +83,11 @@ pending_patterns:
     pr: 236
     file: "internal/infrastructure/eolevaluator/evaluator_npm_test.go"
     date: "2026-04-08"
+  - category: "defensive-coding"
+    summary: "Gate fallback/retry logic on the error value, not result nilness — a nil result with nil error is a valid success case (e.g., zero matches) and should still trigger fallback behavior"
+    pr: 276
+    file: "internal/application/diet/service.go"
+    date: "2026-04-11"
   - category: "testing"
     summary: "Accept interface types in test-setter methods (e.g., SetXxxClient) so fakes can be injected via public API instead of unexported fields"
     pr: 236

--- a/.github/instructions/copilot-learned-coding.instructions.md
+++ b/.github/instructions/copilot-learned-coding.instructions.md
@@ -83,6 +83,11 @@ pending_patterns:
     pr: 236
     file: "internal/infrastructure/eolevaluator/evaluator_npm_test.go"
     date: "2026-04-08"
+  - category: "testing"
+    summary: "When code merges results into a map that may be nil (e.g., initialized only on non-empty results), add a test where the initial map is nil and the merge path still executes — catches nil map assignment panics"
+    pr: 276
+    file: "internal/application/diet/service_test.go"
+    date: "2026-04-11"
   - category: "security"
     summary: "Validate URL host non-empty alongside scheme check — hostless URLs like https:///path pass scheme validation but fail later in uncontrolled ways"
     pr: 276

--- a/.github/instructions/copilot-learned-coding.instructions.md
+++ b/.github/instructions/copilot-learned-coding.instructions.md
@@ -12,6 +12,7 @@ Rules extracted from recurring Copilot review patterns on coding-standards topic
 - **Reject Flags That Silently Have No Effect**: When a CLI flag only applies to a specific input mode (e.g., `--sample` for PURL list files), explicitly reject it with a clear error when the input is a different mode (e.g., go.mod or SBOM). Do not silently ignore the flag — users assume their flags take effect.
 - **Deduplicate Inputs Before Batch API Calls**: When accepting user-provided input lists (PURLs, URLs) that feed into batch API calls, deduplicate them while preserving first-seen order before processing. Duplicates cause redundant external calls, skew logging/counts, and waste resources.
 - **Normalize User-Provided Enum Values**: When accepting string values for format selectors, mode switches, or other enums from CLI flags, normalize with `strings.TrimSpace(strings.ToLower(...))` before validation. Case-sensitive matching rejects common inputs like `--format JSON` or `--format "json "`.
+- **Interface Contract Documentation Must Match Signature Semantics**: When documenting an interface method, the doc comment must accurately reflect the method's full signature — including error returns, nil semantics, and parameter constraints. If the signature returns `(T, error)`, do not document it as "returns nil/empty on failure" — state that errors may be returned and describe the caller's expected handling (e.g., non-fatal/graceful degradation). Mismatched contract documentation misleads implementers and callers.
 - **GitHub Actions `||` Treats Empty as Falsy**: When a workflow input documents "empty = X behavior", do not use `${{ inputs.foo || 'default' }}` — the `||` operator treats empty string as falsy and applies the default, preventing users from intentionally selecting the empty option. Instead, pass the raw input via an env var and apply defaults conditionally (e.g., only for scheduled triggers).
 - **Guard Downstream Jobs Against Missing Outputs**: When a CI job produces outputs that downstream jobs depend on (exit codes, flags), gate downstream jobs on `needs.<job>.outputs.<key> != ''` to prevent execution when the upstream job fails before setting outputs. Otherwise, empty values may be misinterpreted (e.g., empty exit code `""` compared with `!= "0"` evaluates to true, creating misleading reports).
 - **CI Job Gating — Key on Outputs, Not Job Result**: When a CI job intentionally exits non-zero for a primary use case (e.g., policy violations), downstream jobs must not gate on `needs.<job>.result == 'success'`. Use explicit output variables (exit codes, flags) to control downstream behavior, so jobs run in the scenarios they are designed for.
@@ -28,6 +29,7 @@ Rules extracted from recurring Copilot review patterns on coding-standards topic
 - **Nil vs Empty Map Semantics for Sentinel-Checked Maps**: When a function returns a map that callers check for `nil` as a sentinel (e.g., "no data available" vs "data resolved but empty"), return `nil` when the resolved set is empty rather than an empty non-nil map. An empty non-nil map can cause callers to misinterpret "no results found" as "all items excluded", leading to incorrect classification or silent data loss.
 - **Normalize Repo-Scoped Paths with `path.Clean`**: When accepting user- or YAML-supplied paths that are scoped within a repository (e.g., local action `./` references), normalize with `path.Clean` (not `filepath.Clean`) and reject results that equal `"."` or start with `".."`. Also reject backslashes. This prevents traversal beyond the repository root via the Contents API without blocking valid intra-repo `..` segments (e.g., `./foo/../bar` → `bar`).
 - **Accurate Error Map Keys**: When recording errors in a `map[string]error` keyed by file path, use the actual resolved path — not a hardcoded filename. If a fetch tries `action.yml` then falls back to `action.yaml`, the error key must reflect which file was attempted, or use the parent path without a filename assumption.
+- **Handle All Valid Input Forms in Format Parsers**: When parsing a structured format (ZIP entries, RECORD files, manifests), handle all valid representations defined by the spec — not just the common case. For example, Python wheel RECORD files contain both package directories (`pkg/__init__.py`) and root-level modules (`six.py`); skipping root-level entries silently drops valid import names for single-module packages.
 - **Explicit Fallback for Unknown Enum Values**: When mapping external values (API responses, YAML fields) to internal enums or display strings, map unrecognized values to an explicit fallback (e.g., `"unknown(X)"`) rather than silently defaulting to a valid enum member. Silent defaults hide data quality issues and make debugging harder.
 - **Machine-Readable Columns Must Contain Single Values**: When adding columns to machine-readable output (CSV, JSON), each column must contain exactly one data type — do not combine a label and a number in a single field (e.g., `"HIGH (7.5)"`). Split compound values into separate columns (e.g., `max_advisory_severity` + `max_cvss3_score`). Mixed-format cells break downstream parsing and sorting.
 - **Use Domain Constants for Domain-Defined String Values**: When display or mapping logic switches on string values that are defined as domain constants (e.g., `LicenseSource*`), reference the constants — not duplicated raw strings. Duplicating values causes silent drift when constants are renamed or new values are added.
@@ -81,16 +83,6 @@ pending_patterns:
     pr: 236
     file: "internal/infrastructure/eolevaluator/evaluator_npm_test.go"
     date: "2026-04-08"
-  - category: "comment-doc-drift"
-    summary: "Doc comments must not make absolute claims about external system behavior — scope claims to what the current function actually handles"
-    pr: 253
-    file: "internal/infrastructure/treesitter/analyzer.go"
-    date: "2026-04-09"
-  - category: "defensive-coding"
-    summary: "Use utf8.DecodeRuneInString + unicode.ToLower for first-character case conversion — byte slicing alias[:1] produces invalid UTF-8 for non-ASCII identifiers"
-    pr: 277
-    file: "internal/infrastructure/treesitter/lang_java.go"
-    date: "2026-04-11"
   - category: "testing"
     summary: "Accept interface types in test-setter methods (e.g., SetXxxClient) so fakes can be injected via public API instead of unexported fields"
     pr: 236
@@ -119,6 +111,8 @@ pending_patterns:
 ```
 
 <!-- Promotion history (kept for audit trail):
+  # comment-doc-drift: promoted to copilot-learned-coding.instructions.md (PRs #253, #276 — interface contract doc must match signature semantics)
+  # defensive-coding: promoted to copilot-learned-coding.instructions.md (PRs #277, #276 — handle all valid input forms in format parsers)
   # error-handling: promoted to error-handling.instructions.md (PRs #87, #159 — surface initialization errors instead of silent degradation)
   # defensive-coding: already covered by promoted rules (PR #159, analyzer.go:382 — filter tree-sitter captures by name to skip non-import captures)
   # deterministic-output: already covered by promoted rule (PR #159, analyzer.go:315 — sort ImportFiles for deterministic JSON output)

--- a/.github/instructions/copilot-learned-coding.instructions.md
+++ b/.github/instructions/copilot-learned-coding.instructions.md
@@ -83,6 +83,16 @@ pending_patterns:
     pr: 236
     file: "internal/infrastructure/eolevaluator/evaluator_npm_test.go"
     date: "2026-04-08"
+  - category: "defensive-coding"
+    summary: "When retrying a subset of inputs through an analyzer that tracks collisions, rerun with the combined input set (original + retry) to preserve attribution consistency — subset reruns misattribute shared matches"
+    pr: 276
+    file: "internal/application/diet/service.go"
+    date: "2026-04-11"
+  - category: "security"
+    summary: "When using io.LimitReader to cap entry reads, read maxSize+1 and reject if oversized — plain LimitReader silently truncates, causing downstream parsers to operate on partial/corrupt data"
+    pr: 276
+    file: "internal/infrastructure/pypi/wheel.go"
+    date: "2026-04-11"
   - category: "security"
     summary: "Cap HTTP response body sizes with io.LimitReader before decoding — uncapped reads from overridden base URLs or mirrors can cause excessive memory usage"
     pr: 276

--- a/.github/instructions/copilot-learned-coding.instructions.md
+++ b/.github/instructions/copilot-learned-coding.instructions.md
@@ -83,6 +83,11 @@ pending_patterns:
     pr: 236
     file: "internal/infrastructure/eolevaluator/evaluator_npm_test.go"
     date: "2026-04-08"
+  - category: "security"
+    summary: "Cap HTTP response body sizes with io.LimitReader before decoding — uncapped reads from overridden base URLs or mirrors can cause excessive memory usage"
+    pr: 276
+    file: "internal/infrastructure/pypi/client.go"
+    date: "2026-04-11"
   - category: "testing"
     summary: "When code merges results into a map that may be nil (e.g., initialized only on non-empty results), add a test where the initial map is nil and the merge path still executes — catches nil map assignment panics"
     pr: 276

--- a/.github/instructions/copilot-learned-coding.instructions.md
+++ b/.github/instructions/copilot-learned-coding.instructions.md
@@ -83,6 +83,11 @@ pending_patterns:
     pr: 236
     file: "internal/infrastructure/eolevaluator/evaluator_npm_test.go"
     date: "2026-04-08"
+  - category: "security"
+    summary: "Validate URL host non-empty alongside scheme check — hostless URLs like https:///path pass scheme validation but fail later in uncontrolled ways"
+    pr: 276
+    file: "internal/infrastructure/pypi/wheel.go"
+    date: "2026-04-11"
   - category: "defensive-coding"
     summary: "Gate fallback/retry logic on the error value, not result nilness — a nil result with nil error is a valid success case (e.g., zero matches) and should still trigger fallback behavior"
     pr: 276
@@ -98,6 +103,11 @@ pending_patterns:
     pr: 237
     file: "internal/application/diet/coupling_integration_test.go"
     date: "2026-04-08"
+  - category: "defensive-coding"
+    summary: "Use spec-compliant parsers (e.g., encoding/csv) instead of naive string splitting for standardized file formats — naive splits misparse quoted or escaped fields"
+    pr: 276
+    file: "internal/infrastructure/pypi/wheel.go"
+    date: "2026-04-11"
   - category: "whitespace-agnostic-matching"
     summary: "Use bytes.Fields tokenization instead of fixed-separator prefix checks when matching directives — tabs and multiple spaces are valid separators"
     pr: 140

--- a/cmd/uzomuzo-diet/e2e_test.go
+++ b/cmd/uzomuzo-diet/e2e_test.go
@@ -91,7 +91,7 @@ func runDiet(t *testing.T, format string) string {
 		readErrCh <- readErr
 	}()
 
-	runErr := cli.RunDiet(context.Background(), cfg, opts, graphAnalyzer, sourceAnalyzer)
+	runErr := cli.RunDiet(context.Background(), cfg, opts, graphAnalyzer, sourceAnalyzer, nil)
 
 	os.Stdout = oldStdout
 	if err := w.Close(); err != nil {
@@ -277,7 +277,7 @@ func TestE2E_DietCLIFlags(t *testing.T) {
 				SourceRoot: cmd.String("source"),
 				Format:     cmd.String("format"),
 			}
-			return cli.RunDiet(ctx, cfg, opts, graphAnalyzer, sourceAnalyzer)
+			return cli.RunDiet(ctx, cfg, opts, graphAnalyzer, sourceAnalyzer, nil)
 		},
 	}
 
@@ -308,7 +308,7 @@ func TestE2E_DietSourceValidation(t *testing.T) {
 		SourceRoot: testSBOMPath, // a file, not a directory
 		Format:     "json",
 	}
-	err = cli.RunDiet(context.Background(), cfg, opts, graphAnalyzer, sourceAnalyzer)
+	err = cli.RunDiet(context.Background(), cfg, opts, graphAnalyzer, sourceAnalyzer, nil)
 	if err == nil {
 		t.Fatal("expected error when --source is a file, got nil")
 	}
@@ -318,7 +318,7 @@ func TestE2E_DietSourceValidation(t *testing.T) {
 
 	// --source pointing to nonexistent path should fail
 	opts.SourceRoot = "/nonexistent/path/that/does/not/exist"
-	err = cli.RunDiet(context.Background(), cfg, opts, graphAnalyzer, sourceAnalyzer)
+	err = cli.RunDiet(context.Background(), cfg, opts, graphAnalyzer, sourceAnalyzer, nil)
 	if err == nil {
 		t.Fatal("expected error when --source does not exist, got nil")
 	}
@@ -388,7 +388,7 @@ func TestE2E_DietStdinSBOM(t *testing.T) {
 
 	graphAnalyzer := depgraph.NewAnalyzer()
 	sourceAnalyzer := treesitter.NewAnalyzer()
-	runErr := cli.RunDiet(context.Background(), cfg, opts, graphAnalyzer, sourceAnalyzer)
+	runErr := cli.RunDiet(context.Background(), cfg, opts, graphAnalyzer, sourceAnalyzer, nil)
 
 	os.Stdout = oldStdout
 	if err := w.Close(); err != nil {

--- a/cmd/uzomuzo-diet/main.go
+++ b/cmd/uzomuzo-diet/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/future-architect/uzomuzo-oss/internal/infrastructure/config"
 	"github.com/future-architect/uzomuzo-oss/internal/infrastructure/depgraph"
 	"github.com/future-architect/uzomuzo-oss/internal/infrastructure/depparser/gomod"
+	"github.com/future-architect/uzomuzo-oss/internal/infrastructure/pypi"
 	"github.com/future-architect/uzomuzo-oss/internal/infrastructure/treesitter"
 	"github.com/future-architect/uzomuzo-oss/internal/interfaces/cli"
 
@@ -72,8 +73,9 @@ func main() {
 
 			graphAnalyzer := depgraph.NewAnalyzer()
 			sourceAnalyzer := treesitter.NewAnalyzer()
+			pypiResolver := pypi.NewClient()
 
-			return cli.RunDiet(ctx, cfg, opts, graphAnalyzer, sourceAnalyzer)
+			return cli.RunDiet(ctx, cfg, opts, graphAnalyzer, sourceAnalyzer, pypiResolver)
 		},
 	}
 

--- a/docs/diet.md
+++ b/docs/diet.md
@@ -141,6 +141,10 @@ Analyzes your source code to measure how deeply each dependency is integrated:
 
 Supported languages: Go, Python, JavaScript/TypeScript, Java.
 
+#### Phase 2.5: Wheel-based PyPI fallback
+
+For Python (PyPI) packages where Phase 2 finds zero import matches, diet automatically downloads the smallest wheel file and extracts actual import names from `top_level.txt`, `RECORD`, or `__init__.py` directory listing. This resolves common PyPI name mismatches (e.g., `beautifulsoup4` imports as `bs4`, `pyyaml` as `yaml`). Wheels larger than 5 MB are skipped.
+
 ### Phase 3: Health Signals (API)
 
 Reuses the existing `uzomuzo scan` infrastructure to fetch:

--- a/internal/application/diet/service.go
+++ b/internal/application/diet/service.go
@@ -28,6 +28,15 @@ type GraphAnalyzer interface {
 	AnalyzeGraph(ctx context.Context, sbomData []byte) (*domaindiet.GraphResult, error)
 }
 
+// PyPIImportResolver resolves Python import names from wheel metadata.
+// This is the fallback used when heuristic import path guessing fails.
+type PyPIImportResolver interface {
+	// ResolveImportNames fetches the actual Python import names for a PyPI
+	// package by downloading and inspecting the smallest wheel file.
+	// Returns nil/empty if resolution fails (graceful degradation).
+	ResolveImportNames(ctx context.Context, packageName string) ([]string, error)
+}
+
 // DietInput contains the inputs for a diet analysis run.
 type DietInput struct {
 	SBOMData   []byte
@@ -42,7 +51,8 @@ type DietInput struct {
 // Service orchestrates the 4-phase diet pipeline.
 type Service struct {
 	graphAnalyzer   GraphAnalyzer
-	sourceAnalyzer  SourceAnalyzer // nil = skip source analysis
+	sourceAnalyzer  SourceAnalyzer     // nil = skip source analysis
+	pypiResolver    PyPIImportResolver // nil = skip wheel fallback
 	analysisService *application.AnalysisService
 }
 
@@ -50,11 +60,13 @@ type Service struct {
 func NewService(
 	graphAnalyzer GraphAnalyzer,
 	sourceAnalyzer SourceAnalyzer,
+	pypiResolver PyPIImportResolver,
 	analysisService *application.AnalysisService,
 ) *Service {
 	return &Service{
 		graphAnalyzer:   graphAnalyzer,
 		sourceAnalyzer:  sourceAnalyzer,
+		pypiResolver:    pypiResolver,
 		analysisService: analysisService,
 	}
 }
@@ -98,6 +110,23 @@ func (s *Service) Run(ctx context.Context, input DietInput) (*domaindiet.DietPla
 				slog.Warn("Phase 2: no imports matched any dependency — verify --source points to the correct directory", "source", input.SourceRoot)
 			} else {
 				slog.Info("Phase 2 complete", "analyzed", len(couplingResults))
+			}
+
+			// Phase 2.5: Wheel-based fallback for PyPI packages with zero matches
+			if s.pypiResolver != nil && couplingResults != nil {
+				retryPaths := s.resolveUnmatchedPyPI(ctx, graphResult.DirectDeps, couplingResults)
+				if len(retryPaths) > 0 {
+					slog.Info("Phase 2.5: Retrying coupling with wheel-resolved import names", "count", len(retryPaths))
+					retryCoupling, retryErr := s.sourceAnalyzer.AnalyzeCoupling(ctx, input.SourceRoot, retryPaths)
+					if retryErr != nil {
+						slog.Warn("Phase 2.5 failed, continuing with heuristic results", "error", retryErr)
+					} else {
+						for purl, ca := range retryCoupling {
+							couplingResults[purl] = ca
+						}
+						slog.Info("Phase 2.5 complete", "resolved", len(retryCoupling))
+					}
+				}
 			}
 		} else {
 			slog.Info("Phase 2: Skipped (no source root provided)")
@@ -473,13 +502,13 @@ var mavenPackageOverrides = map[string][]string{
 
 	// Jackson family: Maven groupId (e.g. com.fasterxml.jackson.core) does not
 	// match the actual Java package name (e.g. com.fasterxml.jackson.annotation).
-	"com.fasterxml.jackson.core/jackson-annotations":          {"com.fasterxml.jackson.annotation"},
-	"com.fasterxml.jackson.core/jackson-databind":             {"com.fasterxml.jackson.databind"},
-	"com.fasterxml.jackson.dataformat/jackson-dataformat-csv": {"com.fasterxml.jackson.dataformat.csv"},
-	"com.fasterxml.jackson.dataformat/jackson-dataformat-xml": {"com.fasterxml.jackson.dataformat.xml"},
+	"com.fasterxml.jackson.core/jackson-annotations":           {"com.fasterxml.jackson.annotation"},
+	"com.fasterxml.jackson.core/jackson-databind":              {"com.fasterxml.jackson.databind"},
+	"com.fasterxml.jackson.dataformat/jackson-dataformat-csv":  {"com.fasterxml.jackson.dataformat.csv"},
+	"com.fasterxml.jackson.dataformat/jackson-dataformat-xml":  {"com.fasterxml.jackson.dataformat.xml"},
 	"com.fasterxml.jackson.dataformat/jackson-dataformat-yaml": {"com.fasterxml.jackson.dataformat.yaml"},
-	"com.fasterxml.jackson.datatype/jackson-datatype-jsr310":  {"com.fasterxml.jackson.datatype.jsr310"},
-	"com.fasterxml.jackson.module/jackson-module-kotlin":      {"com.fasterxml.jackson.module.kotlin"},
+	"com.fasterxml.jackson.datatype/jackson-datatype-jsr310":   {"com.fasterxml.jackson.datatype.jsr310"},
+	"com.fasterxml.jackson.module/jackson-module-kotlin":       {"com.fasterxml.jackson.module.kotlin"},
 
 	// javax.inject: groupId and artifactId both equal "javax.inject", so the
 	// heuristic already produces the correct candidate, but an explicit override
@@ -574,4 +603,34 @@ func isJavaDottedPackageSafe(s string) bool {
 		}
 	}
 	return true
+}
+
+// resolveUnmatchedPyPI identifies PyPI PURLs that had zero coupling matches
+// and attempts to resolve their import names via wheel metadata. Returns
+// a map of PURL → resolved import paths suitable for a retry AnalyzeCoupling call.
+func (s *Service) resolveUnmatchedPyPI(
+	ctx context.Context,
+	directDeps []string,
+	couplingResults map[string]*domaindiet.CouplingAnalysis,
+) map[string][]string {
+	retryPaths := make(map[string][]string)
+	for _, purl := range directDeps {
+		parsed, err := packageurl.FromString(purl)
+		if err != nil || parsed.Type != "pypi" {
+			continue
+		}
+		// Only retry packages that got zero matches from heuristic paths.
+		if _, found := couplingResults[purl]; found {
+			continue
+		}
+		names, resolveErr := s.pypiResolver.ResolveImportNames(ctx, parsed.Name)
+		if resolveErr != nil {
+			slog.Debug("pypi_wheel: resolve failed, skipping", "package", parsed.Name, "error", resolveErr)
+			continue
+		}
+		if len(names) > 0 {
+			retryPaths[purl] = names
+		}
+	}
+	return retryPaths
 }

--- a/internal/application/diet/service.go
+++ b/internal/application/diet/service.go
@@ -116,9 +116,10 @@ func (s *Service) Run(ctx context.Context, input DietInput) (*domaindiet.DietPla
 			}
 
 			// Phase 2.5: Wheel-based fallback for PyPI packages with zero matches.
-			// Skip when couplingResults is nil (Phase 2 error) — no point retrying
-			// if the source analyzer itself failed.
-			if s.pypiResolver != nil && couplingResults != nil {
+			// Gate on couplingErr (not couplingResults) because AnalyzeCoupling
+			// returns (nil, nil) when no imports matched — that nil map is exactly
+			// the scenario the wheel fallback should recover from.
+			if s.pypiResolver != nil && couplingErr == nil {
 				retryPaths := s.resolveUnmatchedPyPI(ctx, graphResult.DirectDeps, couplingResults)
 				if len(retryPaths) > 0 {
 					slog.Info("Phase 2.5: Retrying coupling with wheel-resolved import names", "count", len(retryPaths))
@@ -126,6 +127,9 @@ func (s *Service) Run(ctx context.Context, input DietInput) (*domaindiet.DietPla
 					if retryErr != nil {
 						slog.Warn("Phase 2.5 failed, continuing with heuristic results", "error", retryErr)
 					} else {
+						if couplingResults == nil {
+							couplingResults = make(map[string]*domaindiet.CouplingAnalysis, len(retryCoupling))
+						}
 						for purl, ca := range retryCoupling {
 							couplingResults[purl] = ca
 						}

--- a/internal/application/diet/service.go
+++ b/internal/application/diet/service.go
@@ -112,7 +112,9 @@ func (s *Service) Run(ctx context.Context, input DietInput) (*domaindiet.DietPla
 				slog.Info("Phase 2 complete", "analyzed", len(couplingResults))
 			}
 
-			// Phase 2.5: Wheel-based fallback for PyPI packages with zero matches
+			// Phase 2.5: Wheel-based fallback for PyPI packages with zero matches.
+			// Skip when couplingResults is nil (Phase 2 error) — no point retrying
+			// if the source analyzer itself failed.
 			if s.pypiResolver != nil && couplingResults != nil {
 				retryPaths := s.resolveUnmatchedPyPI(ctx, graphResult.DirectDeps, couplingResults)
 				if len(retryPaths) > 0 {

--- a/internal/application/diet/service.go
+++ b/internal/application/diet/service.go
@@ -123,16 +123,41 @@ func (s *Service) Run(ctx context.Context, input DietInput) (*domaindiet.DietPla
 				retryPaths := s.resolveUnmatchedPyPI(ctx, graphResult.DirectDeps, couplingResults)
 				if len(retryPaths) > 0 {
 					slog.Info("Phase 2.5: Retrying coupling with wheel-resolved import names", "count", len(retryPaths))
-					retryCoupling, retryErr := s.sourceAnalyzer.AnalyzeCoupling(ctx, input.SourceRoot, retryPaths)
+
+					// Build combined importPaths (original heuristic + wheel-resolved)
+					// so AnalyzeCoupling sees the full dependency set and collision
+					// attribution stays consistent with Phase 2.
+					combinedImportPaths := make(map[string][]string, len(importPaths))
+					for purl, paths := range importPaths {
+						copiedPaths := make([]string, len(paths))
+						copy(copiedPaths, paths)
+						combinedImportPaths[purl] = copiedPaths
+					}
+					for purl, paths := range retryPaths {
+						seen := make(map[string]struct{}, len(combinedImportPaths[purl])+len(paths))
+						mergedPaths := make([]string, 0, len(combinedImportPaths[purl])+len(paths))
+						for _, p := range combinedImportPaths[purl] {
+							if _, ok := seen[p]; ok {
+								continue
+							}
+							seen[p] = struct{}{}
+							mergedPaths = append(mergedPaths, p)
+						}
+						for _, p := range paths {
+							if _, ok := seen[p]; ok {
+								continue
+							}
+							seen[p] = struct{}{}
+							mergedPaths = append(mergedPaths, p)
+						}
+						combinedImportPaths[purl] = mergedPaths
+					}
+
+					retryCoupling, retryErr := s.sourceAnalyzer.AnalyzeCoupling(ctx, input.SourceRoot, combinedImportPaths)
 					if retryErr != nil {
 						slog.Warn("Phase 2.5 failed, continuing with heuristic results", "error", retryErr)
 					} else {
-						if couplingResults == nil {
-							couplingResults = make(map[string]*domaindiet.CouplingAnalysis, len(retryCoupling))
-						}
-						for purl, ca := range retryCoupling {
-							couplingResults[purl] = ca
-						}
+						couplingResults = retryCoupling
 						slog.Info("Phase 2.5 complete", "resolved", len(retryCoupling))
 					}
 				}

--- a/internal/application/diet/service.go
+++ b/internal/application/diet/service.go
@@ -33,7 +33,10 @@ type GraphAnalyzer interface {
 type PyPIImportResolver interface {
 	// ResolveImportNames fetches the actual Python import names for a PyPI
 	// package by downloading and inspecting the smallest wheel file.
-	// Returns nil/empty if resolution fails (graceful degradation).
+	// It may return an error if metadata lookup, wheel download, or inspection
+	// fails. Callers should treat such errors as non-fatal fallback failures
+	// (graceful degradation) and continue with heuristic guesses or an empty
+	// result when appropriate.
 	ResolveImportNames(ctx context.Context, packageName string) ([]string, error)
 }
 

--- a/internal/application/diet/service_test.go
+++ b/internal/application/diet/service_test.go
@@ -2,6 +2,7 @@ package diet
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -431,6 +432,7 @@ func TestRun_BasicPipeline(t *testing.T) {
 	svc := NewService(
 		&stubGraphAnalyzer{result: graphResult},
 		&stubSourceAnalyzer{result: sourceResults},
+		nil, // no PyPI resolver for this test
 		nil, // no AnalysisService for this test
 	)
 
@@ -549,7 +551,8 @@ func TestRun_ToolDepsNotFlaggedAsUnused(t *testing.T) {
 	svc := NewService(
 		&stubGraphAnalyzer{result: graphResult},
 		&stubSourceAnalyzer{result: sourceResults},
-		nil,
+		nil, // no PyPI resolver
+		nil, // no AnalysisService
 	)
 
 	plan, err := svc.Run(context.Background(), DietInput{
@@ -605,7 +608,8 @@ func TestRun_NoSourceAnalyzer(t *testing.T) {
 	svc := NewService(
 		&stubGraphAnalyzer{result: graphResult},
 		nil, // no source analyzer
-		nil,
+		nil, // no PyPI resolver
+		nil, // no AnalysisService
 	)
 
 	plan, err := svc.Run(context.Background(), DietInput{
@@ -621,5 +625,184 @@ func TestRun_NoSourceAnalyzer(t *testing.T) {
 	// Without source analyzer, coupling should be zero-value (not unused)
 	if plan.Entries[0].Coupling.IsUnused {
 		t.Error("without source analyzer, coupling should not be marked unused")
+	}
+}
+
+// --- Phase 2.5 wheel fallback tests ---
+
+type stubPyPIResolver struct {
+	names map[string][]string // packageName → import names
+	err   error
+}
+
+func (s *stubPyPIResolver) ResolveImportNames(_ context.Context, name string) ([]string, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.names[name], nil
+}
+
+// retrySourceAnalyzer returns different results on the first vs second call.
+// First call returns firstResult; second call returns secondResult.
+type retrySourceAnalyzer struct {
+	firstResult  map[string]*domaindiet.CouplingAnalysis
+	secondResult map[string]*domaindiet.CouplingAnalysis
+	callCount    int
+}
+
+func (s *retrySourceAnalyzer) AnalyzeCoupling(_ context.Context, _ string, _ map[string][]string) (map[string]*domaindiet.CouplingAnalysis, error) {
+	s.callCount++
+	if s.callCount == 1 {
+		return s.firstResult, nil
+	}
+	return s.secondResult, nil
+}
+
+func TestRun_WheelFallback(t *testing.T) {
+	t.Parallel()
+
+	pypiPURL := "pkg:pypi/beautifulsoup4@4.12.3"
+	goPURL := "pkg:golang/github.com/stretchr/testify@v1.9.0"
+
+	graphResult := &domaindiet.GraphResult{
+		DirectDeps: []string{pypiPURL, goPURL},
+		Metrics: map[string]*domaindiet.GraphMetrics{
+			pypiPURL: {TotalTransitiveCount: 2},
+			goPURL:   {TotalTransitiveCount: 5},
+		},
+		TotalTransitive: 7,
+	}
+
+	// Phase 2: heuristic paths find testify but NOT beautifulsoup4 (it needs "bs4").
+	// Phase 2.5: wheel resolver returns "bs4", retry finds it.
+	sourceAnalyzer := &retrySourceAnalyzer{
+		firstResult: map[string]*domaindiet.CouplingAnalysis{
+			goPURL: {ImportFileCount: 3, CallSiteCount: 5},
+		},
+		secondResult: map[string]*domaindiet.CouplingAnalysis{
+			pypiPURL: {ImportFileCount: 1, CallSiteCount: 2},
+		},
+	}
+
+	resolver := &stubPyPIResolver{
+		names: map[string][]string{
+			"beautifulsoup4": {"bs4"},
+		},
+	}
+
+	svc := NewService(
+		&stubGraphAnalyzer{result: graphResult},
+		sourceAnalyzer,
+		resolver,
+		nil,
+	)
+
+	plan, err := svc.Run(context.Background(), DietInput{
+		SBOMData:   []byte("fake-sbom"),
+		SBOMPath:   "test.sbom.json",
+		SourceRoot: "/tmp/src",
+	})
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+
+	// beautifulsoup4 should NOT be marked unused (resolved via wheel fallback)
+	for _, entry := range plan.Entries {
+		if entry.PURL == pypiPURL {
+			if entry.Coupling.IsUnused {
+				t.Errorf("beautifulsoup4 should not be marked unused after wheel fallback")
+			}
+			if entry.Coupling.ImportFileCount != 1 {
+				t.Errorf("expected ImportFileCount=1, got %d", entry.Coupling.ImportFileCount)
+			}
+			return
+		}
+	}
+	t.Fatal("beautifulsoup4 entry not found in plan")
+}
+
+func TestRun_WheelFallback_NilResolver(t *testing.T) {
+	t.Parallel()
+
+	pypiPURL := "pkg:pypi/beautifulsoup4@4.12.3"
+
+	graphResult := &domaindiet.GraphResult{
+		DirectDeps: []string{pypiPURL},
+		Metrics: map[string]*domaindiet.GraphMetrics{
+			pypiPURL: {TotalTransitiveCount: 2},
+		},
+		TotalTransitive: 2,
+	}
+
+	// Source analyzer finds nothing — beautifulsoup4 unmatched.
+	sourceAnalyzer := &stubSourceAnalyzer{
+		result: map[string]*domaindiet.CouplingAnalysis{},
+	}
+
+	svc := NewService(
+		&stubGraphAnalyzer{result: graphResult},
+		sourceAnalyzer,
+		nil, // no resolver
+		nil,
+	)
+
+	plan, err := svc.Run(context.Background(), DietInput{
+		SBOMData:   []byte("fake-sbom"),
+		SBOMPath:   "test.sbom.json",
+		SourceRoot: "/tmp/src",
+	})
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+
+	for _, entry := range plan.Entries {
+		if entry.PURL == pypiPURL && !entry.Coupling.IsUnused {
+			t.Error("without resolver, beautifulsoup4 should stay unused")
+		}
+	}
+}
+
+func TestRun_WheelFallback_ResolverError(t *testing.T) {
+	t.Parallel()
+
+	pypiPURL := "pkg:pypi/beautifulsoup4@4.12.3"
+
+	graphResult := &domaindiet.GraphResult{
+		DirectDeps: []string{pypiPURL},
+		Metrics: map[string]*domaindiet.GraphMetrics{
+			pypiPURL: {TotalTransitiveCount: 2},
+		},
+		TotalTransitive: 2,
+	}
+
+	sourceAnalyzer := &stubSourceAnalyzer{
+		result: map[string]*domaindiet.CouplingAnalysis{},
+	}
+
+	resolver := &stubPyPIResolver{
+		err: fmt.Errorf("network error"),
+	}
+
+	svc := NewService(
+		&stubGraphAnalyzer{result: graphResult},
+		sourceAnalyzer,
+		resolver,
+		nil,
+	)
+
+	plan, err := svc.Run(context.Background(), DietInput{
+		SBOMData:   []byte("fake-sbom"),
+		SBOMPath:   "test.sbom.json",
+		SourceRoot: "/tmp/src",
+	})
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+
+	// Should gracefully degrade — beautifulsoup4 stays unused
+	for _, entry := range plan.Entries {
+		if entry.PURL == pypiPURL && !entry.Coupling.IsUnused {
+			t.Error("on resolver error, beautifulsoup4 should stay unused")
+		}
 	}
 }

--- a/internal/application/diet/service_test.go
+++ b/internal/application/diet/service_test.go
@@ -722,6 +722,64 @@ func TestRun_WheelFallback(t *testing.T) {
 	t.Fatal("beautifulsoup4 entry not found in plan")
 }
 
+func TestRun_WheelFallback_NilCouplingResults(t *testing.T) {
+	t.Parallel()
+
+	pypiPURL := "pkg:pypi/beautifulsoup4@4.12.3"
+
+	graphResult := &domaindiet.GraphResult{
+		DirectDeps: []string{pypiPURL},
+		Metrics: map[string]*domaindiet.GraphMetrics{
+			pypiPURL: {TotalTransitiveCount: 2},
+		},
+		TotalTransitive: 2,
+	}
+
+	// Phase 2 returns (nil, nil) — zero imports matched any dependency.
+	// Phase 2.5 should still run and merge retry results without panicking.
+	sourceAnalyzer := &retrySourceAnalyzer{
+		firstResult:  nil, // nil map, not empty map
+		secondResult: map[string]*domaindiet.CouplingAnalysis{
+			pypiPURL: {ImportFileCount: 1, CallSiteCount: 2},
+		},
+	}
+
+	resolver := &stubPyPIResolver{
+		names: map[string][]string{
+			"beautifulsoup4": {"bs4"},
+		},
+	}
+
+	svc := NewService(
+		&stubGraphAnalyzer{result: graphResult},
+		sourceAnalyzer,
+		resolver,
+		nil,
+	)
+
+	plan, err := svc.Run(context.Background(), DietInput{
+		SBOMData:   []byte("fake-sbom"),
+		SBOMPath:   "test.sbom.json",
+		SourceRoot: "/tmp/src",
+	})
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+
+	for _, entry := range plan.Entries {
+		if entry.PURL == pypiPURL {
+			if entry.Coupling.IsUnused {
+				t.Errorf("beautifulsoup4 should not be marked unused after wheel fallback with nil initial results")
+			}
+			if entry.Coupling.ImportFileCount != 1 {
+				t.Errorf("expected ImportFileCount=1, got %d", entry.Coupling.ImportFileCount)
+			}
+			return
+		}
+	}
+	t.Fatal("beautifulsoup4 entry not found in plan")
+}
+
 func TestRun_WheelFallback_NilResolver(t *testing.T) {
 	t.Parallel()
 

--- a/internal/application/diet/service_test.go
+++ b/internal/application/diet/service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"sync/atomic"
 	"testing"
 
 	domain "github.com/future-architect/uzomuzo-oss/internal/domain/analysis"
@@ -647,12 +648,12 @@ func (s *stubPyPIResolver) ResolveImportNames(_ context.Context, name string) ([
 type retrySourceAnalyzer struct {
 	firstResult  map[string]*domaindiet.CouplingAnalysis
 	secondResult map[string]*domaindiet.CouplingAnalysis
-	callCount    int
+	callCount    atomic.Int32
 }
 
 func (s *retrySourceAnalyzer) AnalyzeCoupling(_ context.Context, _ string, _ map[string][]string) (map[string]*domaindiet.CouplingAnalysis, error) {
-	s.callCount++
-	if s.callCount == 1 {
+	n := s.callCount.Add(1)
+	if n == 1 {
 		return s.firstResult, nil
 	}
 	return s.secondResult, nil
@@ -755,10 +756,17 @@ func TestRun_WheelFallback_NilResolver(t *testing.T) {
 		t.Fatalf("Run() error: %v", err)
 	}
 
+	found := false
 	for _, entry := range plan.Entries {
-		if entry.PURL == pypiPURL && !entry.Coupling.IsUnused {
-			t.Error("without resolver, beautifulsoup4 should stay unused")
+		if entry.PURL == pypiPURL {
+			found = true
+			if !entry.Coupling.IsUnused {
+				t.Error("without resolver, beautifulsoup4 should stay unused")
+			}
 		}
+	}
+	if !found {
+		t.Fatal("beautifulsoup4 entry not found in plan")
 	}
 }
 
@@ -800,9 +808,16 @@ func TestRun_WheelFallback_ResolverError(t *testing.T) {
 	}
 
 	// Should gracefully degrade — beautifulsoup4 stays unused
+	found := false
 	for _, entry := range plan.Entries {
-		if entry.PURL == pypiPURL && !entry.Coupling.IsUnused {
-			t.Error("on resolver error, beautifulsoup4 should stay unused")
+		if entry.PURL == pypiPURL {
+			found = true
+			if !entry.Coupling.IsUnused {
+				t.Error("on resolver error, beautifulsoup4 should stay unused")
+			}
 		}
+	}
+	if !found {
+		t.Fatal("beautifulsoup4 entry not found in plan")
 	}
 }

--- a/internal/infrastructure/pypi/client.go
+++ b/internal/infrastructure/pypi/client.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/url"
@@ -161,7 +162,7 @@ func (c *Client) GetProject(ctx context.Context, name string) (*ProjectInfo, boo
 			HomePage    string            `json:"home_page"`
 		} `json:"info"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxJSONResponseSize)).Decode(&raw); err != nil {
 		return nil, false, fmt.Errorf("pypi decode failed: %w", err)
 	}
 	info := &ProjectInfo{

--- a/internal/infrastructure/pypi/client.go
+++ b/internal/infrastructure/pypi/client.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -133,7 +134,7 @@ func (c *Client) GetProject(ctx context.Context, name string) (*ProjectInfo, boo
 		slog.Debug("pypi: cache hit", "name", lower)
 		return info, true, nil
 	}
-	apiURL := fmt.Sprintf("%s/pypi/%s/json", c.resolvedBaseURL(), n)
+	apiURL := fmt.Sprintf("%s/pypi/%s/json", c.resolvedBaseURL(), url.PathEscape(n))
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
 	if err != nil {
 		return nil, false, fmt.Errorf("pypi request build failed: %w", err)

--- a/internal/infrastructure/pypi/client.go
+++ b/internal/infrastructure/pypi/client.go
@@ -28,6 +28,8 @@ type Client struct {
 	mu    sync.RWMutex
 	cache map[string]cacheEntry
 	ttl   time.Duration
+
+	importCacheFields // wheel-based import name cache (lazily initialised)
 }
 
 type cacheEntry struct {

--- a/internal/infrastructure/pypi/client.go
+++ b/internal/infrastructure/pypi/client.go
@@ -20,6 +20,9 @@ import (
 	"github.com/future-architect/uzomuzo-oss/internal/infrastructure/httpclient"
 )
 
+// pypiUserAgent is the User-Agent sent on all PyPI HTTP requests.
+const pypiUserAgent = "uzomuzo-pypi-client/1.0 (+https://github.com/future-architect/uzomuzo-oss)"
+
 // Client fetches PyPI project JSON metadata.
 type Client struct {
 	http    *httpclient.Client
@@ -75,6 +78,14 @@ func (c *Client) SetBaseURL(u string) { c.baseURL = strings.TrimRight(u, "/") }
 // SetCacheTTL sets the in-memory cache TTL (<=0 disables caching).
 func (c *Client) SetCacheTTL(d time.Duration) { c.ttl = d }
 
+// resolvedBaseURL returns the configured base URL or the default.
+func (c *Client) resolvedBaseURL() string {
+	if c.baseURL != "" {
+		return c.baseURL
+	}
+	return "https://pypi.org"
+}
+
 func (c *Client) getCached(name string) (*ProjectInfo, bool) {
 	if c.ttl <= 0 {
 		return nil, false
@@ -122,16 +133,12 @@ func (c *Client) GetProject(ctx context.Context, name string) (*ProjectInfo, boo
 		slog.Debug("pypi: cache hit", "name", lower)
 		return info, true, nil
 	}
-	base := c.baseURL
-	if base == "" {
-		base = "https://pypi.org"
-	}
-	url := fmt.Sprintf("%s/pypi/%s/json", base, n)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	apiURL := fmt.Sprintf("%s/pypi/%s/json", c.resolvedBaseURL(), n)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
 	if err != nil {
 		return nil, false, fmt.Errorf("pypi request build failed: %w", err)
 	}
-	req.Header.Set("User-Agent", "uzomuzo-pypi-client/1.0 (+https://github.com/future-architect/uzomuzo-oss)")
+	req.Header.Set("User-Agent", pypiUserAgent)
 	resp, err := c.http.Do(ctx, req)
 	if err != nil {
 		return nil, false, fmt.Errorf("pypi http failed: %w", err)

--- a/internal/infrastructure/pypi/wheel.go
+++ b/internal/infrastructure/pypi/wheel.go
@@ -34,6 +34,9 @@ const maxWheelSize = 5 << 20
 // gigabytes of data.
 const maxEntrySize = 1 << 20
 
+// maxJSONResponseSize caps the PyPI JSON API response body (10 MB).
+const maxJSONResponseSize = 10 << 20
+
 // importNameCacheEntry stores resolved import names with a timestamp for TTL.
 type importNameCacheEntry struct {
 	names []string
@@ -156,8 +159,7 @@ func (c *Client) selectSmallestWheel(ctx context.Context, packageName string) (s
 	var raw struct {
 		URLs []wheelURL `json:"urls"`
 	}
-	// Cap the JSON response to 10 MB to prevent memory exhaustion.
-	if err := json.NewDecoder(io.LimitReader(resp.Body, 10<<20)).Decode(&raw); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxJSONResponseSize)).Decode(&raw); err != nil {
 		return "", fmt.Errorf("decode failed: %w", err)
 	}
 

--- a/internal/infrastructure/pypi/wheel.go
+++ b/internal/infrastructure/pypi/wheel.go
@@ -156,7 +156,8 @@ func (c *Client) selectSmallestWheel(ctx context.Context, packageName string) (s
 	var raw struct {
 		URLs []wheelURL `json:"urls"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+	// Cap the JSON response to 10 MB to prevent memory exhaustion.
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 10<<20)).Decode(&raw); err != nil {
 		return "", fmt.Errorf("decode failed: %w", err)
 	}
 
@@ -187,6 +188,10 @@ func (c *Client) selectSmallestWheel(ctx context.Context, packageName string) (s
 
 // downloadWheel fetches the wheel file content, capped at maxWheelSize.
 func (c *Client) downloadWheel(ctx context.Context, dlURL string) ([]byte, error) {
+	parsed, err := url.Parse(dlURL)
+	if err != nil || (parsed.Scheme != "https" && parsed.Scheme != "http") {
+		return nil, fmt.Errorf("invalid wheel URL scheme: %s", dlURL)
+	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, dlURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("build request: %w", err)

--- a/internal/infrastructure/pypi/wheel.go
+++ b/internal/infrastructure/pypi/wheel.go
@@ -12,6 +12,7 @@ import (
 	"archive/zip"
 	"bytes"
 	"context"
+	"encoding/csv"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -194,8 +195,8 @@ func (c *Client) selectSmallestWheel(ctx context.Context, packageName string) (s
 // downloadWheel fetches the wheel file content, capped at maxWheelSize.
 func (c *Client) downloadWheel(ctx context.Context, dlURL string) ([]byte, error) {
 	parsed, err := url.Parse(dlURL)
-	if err != nil || (parsed.Scheme != "https" && parsed.Scheme != "http") {
-		return nil, fmt.Errorf("invalid wheel URL scheme: %s", dlURL)
+	if err != nil || (parsed.Scheme != "https" && parsed.Scheme != "http") || parsed.Host == "" {
+		return nil, fmt.Errorf("invalid wheel URL: %s", dlURL)
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, dlURL, nil)
 	if err != nil {
@@ -314,14 +315,20 @@ func parseRECORD(r *zip.Reader) []string {
 		}
 
 		pkgDirs := make(map[string]struct{})
-		for _, line := range strings.Split(string(data), "\n") {
-			line = strings.TrimSpace(line)
-			if line == "" {
+		csvReader := csv.NewReader(bytes.NewReader(data))
+		csvReader.FieldsPerRecord = -1 // variable field count
+		for {
+			record, csvErr := csvReader.Read()
+			if csvErr != nil {
+				break
+			}
+			if len(record) == 0 {
 				continue
 			}
-			// RECORD format: path,hash,size — extract the path field only.
-			fields := strings.SplitN(line, ",", 2)
-			recPath := fields[0]
+			recPath := strings.TrimSpace(record[0])
+			if recPath == "" {
+				continue
+			}
 
 			parts := strings.SplitN(recPath, "/", 2)
 			if len(parts) < 2 {

--- a/internal/infrastructure/pypi/wheel.go
+++ b/internal/infrastructure/pypi/wheel.go
@@ -17,6 +17,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"path"
 	"sort"
 	"strings"
@@ -27,6 +28,11 @@ import (
 // maxWheelSize is the maximum wheel file size we are willing to download (5 MB).
 // Wheels larger than this are skipped to avoid excessive network and memory usage.
 const maxWheelSize = 5 << 20
+
+// maxEntrySize caps the decompressed size of a single ZIP entry (1 MB).
+// This prevents zip-bomb attacks where a tiny compressed entry expands to
+// gigabytes of data.
+const maxEntrySize = 1 << 20
 
 // importNameCacheEntry stores resolved import names with a timestamp for TTL.
 type importNameCacheEntry struct {
@@ -126,16 +132,12 @@ func (c *Client) ResolveImportNames(ctx context.Context, packageName string) ([]
 // selectSmallestWheel fetches the PyPI JSON API and returns the URL of the
 // smallest bdist_wheel distribution that fits within maxWheelSize.
 func (c *Client) selectSmallestWheel(ctx context.Context, packageName string) (string, error) {
-	base := c.baseURL
-	if base == "" {
-		base = "https://pypi.org"
-	}
-	apiURL := fmt.Sprintf("%s/pypi/%s/json", base, packageName)
+	apiURL := fmt.Sprintf("%s/pypi/%s/json", c.resolvedBaseURL(), url.PathEscape(packageName))
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
 	if err != nil {
 		return "", fmt.Errorf("build request: %w", err)
 	}
-	req.Header.Set("User-Agent", "uzomuzo-pypi-client/1.0 (+https://github.com/future-architect/uzomuzo-oss)")
+	req.Header.Set("User-Agent", pypiUserAgent)
 
 	resp, err := c.http.Do(ctx, req)
 	if err != nil {
@@ -144,6 +146,7 @@ func (c *Client) selectSmallestWheel(ctx context.Context, packageName string) (s
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode == http.StatusNotFound {
+		slog.Debug("pypi_wheel: package not found on PyPI", "package", packageName)
 		return "", nil
 	}
 	if resp.StatusCode != http.StatusOK {
@@ -163,7 +166,10 @@ func (c *Client) selectSmallestWheel(ctx context.Context, packageName string) (s
 		if u.PackageType != "bdist_wheel" {
 			continue
 		}
-		if u.Size > maxWheelSize {
+		if u.Size <= 0 || u.Size > maxWheelSize {
+			continue
+		}
+		if u.URL == "" {
 			continue
 		}
 		candidates = append(candidates, u)
@@ -180,12 +186,12 @@ func (c *Client) selectSmallestWheel(ctx context.Context, packageName string) (s
 }
 
 // downloadWheel fetches the wheel file content, capped at maxWheelSize.
-func (c *Client) downloadWheel(ctx context.Context, wheelURL string) ([]byte, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, wheelURL, nil)
+func (c *Client) downloadWheel(ctx context.Context, dlURL string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, dlURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("build request: %w", err)
 	}
-	req.Header.Set("User-Agent", "uzomuzo-pypi-client/1.0 (+https://github.com/future-architect/uzomuzo-oss)")
+	req.Header.Set("User-Agent", pypiUserAgent)
 
 	resp, err := c.http.Do(ctx, req)
 	if err != nil {
@@ -249,7 +255,7 @@ func parseTopLevelTxt(r *zip.Reader) []string {
 		if err != nil {
 			continue
 		}
-		data, err := io.ReadAll(rc)
+		data, err := io.ReadAll(io.LimitReader(rc, maxEntrySize))
 		_ = rc.Close()
 		if err != nil {
 			continue
@@ -277,7 +283,7 @@ func parseTopLevelTxt(r *zip.Reader) []string {
 
 // parseRECORD extracts top-level package directories from a RECORD file
 // inside .dist-info. Each line is "path,hash,size". We look for entries
-// whose first path component contains __init__.py.
+// whose first path component contains __init__.py at depth 1 only.
 func parseRECORD(r *zip.Reader) []string {
 	for _, f := range r.File {
 		dir, base := path.Split(f.Name)
@@ -291,7 +297,7 @@ func parseRECORD(r *zip.Reader) []string {
 		if err != nil {
 			continue
 		}
-		data, err := io.ReadAll(rc)
+		data, err := io.ReadAll(io.LimitReader(rc, maxEntrySize))
 		_ = rc.Close()
 		if err != nil {
 			continue
@@ -303,7 +309,7 @@ func parseRECORD(r *zip.Reader) []string {
 			if line == "" {
 				continue
 			}
-			// RECORD format: path,hash,size
+			// RECORD format: path,hash,size — extract the path field only.
 			fields := strings.SplitN(line, ",", 2)
 			recPath := fields[0]
 
@@ -318,8 +324,8 @@ func parseRECORD(r *zip.Reader) []string {
 			if strings.HasSuffix(topDir, ".dist-info") || strings.HasSuffix(topDir, ".data") {
 				continue
 			}
-			// Only include directories that have __init__.py
-			if rest == "__init__.py" || strings.HasPrefix(rest, "__init__.py,") {
+			// Only include top-level directories that have __init__.py (depth 1).
+			if rest == "__init__.py" {
 				if isPyIdentifierSafe(topDir) {
 					pkgDirs[topDir] = struct{}{}
 				}

--- a/internal/infrastructure/pypi/wheel.go
+++ b/internal/infrastructure/pypi/wheel.go
@@ -266,9 +266,12 @@ func parseTopLevelTxt(r *zip.Reader) []string {
 		if err != nil {
 			continue
 		}
-		data, err := io.ReadAll(io.LimitReader(rc, maxEntrySize))
+		data, err := io.ReadAll(io.LimitReader(rc, maxEntrySize+1))
 		_ = rc.Close()
 		if err != nil {
+			continue
+		}
+		if int64(len(data)) > maxEntrySize {
 			continue
 		}
 		var names []string
@@ -308,9 +311,12 @@ func parseRECORD(r *zip.Reader) []string {
 		if err != nil {
 			continue
 		}
-		data, err := io.ReadAll(io.LimitReader(rc, maxEntrySize))
+		data, err := io.ReadAll(io.LimitReader(rc, maxEntrySize+1))
 		_ = rc.Close()
 		if err != nil {
+			continue
+		}
+		if int64(len(data)) > maxEntrySize {
 			continue
 		}
 

--- a/internal/infrastructure/pypi/wheel.go
+++ b/internal/infrastructure/pypi/wheel.go
@@ -91,9 +91,12 @@ type wheelURL struct {
 }
 
 // ResolveImportNames fetches the actual Python import module names for a PyPI
-// package by downloading and inspecting the smallest wheel file. Returns nil
-// if resolution fails (graceful degradation — the caller should fall back to
-// heuristic names).
+// package by downloading and inspecting the smallest wheel file.
+//
+// It returns nil, nil when the package name is empty or when no suitable wheel
+// can be used to resolve import names. It may return a non-nil error for wheel
+// lookup or download failures; callers should treat those as non-fatal fallback
+// failures and fall back to heuristic names.
 func (c *Client) ResolveImportNames(ctx context.Context, packageName string) ([]string, error) {
 	n := strings.TrimSpace(packageName)
 	if n == "" {

--- a/internal/infrastructure/pypi/wheel.go
+++ b/internal/infrastructure/pypi/wheel.go
@@ -1,0 +1,402 @@
+package pypi
+
+// Wheel-based import name resolution for PyPI packages.
+//
+// DDD Layer: Infrastructure
+// Responsibility: Download the smallest wheel for a PyPI package and extract
+// the actual Python import module names from its metadata (top_level.txt,
+// RECORD, or directory listing). This is a last-resort fallback used when
+// heuristic name guessing produces zero coupling matches.
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"path"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+// maxWheelSize is the maximum wheel file size we are willing to download (5 MB).
+// Wheels larger than this are skipped to avoid excessive network and memory usage.
+const maxWheelSize = 5 << 20
+
+// importNameCacheEntry stores resolved import names with a timestamp for TTL.
+type importNameCacheEntry struct {
+	names []string
+	ts    time.Time
+}
+
+// importNameCache is the mutex and map for import name caching on Client.
+// These fields are added to Client via composition below.
+
+// initImportCache lazily initialises the import name cache.
+func (c *Client) initImportCache() {
+	c.importOnce.Do(func() {
+		c.importCache = make(map[string]importNameCacheEntry)
+	})
+}
+
+// getImportCached returns cached import names if the TTL has not expired.
+func (c *Client) getImportCached(name string) ([]string, bool) {
+	if c.ttl <= 0 {
+		return nil, false
+	}
+	c.initImportCache()
+	c.importMu.RLock()
+	ent, ok := c.importCache[name]
+	c.importMu.RUnlock()
+	if !ok {
+		return nil, false
+	}
+	if time.Since(ent.ts) > c.ttl {
+		return nil, false
+	}
+	return ent.names, true
+}
+
+// setImportCache stores resolved import names in the cache.
+func (c *Client) setImportCache(name string, names []string) {
+	if c.ttl <= 0 {
+		return
+	}
+	c.initImportCache()
+	c.importMu.Lock()
+	c.importCache[name] = importNameCacheEntry{names: names, ts: time.Now()}
+	c.importMu.Unlock()
+}
+
+// wheelURL describes a single distribution file from the PyPI JSON API urls array.
+type wheelURL struct {
+	Filename    string `json:"filename"`
+	PackageType string `json:"packagetype"`
+	Size        int64  `json:"size"`
+	URL         string `json:"url"`
+}
+
+// ResolveImportNames fetches the actual Python import module names for a PyPI
+// package by downloading and inspecting the smallest wheel file. Returns nil
+// if resolution fails (graceful degradation — the caller should fall back to
+// heuristic names).
+func (c *Client) ResolveImportNames(ctx context.Context, packageName string) ([]string, error) {
+	n := strings.TrimSpace(packageName)
+	if n == "" {
+		return nil, nil
+	}
+	lower := strings.ToLower(n)
+
+	// Check cache first.
+	if names, ok := c.getImportCached(lower); ok {
+		slog.Debug("pypi_wheel: import name cache hit", "package", lower)
+		return names, nil
+	}
+
+	// Fetch the wheel URL.
+	wURL, err := c.selectSmallestWheel(ctx, n)
+	if err != nil {
+		return nil, fmt.Errorf("pypi wheel URL lookup failed for %s: %w", n, err)
+	}
+	if wURL == "" {
+		slog.Debug("pypi_wheel: no suitable wheel found", "package", n)
+		c.setImportCache(lower, nil) // cache negative result
+		return nil, nil
+	}
+
+	// Download the wheel.
+	wheelData, err := c.downloadWheel(ctx, wURL)
+	if err != nil {
+		return nil, fmt.Errorf("pypi wheel download failed for %s: %w", n, err)
+	}
+
+	// Extract import names from the ZIP.
+	names := extractImportNamesFromWheel(wheelData)
+	slog.Debug("pypi_wheel: resolved import names", "package", n, "names", names)
+
+	c.setImportCache(lower, names)
+	return names, nil
+}
+
+// selectSmallestWheel fetches the PyPI JSON API and returns the URL of the
+// smallest bdist_wheel distribution that fits within maxWheelSize.
+func (c *Client) selectSmallestWheel(ctx context.Context, packageName string) (string, error) {
+	base := c.baseURL
+	if base == "" {
+		base = "https://pypi.org"
+	}
+	apiURL := fmt.Sprintf("%s/pypi/%s/json", base, packageName)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("User-Agent", "uzomuzo-pypi-client/1.0 (+https://github.com/future-architect/uzomuzo-oss)")
+
+	resp, err := c.http.Do(ctx, req)
+	if err != nil {
+		return "", fmt.Errorf("http failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return "", nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("http status %d", resp.StatusCode)
+	}
+
+	var raw struct {
+		URLs []wheelURL `json:"urls"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+		return "", fmt.Errorf("decode failed: %w", err)
+	}
+
+	// Filter to wheels only, respecting size limit.
+	var candidates []wheelURL
+	for _, u := range raw.URLs {
+		if u.PackageType != "bdist_wheel" {
+			continue
+		}
+		if u.Size > maxWheelSize {
+			continue
+		}
+		candidates = append(candidates, u)
+	}
+	if len(candidates) == 0 {
+		return "", nil
+	}
+
+	// Pick the smallest.
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].Size < candidates[j].Size
+	})
+	return candidates[0].URL, nil
+}
+
+// downloadWheel fetches the wheel file content, capped at maxWheelSize.
+func (c *Client) downloadWheel(ctx context.Context, wheelURL string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, wheelURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("User-Agent", "uzomuzo-pypi-client/1.0 (+https://github.com/future-architect/uzomuzo-oss)")
+
+	resp, err := c.http.Do(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("http failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("http status %d", resp.StatusCode)
+	}
+
+	// Read with a safety cap to prevent memory exhaustion.
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxWheelSize+1))
+	if err != nil {
+		return nil, fmt.Errorf("read body: %w", err)
+	}
+	if int64(len(data)) > maxWheelSize {
+		return nil, fmt.Errorf("wheel exceeds %d bytes", maxWheelSize)
+	}
+	return data, nil
+}
+
+// extractImportNamesFromWheel parses a wheel ZIP and extracts Python import
+// module names. Resolution priority:
+//  1. top_level.txt in .dist-info
+//  2. RECORD in .dist-info
+//  3. Directory listing (__init__.py at top level)
+func extractImportNamesFromWheel(data []byte) []string {
+	r, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		slog.Debug("pypi_wheel: invalid zip", "error", err)
+		return nil
+	}
+
+	// 1. Try top_level.txt
+	if names := parseTopLevelTxt(r); len(names) > 0 {
+		return names
+	}
+
+	// 2. Try RECORD
+	if names := parseRECORD(r); len(names) > 0 {
+		return names
+	}
+
+	// 3. Fallback: directories containing __init__.py at depth 1
+	return parseInitPyDirs(r)
+}
+
+// parseTopLevelTxt looks for a top_level.txt file inside any .dist-info
+// directory and extracts one module name per line.
+func parseTopLevelTxt(r *zip.Reader) []string {
+	for _, f := range r.File {
+		dir, base := path.Split(f.Name)
+		if base != "top_level.txt" {
+			continue
+		}
+		if !strings.HasSuffix(dir, ".dist-info/") {
+			continue
+		}
+		rc, err := f.Open()
+		if err != nil {
+			continue
+		}
+		data, err := io.ReadAll(rc)
+		_ = rc.Close()
+		if err != nil {
+			continue
+		}
+		var names []string
+		seen := make(map[string]struct{})
+		for _, line := range strings.Split(string(data), "\n") {
+			name := strings.TrimSpace(line)
+			if name == "" {
+				continue
+			}
+			if !isPyIdentifierSafe(name) {
+				continue
+			}
+			if _, ok := seen[name]; ok {
+				continue
+			}
+			seen[name] = struct{}{}
+			names = append(names, name)
+		}
+		return names
+	}
+	return nil
+}
+
+// parseRECORD extracts top-level package directories from a RECORD file
+// inside .dist-info. Each line is "path,hash,size". We look for entries
+// whose first path component contains __init__.py.
+func parseRECORD(r *zip.Reader) []string {
+	for _, f := range r.File {
+		dir, base := path.Split(f.Name)
+		if base != "RECORD" {
+			continue
+		}
+		if !strings.HasSuffix(dir, ".dist-info/") {
+			continue
+		}
+		rc, err := f.Open()
+		if err != nil {
+			continue
+		}
+		data, err := io.ReadAll(rc)
+		_ = rc.Close()
+		if err != nil {
+			continue
+		}
+
+		pkgDirs := make(map[string]struct{})
+		for _, line := range strings.Split(string(data), "\n") {
+			line = strings.TrimSpace(line)
+			if line == "" {
+				continue
+			}
+			// RECORD format: path,hash,size
+			fields := strings.SplitN(line, ",", 2)
+			recPath := fields[0]
+
+			parts := strings.SplitN(recPath, "/", 2)
+			if len(parts) < 2 {
+				continue
+			}
+			topDir := parts[0]
+			rest := parts[1]
+
+			// Skip dist-info/data directories
+			if strings.HasSuffix(topDir, ".dist-info") || strings.HasSuffix(topDir, ".data") {
+				continue
+			}
+			// Only include directories that have __init__.py
+			if rest == "__init__.py" || strings.HasPrefix(rest, "__init__.py,") {
+				if isPyIdentifierSafe(topDir) {
+					pkgDirs[topDir] = struct{}{}
+				}
+			}
+		}
+
+		if len(pkgDirs) == 0 {
+			return nil
+		}
+		names := make([]string, 0, len(pkgDirs))
+		for d := range pkgDirs {
+			names = append(names, d)
+		}
+		sort.Strings(names) // deterministic output
+		return names
+	}
+	return nil
+}
+
+// parseInitPyDirs scans the ZIP for directories at depth 1 that contain
+// __init__.py (the classic Python package indicator).
+func parseInitPyDirs(r *zip.Reader) []string {
+	dirs := make(map[string]struct{})
+	for _, f := range r.File {
+		parts := strings.SplitN(f.Name, "/", 3)
+		if len(parts) < 2 {
+			continue
+		}
+		topDir := parts[0]
+		rest := parts[1]
+
+		// Skip metadata directories
+		if strings.HasSuffix(topDir, ".dist-info") || strings.HasSuffix(topDir, ".data") {
+			continue
+		}
+		if strings.HasPrefix(topDir, "_") {
+			continue
+		}
+		if rest == "__init__.py" {
+			if isPyIdentifierSafe(topDir) {
+				dirs[topDir] = struct{}{}
+			}
+		}
+	}
+	if len(dirs) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(dirs))
+	for d := range dirs {
+		names = append(names, d)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// isPyIdentifierSafe reports whether s is a valid Python identifier segment.
+// Duplicated from application/diet/service.go to avoid cross-layer import.
+func isPyIdentifierSafe(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i, r := range s {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || r == '_' {
+			continue
+		}
+		if i > 0 && r >= '0' && r <= '9' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+// importCacheFields groups the fields added to Client for import name caching.
+// They are initialised lazily via initImportCache.
+type importCacheFields struct {
+	importOnce  sync.Once
+	importMu    sync.RWMutex
+	importCache map[string]importNameCacheEntry
+}

--- a/internal/infrastructure/pypi/wheel.go
+++ b/internal/infrastructure/pypi/wheel.go
@@ -322,6 +322,13 @@ func parseRECORD(r *zip.Reader) []string {
 
 			parts := strings.SplitN(recPath, "/", 2)
 			if len(parts) < 2 {
+				// Root-level .py module (e.g., "six.py", "certifi.py").
+				if strings.HasSuffix(recPath, ".py") {
+					stem := strings.TrimSuffix(recPath, ".py")
+					if isPyIdentifierSafe(stem) && !strings.HasPrefix(stem, "_") {
+						pkgDirs[stem] = struct{}{}
+					}
+				}
 				continue
 			}
 			topDir := parts[0]
@@ -331,7 +338,7 @@ func parseRECORD(r *zip.Reader) []string {
 			if strings.HasSuffix(topDir, ".dist-info") || strings.HasSuffix(topDir, ".data") {
 				continue
 			}
-			// Only include top-level directories that have __init__.py (depth 1).
+			// Top-level directories with __init__.py (depth 1).
 			if rest == "__init__.py" {
 				if isPyIdentifierSafe(topDir) {
 					pkgDirs[topDir] = struct{}{}

--- a/internal/infrastructure/pypi/wheel_test.go
+++ b/internal/infrastructure/pypi/wheel_test.go
@@ -81,6 +81,20 @@ func TestExtractImportNamesFromWheel_RECORD(t *testing.T) {
 	}
 }
 
+func TestExtractImportNamesFromWheel_RECORD_RootLevelModule(t *testing.T) {
+	t.Parallel()
+	// Wheels like "six" expose a single root-level .py file, not a package dir.
+	wheel := buildTestWheel(t, map[string]string{
+		"six.py": "",
+		"six-1.16.0.dist-info/RECORD": "six.py,sha256=abc,100\n" +
+			"six-1.16.0.dist-info/METADATA,,\n",
+	})
+	names := extractImportNamesFromWheel(wheel)
+	if len(names) != 1 || names[0] != "six" {
+		t.Fatalf("expected [six], got %v", names)
+	}
+}
+
 func TestExtractImportNamesFromWheel_InitPyFallback(t *testing.T) {
 	t.Parallel()
 	// No top_level.txt, no RECORD — only directory structure

--- a/internal/infrastructure/pypi/wheel_test.go
+++ b/internal/infrastructure/pypi/wheel_test.go
@@ -54,12 +54,15 @@ func TestExtractImportNamesFromWheel_TopLevelTxt_Multiple(t *testing.T) {
 		"_yaml/__init__.py":               "",
 	})
 	names := extractImportNamesFromWheel(wheel)
-	// _yaml starts with underscore but isPyIdentifierSafe allows it
-	if len(names) != 2 {
-		t.Fatalf("expected 2 names, got %v", names)
+	// top_level.txt preserves order, so names follow file order: yaml, _yaml
+	want := []string{"yaml", "_yaml"}
+	if len(names) != len(want) {
+		t.Fatalf("expected %v, got %v", want, names)
 	}
-	if names[0] != "yaml" && names[1] != "yaml" {
-		t.Fatalf("expected yaml in result, got %v", names)
+	for i, w := range want {
+		if names[i] != w {
+			t.Fatalf("names[%d] = %q, want %q (full: %v)", i, names[i], w, names)
+		}
 	}
 }
 
@@ -145,7 +148,7 @@ func TestResolveImportNames_Integration(t *testing.T) {
 						"filename":    "beautifulsoup4-4.12.3.tar.gz",
 						"packagetype": "sdist",
 						"size":        500000,
-						"url":         fmt.Sprintf("%s/files/beautifulsoup4-4.12.3.tar.gz", r.Host),
+						"url":         fmt.Sprintf("http://%s/files/beautifulsoup4-4.12.3.tar.gz", r.Host),
 					},
 					{
 						"filename":    "beautifulsoup4-4.12.3-py3-none-any.whl",

--- a/internal/infrastructure/pypi/wheel_test.go
+++ b/internal/infrastructure/pypi/wheel_test.go
@@ -1,0 +1,349 @@
+package pypi
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// buildTestWheel creates an in-memory ZIP (wheel) with the given file entries.
+func buildTestWheel(t *testing.T, files map[string]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	w := zip.NewWriter(&buf)
+	for name, content := range files {
+		f, err := w.Create(name)
+		if err != nil {
+			t.Fatalf("zip.Create(%q): %v", name, err)
+		}
+		if _, err := f.Write([]byte(content)); err != nil {
+			t.Fatalf("zip.Write(%q): %v", name, err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("zip.Close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func TestExtractImportNamesFromWheel_TopLevelTxt(t *testing.T) {
+	t.Parallel()
+	wheel := buildTestWheel(t, map[string]string{
+		"bs4/__init__.py":                               "",
+		"beautifulsoup4-4.12.3.dist-info/METADATA":      "Name: beautifulsoup4",
+		"beautifulsoup4-4.12.3.dist-info/top_level.txt": "bs4\n",
+	})
+	names := extractImportNamesFromWheel(wheel)
+	if len(names) != 1 || names[0] != "bs4" {
+		t.Fatalf("expected [bs4], got %v", names)
+	}
+}
+
+func TestExtractImportNamesFromWheel_TopLevelTxt_Multiple(t *testing.T) {
+	t.Parallel()
+	wheel := buildTestWheel(t, map[string]string{
+		"pkg-1.0.dist-info/top_level.txt": "yaml\n_yaml\n",
+		"yaml/__init__.py":                "",
+		"_yaml/__init__.py":               "",
+	})
+	names := extractImportNamesFromWheel(wheel)
+	// _yaml starts with underscore but isPyIdentifierSafe allows it
+	if len(names) != 2 {
+		t.Fatalf("expected 2 names, got %v", names)
+	}
+	if names[0] != "yaml" && names[1] != "yaml" {
+		t.Fatalf("expected yaml in result, got %v", names)
+	}
+}
+
+func TestExtractImportNamesFromWheel_RECORD(t *testing.T) {
+	t.Parallel()
+	wheel := buildTestWheel(t, map[string]string{
+		"mypkg/__init__.py": "",
+		"mypkg/core.py":     "",
+		"mypkg-1.0.dist-info/RECORD": "mypkg/__init__.py,sha256=abc,0\n" +
+			"mypkg/core.py,sha256=def,100\n" +
+			"mypkg-1.0.dist-info/METADATA,,\n",
+	})
+	names := extractImportNamesFromWheel(wheel)
+	if len(names) != 1 || names[0] != "mypkg" {
+		t.Fatalf("expected [mypkg], got %v", names)
+	}
+}
+
+func TestExtractImportNamesFromWheel_InitPyFallback(t *testing.T) {
+	t.Parallel()
+	// No top_level.txt, no RECORD — only directory structure
+	wheel := buildTestWheel(t, map[string]string{
+		"airthings/__init__.py":               "",
+		"airthings/cloud.py":                  "",
+		"airthings_cloud-1.0.dist-info/WHEEL": "Wheel-Version: 1.0",
+	})
+	names := extractImportNamesFromWheel(wheel)
+	if len(names) != 1 || names[0] != "airthings" {
+		t.Fatalf("expected [airthings], got %v", names)
+	}
+}
+
+func TestExtractImportNamesFromWheel_Empty(t *testing.T) {
+	t.Parallel()
+	// Only metadata, no Python packages
+	wheel := buildTestWheel(t, map[string]string{
+		"pkg-1.0.dist-info/METADATA": "Name: pkg",
+		"pkg-1.0.dist-info/WHEEL":    "Wheel-Version: 1.0",
+	})
+	names := extractImportNamesFromWheel(wheel)
+	if len(names) != 0 {
+		t.Fatalf("expected empty, got %v", names)
+	}
+}
+
+func TestExtractImportNamesFromWheel_InvalidZip(t *testing.T) {
+	t.Parallel()
+	names := extractImportNamesFromWheel([]byte("not a zip"))
+	if names != nil {
+		t.Fatalf("expected nil for invalid zip, got %v", names)
+	}
+}
+
+func TestExtractImportNamesFromWheel_SkipsUnderscoredInitPy(t *testing.T) {
+	t.Parallel()
+	// parseInitPyDirs skips directories starting with underscore
+	wheel := buildTestWheel(t, map[string]string{
+		"_private/__init__.py":    "",
+		"real_pkg/__init__.py":    "",
+		"pkg-1.0.dist-info/WHEEL": "Wheel-Version: 1.0",
+	})
+	names := extractImportNamesFromWheel(wheel)
+	if len(names) != 1 || names[0] != "real_pkg" {
+		t.Fatalf("expected [real_pkg], got %v", names)
+	}
+}
+
+func TestResolveImportNames_Integration(t *testing.T) {
+	t.Parallel()
+
+	wheel := buildTestWheel(t, map[string]string{
+		"bs4/__init__.py":                               "",
+		"beautifulsoup4-4.12.3.dist-info/METADATA":      "Name: beautifulsoup4",
+		"beautifulsoup4-4.12.3.dist-info/top_level.txt": "bs4\n",
+	})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/pypi/beautifulsoup4/json":
+			resp := map[string]interface{}{
+				"urls": []map[string]interface{}{
+					{
+						"filename":    "beautifulsoup4-4.12.3.tar.gz",
+						"packagetype": "sdist",
+						"size":        500000,
+						"url":         fmt.Sprintf("%s/files/beautifulsoup4-4.12.3.tar.gz", r.Host),
+					},
+					{
+						"filename":    "beautifulsoup4-4.12.3-py3-none-any.whl",
+						"packagetype": "bdist_wheel",
+						"size":        int64(len(wheel)),
+						"url":         fmt.Sprintf("http://%s/files/beautifulsoup4-4.12.3-py3-none-any.whl", r.Host),
+					},
+				},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(resp)
+		case "/files/beautifulsoup4-4.12.3-py3-none-any.whl":
+			w.Header().Set("Content-Type", "application/octet-stream")
+			_, _ = w.Write(wheel)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	c := NewClient()
+	c.SetBaseURL(srv.URL)
+	c.SetCacheTTL(5 * time.Minute)
+
+	names, err := c.ResolveImportNames(context.Background(), "beautifulsoup4")
+	if err != nil {
+		t.Fatalf("ResolveImportNames: %v", err)
+	}
+	if len(names) != 1 || names[0] != "bs4" {
+		t.Fatalf("expected [bs4], got %v", names)
+	}
+}
+
+func TestResolveImportNames_NoWheel(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]interface{}{
+			"urls": []map[string]interface{}{
+				{
+					"filename":    "pkg-1.0.tar.gz",
+					"packagetype": "sdist",
+					"size":        100000,
+					"url":         "http://example.com/pkg-1.0.tar.gz",
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	c := NewClient()
+	c.SetBaseURL(srv.URL)
+
+	names, err := c.ResolveImportNames(context.Background(), "pkg")
+	if err != nil {
+		t.Fatalf("ResolveImportNames: %v", err)
+	}
+	if len(names) != 0 {
+		t.Fatalf("expected empty for sdist-only, got %v", names)
+	}
+}
+
+func TestResolveImportNames_WheelTooLarge(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]interface{}{
+			"urls": []map[string]interface{}{
+				{
+					"filename":    "big-1.0-cp311-none-linux_x86_64.whl",
+					"packagetype": "bdist_wheel",
+					"size":        10 << 20, // 10 MB — exceeds limit
+					"url":         "http://example.com/big.whl",
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	c := NewClient()
+	c.SetBaseURL(srv.URL)
+
+	names, err := c.ResolveImportNames(context.Background(), "big")
+	if err != nil {
+		t.Fatalf("ResolveImportNames: %v", err)
+	}
+	if len(names) != 0 {
+		t.Fatalf("expected empty for oversized wheel, got %v", names)
+	}
+}
+
+func TestResolveImportNames_Cache(t *testing.T) {
+	t.Parallel()
+	var hits int32
+
+	wheel := buildTestWheel(t, map[string]string{
+		"yaml/__init__.py":                   "",
+		"pyyaml-6.0.dist-info/top_level.txt": "yaml\n",
+	})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		switch r.URL.Path {
+		case "/pypi/pyyaml/json":
+			resp := map[string]interface{}{
+				"urls": []map[string]interface{}{
+					{
+						"filename":    "PyYAML-6.0-py3-none-any.whl",
+						"packagetype": "bdist_wheel",
+						"size":        int64(len(wheel)),
+						"url":         fmt.Sprintf("http://%s/files/PyYAML-6.0-py3-none-any.whl", r.Host),
+					},
+				},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(resp)
+		case "/files/PyYAML-6.0-py3-none-any.whl":
+			_, _ = w.Write(wheel)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	c := NewClient()
+	c.SetBaseURL(srv.URL)
+	c.SetCacheTTL(5 * time.Minute)
+
+	ctx := context.Background()
+
+	// First call — should hit network.
+	names1, err := c.ResolveImportNames(ctx, "pyyaml")
+	if err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	if len(names1) != 1 || names1[0] != "yaml" {
+		t.Fatalf("first call: expected [yaml], got %v", names1)
+	}
+	firstHits := atomic.LoadInt32(&hits)
+
+	// Second call — should hit cache (no new HTTP requests).
+	names2, err := c.ResolveImportNames(ctx, "pyyaml")
+	if err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+	if len(names2) != 1 || names2[0] != "yaml" {
+		t.Fatalf("second call: expected [yaml], got %v", names2)
+	}
+	secondHits := atomic.LoadInt32(&hits)
+	if secondHits != firstHits {
+		t.Fatalf("cache miss: HTTP hits went from %d to %d", firstHits, secondHits)
+	}
+}
+
+func TestResolveImportNames_PackageNotFound(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := NewClient()
+	c.SetBaseURL(srv.URL)
+
+	names, err := c.ResolveImportNames(context.Background(), "nonexistent")
+	if err != nil {
+		t.Fatalf("ResolveImportNames: %v", err)
+	}
+	if len(names) != 0 {
+		t.Fatalf("expected empty for 404, got %v", names)
+	}
+}
+
+func TestIsPyIdentifierSafe(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{name: "valid", in: "bs4", want: true},
+		{name: "underscore_prefix", in: "_yaml", want: true},
+		{name: "with_digits", in: "lib2to3", want: true},
+		{name: "digit_start", in: "3scale", want: false},
+		{name: "hyphen", in: "my-pkg", want: false},
+		{name: "empty", in: "", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isPyIdentifierSafe(tt.in); got != tt.want {
+				t.Errorf("isPyIdentifierSafe(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/interfaces/cli/diet.go
+++ b/internal/interfaces/cli/diet.go
@@ -27,6 +27,7 @@ func RunDiet(
 	opts DietOptions,
 	graphAnalyzer dietapp.GraphAnalyzer,
 	sourceAnalyzer dietapp.SourceAnalyzer,
+	pypiResolver dietapp.PyPIImportResolver,
 ) error {
 	// Validate required options
 	if opts.SBOMPath == "" {
@@ -54,7 +55,7 @@ func RunDiet(
 	analysisService := createAnalysisService(cfg)
 
 	// Create diet service
-	svc := dietapp.NewService(graphAnalyzer, sourceAnalyzer, analysisService)
+	svc := dietapp.NewService(graphAnalyzer, sourceAnalyzer, pypiResolver, analysisService)
 
 	// Run diet pipeline
 	plan, err := svc.Run(ctx, dietapp.DietInput{


### PR DESCRIPTION
## Summary

- Add **Phase 2.5** to the diet pipeline: when heuristic import path guessing (hyphen→underscore, prefix strip) produces zero coupling matches for a PyPI package, download the smallest wheel file and extract actual import names from `top_level.txt`, `RECORD`, or `__init__.py` directory listing
- Define `PyPIImportResolver` interface in the application layer; `pypi.Client` implements it in infrastructure
- Harden PyPI client security: `url.PathEscape` on package names, URL scheme validation for downloads, `io.LimitReader` on ZIP entries and JSON responses

Closes #275

## Design

```
Phase 2 (coupling) → identify zero-match PyPI packages → Phase 2.5 (wheel download + retry) → Phase 3/4
```

- **Trigger**: Only for PyPI packages with `import_file_count == 0` after Phase 2
- **Size limit**: Wheels > 5 MB are skipped (covers ~95% of packages)
- **Cache**: In-memory with same TTL as existing `ProjectInfo` cache
- **Graceful degradation**: All errors logged and skipped — no failure propagates to pipeline

## Key files

| File | Change |
|------|--------|
| `internal/infrastructure/pypi/wheel.go` | NEW: wheel download, ZIP extraction, import name cache |
| `internal/application/diet/service.go` | `PyPIImportResolver` interface, Phase 2.5 retry logic |
| `internal/infrastructure/pypi/client.go` | `pypiUserAgent` const, `resolvedBaseURL()` helper, `url.PathEscape` |
| `docs/diet.md` | Phase 2.5 documentation |

## Test plan

- [x] Unit tests for ZIP extraction (top_level.txt, RECORD, __init__.py, empty, invalid)
- [x] httptest integration tests for `ResolveImportNames` (full flow, no wheel, too large, cache, 404)
- [x] Service-level tests for Phase 2.5 (successful fallback, nil resolver, resolver error)
- [x] All existing tests pass (`go test ./... -short`)
- [x] `golangci-lint run ./...` — 0 issues
- [x] 3-round `/review-until-clean` completed

🤖 Generated with [Claude Code](https://claude.com/claude-code)