### PR TITLE
fix: exclude Python TYPE_CHECKING conditional imports from IBNC analysis

### DIFF
--- a/.claude/rules/copilot-learned-coding.md
+++ b/.claude/rules/copilot-learned-coding.md
@@ -11,6 +11,7 @@ Rules extracted from recurring Copilot review patterns on coding-standards topic
 - **Nullable Field Documentation**: When documenting a pointer or optional field, enumerate **all** conditions under which it can be nil/empty — not just the primary case. For example, a `ForkSource` field should note it is empty when `IsFork` is false **and** when the parent is private/inaccessible. Similarly, ensure the comment names the correct upstream API field (e.g., `parent` vs `source`) that the implementation actually uses.
 - **Defensive Coding — Validate Early, Fail Clearly**: When a constructor or factory function receives a required dependency (e.g., a service, client, or parser), validate it is non-nil and return a descriptive error rather than allowing a nil-pointer panic later. Similarly, when CLI flags are mutually exclusive, reject the invalid combination at the validation layer with a clear message instead of silently preferring one. When a data field is a collection (slice/array), emit all items in serialized output rather than silently taking only the first. When sniffing file formats, validate field **values** (not just key presence) — e.g., check `bomFormat == "CycloneDX"`, not just that `bomFormat` exists.
 - **File Type Detection — Use Exact Basename, Not Suffix**: When detecting file types by name (e.g., `go.mod`), use `filepath.Base(path) == "go.mod"` instead of `strings.HasSuffix(path, ".mod")`. Suffix matching can misclassify unrelated files (e.g., `deps.mod`) and route them to the wrong parser. Similarly, when matching path segments (e.g., `.github/workflows/`), require a leading path separator (`/.github/workflows/`) to avoid false positives from paths where the segment is embedded (e.g., `/tmp/not.github/workflows/`).
+- **Use Spec-Compliant Parsers for Standardized Formats**: When parsing standardized file formats (CSV, RECORD, TSV), use the language's spec-compliant parser (e.g., `encoding/csv`) instead of naive `strings.Split` or similar. Naive splitting misparses quoted or escaped fields, producing silent data corruption.
 - **Reject Flags That Silently Have No Effect**: When a CLI flag only applies to a specific input mode (e.g., `--sample` for PURL list files), explicitly reject it with a clear error when the input is a different mode (e.g., go.mod or SBOM). Do not silently ignore the flag — users assume their flags take effect.
 - **Deduplicate Inputs Before Batch API Calls**: When accepting user-provided input lists (PURLs, URLs) that feed into batch API calls, deduplicate them while preserving first-seen order before processing. Duplicates cause redundant external calls, skew logging/counts, and waste resources.
 - **Normalize User-Provided Enum Values**: When accepting string values for format selectors, mode switches, or other enums from CLI flags, normalize with `strings.TrimSpace(strings.ToLower(...))` before validation. Case-sensitive matching rejects common inputs like `--format JSON` or `--format "json "`.
@@ -23,6 +24,7 @@ Rules extracted from recurring Copilot review patterns on coding-standards topic
 - **Lazy I/O During Format Detection**: When probing a file's format, prefer path-based checks first, then read only a small prefix for content-based heuristics. Read the full file only after confirming the format to avoid wasted I/O on non-matching files (e.g., reading an entire docker-compose.yml just to check if it's a GitHub Actions workflow).
 - **Deterministic Output from Non-Deterministic Sources**: When building ordered output from non-deterministic sources (Go map iteration, goroutine-collected results, API directory listings), sort the data before further processing. This applies to rendered text, BFS seed queues, and any "first-seen wins" algorithm where input order determines provenance.
 - **Post-Filter Fuzzy Search Results**: When using search APIs that perform fuzzy or word-level matching (e.g., GitHub issue search), add a post-filter to verify exact matches before acting on results. Fuzzy matches can cause false-positive deduplication or incorrect state transitions.
+- **Rerun Analyzers with Combined Input Sets on Retry**: When retrying a subset of inputs through an analyzer that tracks collisions or shared matches, rerun with the combined input set (original + retry) to preserve attribution consistency. Subset reruns can misattribute shared matches to the wrong source.
 - **Consolidate Detection Heuristics — Single Source of Truth**: When a detection heuristic (file type sniffing, format detection, path matching) is used in multiple locations, centralize it in the responsible package and have callers delegate. Duplicating the heuristic across layers (e.g., `cmd/` and `infrastructure/`) risks drift when one copy is updated but the other is not.
 - **Use Correct GitHub API Media Types**: When calling GitHub REST APIs, use the documented `Accept` header for the desired response format. For raw file content use `application/vnd.github.raw` (not `application/vnd.github.raw+json`). Incorrect media types may cause silent content-negotiation failures or unexpected response formats. Refer to GitHub's REST API media type documentation before adding a new endpoint call.
 - **Narrow Typed Error Matching to Specific Conditions**: When checking typed errors (e.g., `IsResourceNotFoundError`), verify the error's message or context matches the expected source — not just the error type. A single error type can be returned by multiple code paths with different semantics (e.g., "repo not found" vs "no package managers"), and a broad type check can trigger incorrect fallback behavior for unrelated error origins.
@@ -39,6 +41,7 @@ Rules extracted from recurring Copilot review patterns on coding-standards topic
 - **Use `utf8.RuneCountInString` for Terminal Display Widths**: When computing string widths for terminal display (box drawing, alignment), use `utf8.RuneCountInString` — not `len` — to avoid incorrect sizing with multi-byte characters (box-drawing glyphs, emoji). Clamp computed padding to zero when content already exceeds the budget rather than forcing a minimum that widens output beyond the declared width.
 - **Filter and Normalize IDs Before Batch API Calls**: When building batch API requests from collected IDs, filter empty/whitespace values and deduplicate before processing to prevent invalid HTTP requests and cache pollution. Use `select` on `ctx.Done()` alongside channel operations in batch goroutines to avoid blocking after context cancellation.
 - **Guard Nil Structs Consistently Across Output Formats**: When a struct field may be nil (e.g., `ReleaseInfo`), apply the nil guard in every output renderer that accesses it (text, CSV, JSON). If one renderer has the guard and another does not, the unguarded path will panic on nil input.
+- **Gate Fallback Logic on Error, Not Result Nilness**: When deciding whether to trigger fallback or retry logic, check the error value — not whether the result is nil. A nil result with nil error is a valid success case (e.g., zero matches found), and treating it as a failure triggers unnecessary retries or incorrect fallback paths.
 - **Use Case-Insensitive Comparison for URL Components**: When comparing URL components (scheme, host), use case-insensitive comparison per RFC 3986 — schemes (`HTTP://`) and hosts (`GitHub.COM`) are case-insensitive. Normalize with `strings.ToLower` or `strings.EqualFold` before prefix checks or host matching to avoid double-prefixing or missed matches.
 - **Structured Logging Conventions**: When adding `slog` calls: use DEBUG level for routine per-item telemetry (reserve INFO for exceptional events); use `snake_case` for event names (not spaces) for consistency and filterability; choose field key names that accurately describe the data across all call sites (e.g., `"ref"` not `"purl"` when the function handles both PURLs and URLs).
 - **Match Validation Format Strings to Production Format Strings**: When a validation or check function mirrors a production function's output (e.g., marker validation vs. marker replacement), use the exact same format strings and delimiters. Mismatched formats allow invalid input to pass validation silently.
@@ -50,6 +53,7 @@ Rules extracted from recurring Copilot review patterns on coding-standards topic
 - **Classify from Raw Values Before Rounding**: When deriving a category or label from a computed numeric value (e.g., score → difficulty bucket), apply the classification logic to the raw value before any rounding. Rounding first can push boundary values into the wrong bucket.
 - **Validate Generated Strings Against Target-Language Syntax**: When programmatically generating identifiers, import paths, or package names for a target language, validate each candidate against that language's syntax rules before emitting it. Validation must cover the full identifier grammar — not just invalid characters but also positional rules (e.g., Java identifiers cannot start with a digit) and compound structures (e.g., dot-separated package names must validate each segment independently). For example, Maven artifactIds often contain hyphens (`commons-lang3`) and groupIds can too (`commons-io`), which are invalid in Java package names — emitting them verbatim produces candidates that can never match real imports. Similarly, error hints and suggestions must use terminology appropriate to the detected language/ecosystem, not hardcode references to a single ecosystem (e.g., `go.mod`) when the tool supports multiple languages.
 - **Collect All Matches in Collector Functions — No Early Return**: When a function iterates over children/items to collect all matching results (e.g., AST bindings, search hits), append each match to a slice and return the slice after the loop. Do not `return` on the first match — early return drops remaining items. This applies whenever the caller needs *all* matches, not just the first.
+- **Continue AST Ancestor Walks Past Non-Matching Nodes**: When walking AST ancestors to find a guarding condition (e.g., `if TYPE_CHECKING:` blocks), continue past intermediate nodes of the same type that don't match the target condition. Returning early on the first type match (e.g., the first `if_statement`) misses the actual guard when the import is nested inside inner conditionals.
 - **Normalize Map Keys Consistently Across Insert and Lookup**: When building a `map[string]T` with normalized keys (e.g., `strings.ToLower` at insertion), apply the same normalization at every lookup site. A mismatch causes silent lookup failures for inputs with non-canonical casing (e.g., mixed-case Python module names like `OpenSSL`). Audit all functions that query the map, not just the one you're currently editing.
 - **Use Ecosystem-Neutral Language in Multi-Language Error Messages**: When a CLI tool supports multiple ecosystems, error hints and suggestions must not reference language-specific files (e.g., `go.mod`) unless the current context is confirmed to be that language. Generic messages like "dependency manifest not found" are safer than ecosystem-specific ones.
 - **Extract Shared Helpers for Near-Duplicate Code Paths**: When two functions follow the same sequence (e.g., parse input → call external API → interpret result → populate output) differing only in how one parameter is obtained, extract the shared sequence into a single helper parameterized on that value. Near-duplicate paths drift silently when logging, error handling, or evidence formatting is updated in one copy but not the other.
@@ -85,11 +89,6 @@ pending_patterns:
     pr: 236
     file: "internal/infrastructure/eolevaluator/evaluator_npm_test.go"
     date: "2026-04-08"
-  - category: "defensive-coding"
-    summary: "When retrying a subset of inputs through an analyzer that tracks collisions, rerun with the combined input set (original + retry) to preserve attribution consistency — subset reruns misattribute shared matches"
-    pr: 276
-    file: "internal/application/diet/service.go"
-    date: "2026-04-11"
   - category: "security"
     summary: "When using io.LimitReader to cap entry reads, read maxSize+1 and reject if oversized — plain LimitReader silently truncates, causing downstream parsers to operate on partial/corrupt data"
     pr: 276
@@ -110,11 +109,6 @@ pending_patterns:
     pr: 276
     file: "internal/infrastructure/pypi/wheel.go"
     date: "2026-04-11"
-  - category: "defensive-coding"
-    summary: "Gate fallback/retry logic on the error value, not result nilness — a nil result with nil error is a valid success case (e.g., zero matches) and should still trigger fallback behavior"
-    pr: 276
-    file: "internal/application/diet/service.go"
-    date: "2026-04-11"
   - category: "testing"
     summary: "Accept interface types in test-setter methods (e.g., SetXxxClient) so fakes can be injected via public API instead of unexported fields"
     pr: 236
@@ -125,11 +119,6 @@ pending_patterns:
     pr: 237
     file: "internal/application/diet/coupling_integration_test.go"
     date: "2026-04-08"
-  - category: "defensive-coding"
-    summary: "Use spec-compliant parsers (e.g., encoding/csv) instead of naive string splitting for standardized file formats — naive splits misparse quoted or escaped fields"
-    pr: 276
-    file: "internal/infrastructure/pypi/wheel.go"
-    date: "2026-04-11"
   - category: "whitespace-agnostic-matching"
     summary: "Use bytes.Fields tokenization instead of fixed-separator prefix checks when matching directives — tabs and multiple spaces are valid separators"
     pr: 140
@@ -148,6 +137,7 @@ pending_patterns:
 ```
 
 <!-- Promotion history (kept for audit trail):
+  # defensive-coding: promoted to copilot-learned-coding.instructions.md (PRs #276, #280 — rerun analyzers with combined input, gate fallback on error, spec-compliant parsers, AST ancestor walk continuation)
   # comment-doc-drift: promoted to copilot-learned-coding.instructions.md (PRs #253, #276 — interface contract doc must match signature semantics)
   # defensive-coding: promoted to copilot-learned-coding.instructions.md (PRs #277, #276 — handle all valid input forms in format parsers)
   # error-handling: promoted to error-handling.instructions.md (PRs #87, #159 — surface initialization errors instead of silent degradation)

--- a/.github/instructions/copilot-learned-coding.instructions.md
+++ b/.github/instructions/copilot-learned-coding.instructions.md
@@ -9,6 +9,7 @@ Rules extracted from recurring Copilot review patterns on coding-standards topic
 - **Nullable Field Documentation**: When documenting a pointer or optional field, enumerate **all** conditions under which it can be nil/empty — not just the primary case. For example, a `ForkSource` field should note it is empty when `IsFork` is false **and** when the parent is private/inaccessible. Similarly, ensure the comment names the correct upstream API field (e.g., `parent` vs `source`) that the implementation actually uses.
 - **Defensive Coding — Validate Early, Fail Clearly**: When a constructor or factory function receives a required dependency (e.g., a service, client, or parser), validate it is non-nil and return a descriptive error rather than allowing a nil-pointer panic later. Similarly, when CLI flags are mutually exclusive, reject the invalid combination at the validation layer with a clear message instead of silently preferring one. When a data field is a collection (slice/array), emit all items in serialized output rather than silently taking only the first. When sniffing file formats, validate field **values** (not just key presence) — e.g., check `bomFormat == "CycloneDX"`, not just that `bomFormat` exists.
 - **File Type Detection — Use Exact Basename, Not Suffix**: When detecting file types by name (e.g., `go.mod`), use `filepath.Base(path) == "go.mod"` instead of `strings.HasSuffix(path, ".mod")`. Suffix matching can misclassify unrelated files (e.g., `deps.mod`) and route them to the wrong parser. Similarly, when matching path segments (e.g., `.github/workflows/`), require a leading path separator (`/.github/workflows/`) to avoid false positives from paths where the segment is embedded (e.g., `/tmp/not.github/workflows/`).
+- **Use Spec-Compliant Parsers for Standardized Formats**: When parsing standardized file formats (CSV, RECORD, TSV), use the language's spec-compliant parser (e.g., `encoding/csv`) instead of naive `strings.Split` or similar. Naive splitting misparses quoted or escaped fields, producing silent data corruption.
 - **Reject Flags That Silently Have No Effect**: When a CLI flag only applies to a specific input mode (e.g., `--sample` for PURL list files), explicitly reject it with a clear error when the input is a different mode (e.g., go.mod or SBOM). Do not silently ignore the flag — users assume their flags take effect.
 - **Deduplicate Inputs Before Batch API Calls**: When accepting user-provided input lists (PURLs, URLs) that feed into batch API calls, deduplicate them while preserving first-seen order before processing. Duplicates cause redundant external calls, skew logging/counts, and waste resources.
 - **Normalize User-Provided Enum Values**: When accepting string values for format selectors, mode switches, or other enums from CLI flags, normalize with `strings.TrimSpace(strings.ToLower(...))` before validation. Case-sensitive matching rejects common inputs like `--format JSON` or `--format "json "`.
@@ -21,6 +22,7 @@ Rules extracted from recurring Copilot review patterns on coding-standards topic
 - **Lazy I/O During Format Detection**: When probing a file's format, prefer path-based checks first, then read only a small prefix for content-based heuristics. Read the full file only after confirming the format to avoid wasted I/O on non-matching files (e.g., reading an entire docker-compose.yml just to check if it's a GitHub Actions workflow).
 - **Deterministic Output from Non-Deterministic Sources**: When building ordered output from non-deterministic sources (Go map iteration, goroutine-collected results, API directory listings), sort the data before further processing. This applies to rendered text, BFS seed queues, and any "first-seen wins" algorithm where input order determines provenance.
 - **Post-Filter Fuzzy Search Results**: When using search APIs that perform fuzzy or word-level matching (e.g., GitHub issue search), add a post-filter to verify exact matches before acting on results. Fuzzy matches can cause false-positive deduplication or incorrect state transitions.
+- **Rerun Analyzers with Combined Input Sets on Retry**: When retrying a subset of inputs through an analyzer that tracks collisions or shared matches, rerun with the combined input set (original + retry) to preserve attribution consistency. Subset reruns can misattribute shared matches to the wrong source.
 - **Consolidate Detection Heuristics — Single Source of Truth**: When a detection heuristic (file type sniffing, format detection, path matching) is used in multiple locations, centralize it in the responsible package and have callers delegate. Duplicating the heuristic across layers (e.g., `cmd/` and `infrastructure/`) risks drift when one copy is updated but the other is not.
 - **Use Correct GitHub API Media Types**: When calling GitHub REST APIs, use the documented `Accept` header for the desired response format. For raw file content use `application/vnd.github.raw` (not `application/vnd.github.raw+json`). Incorrect media types may cause silent content-negotiation failures or unexpected response formats. Refer to GitHub's REST API media type documentation before adding a new endpoint call.
 - **Narrow Typed Error Matching to Specific Conditions**: When checking typed errors (e.g., `IsResourceNotFoundError`), verify the error's message or context matches the expected source — not just the error type. A single error type can be returned by multiple code paths with different semantics (e.g., "repo not found" vs "no package managers"), and a broad type check can trigger incorrect fallback behavior for unrelated error origins.
@@ -37,6 +39,7 @@ Rules extracted from recurring Copilot review patterns on coding-standards topic
 - **Use `utf8.RuneCountInString` for Terminal Display Widths**: When computing string widths for terminal display (box drawing, alignment), use `utf8.RuneCountInString` — not `len` — to avoid incorrect sizing with multi-byte characters (box-drawing glyphs, emoji). Clamp computed padding to zero when content already exceeds the budget rather than forcing a minimum that widens output beyond the declared width.
 - **Filter and Normalize IDs Before Batch API Calls**: When building batch API requests from collected IDs, filter empty/whitespace values and deduplicate before processing to prevent invalid HTTP requests and cache pollution. Use `select` on `ctx.Done()` alongside channel operations in batch goroutines to avoid blocking after context cancellation.
 - **Guard Nil Structs Consistently Across Output Formats**: When a struct field may be nil (e.g., `ReleaseInfo`), apply the nil guard in every output renderer that accesses it (text, CSV, JSON). If one renderer has the guard and another does not, the unguarded path will panic on nil input.
+- **Gate Fallback Logic on Error, Not Result Nilness**: When deciding whether to trigger fallback or retry logic, check the error value — not whether the result is nil. A nil result with nil error is a valid success case (e.g., zero matches found), and treating it as a failure triggers unnecessary retries or incorrect fallback paths.
 - **Use Case-Insensitive Comparison for URL Components**: When comparing URL components (scheme, host), use case-insensitive comparison per RFC 3986 — schemes (`HTTP://`) and hosts (`GitHub.COM`) are case-insensitive. Normalize with `strings.ToLower` or `strings.EqualFold` before prefix checks or host matching to avoid double-prefixing or missed matches.
 - **Structured Logging Conventions**: When adding `slog` calls: use DEBUG level for routine per-item telemetry (reserve INFO for exceptional events); use `snake_case` for event names (not spaces) for consistency and filterability; choose field key names that accurately describe the data across all call sites (e.g., `"ref"` not `"purl"` when the function handles both PURLs and URLs).
 - **Match Validation Format Strings to Production Format Strings**: When a validation or check function mirrors a production function's output (e.g., marker validation vs. marker replacement), use the exact same format strings and delimiters. Mismatched formats allow invalid input to pass validation silently.
@@ -48,6 +51,7 @@ Rules extracted from recurring Copilot review patterns on coding-standards topic
 - **Classify from Raw Values Before Rounding**: When deriving a category or label from a computed numeric value (e.g., score → difficulty bucket), apply the classification logic to the raw value before any rounding. Rounding first can push boundary values into the wrong bucket.
 - **Validate Generated Strings Against Target-Language Syntax**: When programmatically generating identifiers, import paths, or package names for a target language, validate each candidate against that language's syntax rules before emitting it. Validation must cover the full identifier grammar — not just invalid characters but also positional rules (e.g., Java identifiers cannot start with a digit) and compound structures (e.g., dot-separated package names must validate each segment independently). For example, Maven artifactIds often contain hyphens (`commons-lang3`) and groupIds can too (`commons-io`), which are invalid in Java package names — emitting them verbatim produces candidates that can never match real imports. Similarly, error hints and suggestions must use terminology appropriate to the detected language/ecosystem, not hardcode references to a single ecosystem (e.g., `go.mod`) when the tool supports multiple languages.
 - **Collect All Matches in Collector Functions — No Early Return**: When a function iterates over children/items to collect all matching results (e.g., AST bindings, search hits), append each match to a slice and return the slice after the loop. Do not `return` on the first match — early return drops remaining items. This applies whenever the caller needs *all* matches, not just the first.
+- **Continue AST Ancestor Walks Past Non-Matching Nodes**: When walking AST ancestors to find a guarding condition (e.g., `if TYPE_CHECKING:` blocks), continue past intermediate nodes of the same type that don't match the target condition. Returning early on the first type match (e.g., the first `if_statement`) misses the actual guard when the import is nested inside inner conditionals.
 - **Normalize Map Keys Consistently Across Insert and Lookup**: When building a `map[string]T` with normalized keys (e.g., `strings.ToLower` at insertion), apply the same normalization at every lookup site. A mismatch causes silent lookup failures for inputs with non-canonical casing (e.g., mixed-case Python module names like `OpenSSL`). Audit all functions that query the map, not just the one you're currently editing.
 - **Use Ecosystem-Neutral Language in Multi-Language Error Messages**: When a CLI tool supports multiple ecosystems, error hints and suggestions must not reference language-specific files (e.g., `go.mod`) unless the current context is confirmed to be that language. Generic messages like "dependency manifest not found" are safer than ecosystem-specific ones.
 - **Extract Shared Helpers for Near-Duplicate Code Paths**: When two functions follow the same sequence (e.g., parse input → call external API → interpret result → populate output) differing only in how one parameter is obtained, extract the shared sequence into a single helper parameterized on that value. Near-duplicate paths drift silently when logging, error handling, or evidence formatting is updated in one copy but not the other.
@@ -83,11 +87,6 @@ pending_patterns:
     pr: 236
     file: "internal/infrastructure/eolevaluator/evaluator_npm_test.go"
     date: "2026-04-08"
-  - category: "defensive-coding"
-    summary: "When retrying a subset of inputs through an analyzer that tracks collisions, rerun with the combined input set (original + retry) to preserve attribution consistency — subset reruns misattribute shared matches"
-    pr: 276
-    file: "internal/application/diet/service.go"
-    date: "2026-04-11"
   - category: "security"
     summary: "When using io.LimitReader to cap entry reads, read maxSize+1 and reject if oversized — plain LimitReader silently truncates, causing downstream parsers to operate on partial/corrupt data"
     pr: 276
@@ -108,11 +107,6 @@ pending_patterns:
     pr: 276
     file: "internal/infrastructure/pypi/wheel.go"
     date: "2026-04-11"
-  - category: "defensive-coding"
-    summary: "Gate fallback/retry logic on the error value, not result nilness — a nil result with nil error is a valid success case (e.g., zero matches) and should still trigger fallback behavior"
-    pr: 276
-    file: "internal/application/diet/service.go"
-    date: "2026-04-11"
   - category: "testing"
     summary: "Accept interface types in test-setter methods (e.g., SetXxxClient) so fakes can be injected via public API instead of unexported fields"
     pr: 236
@@ -123,11 +117,6 @@ pending_patterns:
     pr: 237
     file: "internal/application/diet/coupling_integration_test.go"
     date: "2026-04-08"
-  - category: "defensive-coding"
-    summary: "Use spec-compliant parsers (e.g., encoding/csv) instead of naive string splitting for standardized file formats — naive splits misparse quoted or escaped fields"
-    pr: 276
-    file: "internal/infrastructure/pypi/wheel.go"
-    date: "2026-04-11"
   - category: "whitespace-agnostic-matching"
     summary: "Use bytes.Fields tokenization instead of fixed-separator prefix checks when matching directives — tabs and multiple spaces are valid separators"
     pr: 140
@@ -146,6 +135,7 @@ pending_patterns:
 ```
 
 <!-- Promotion history (kept for audit trail):
+  # defensive-coding: promoted to copilot-learned-coding.instructions.md (PRs #276, #280 — rerun analyzers with combined input, gate fallback on error, spec-compliant parsers, AST ancestor walk continuation)
   # comment-doc-drift: promoted to copilot-learned-coding.instructions.md (PRs #253, #276 — interface contract doc must match signature semantics)
   # defensive-coding: promoted to copilot-learned-coding.instructions.md (PRs #277, #276 — handle all valid input forms in format parsers)
   # error-handling: promoted to error-handling.instructions.md (PRs #87, #159 — surface initialization errors instead of silent degradation)

--- a/internal/infrastructure/treesitter/analyzer.go
+++ b/internal/infrastructure/treesitter/analyzer.go
@@ -378,7 +378,8 @@ func (a *Analyzer) extractImports(
 }
 
 // maxAncestorWalkDepth limits how far ancestor-walking functions (e.g.,
-// findAncestorVariableDeclarator, isPythonTryExceptImport) traverse the AST.
+// findAncestorVariableDeclarator, isPythonTryExceptImport,
+// isPythonTypeCheckingImport) traverse the AST.
 // Prevents false matches against distant, unrelated ancestors in pathological
 // nesting.
 const maxAncestorWalkDepth = 5

--- a/internal/infrastructure/treesitter/lang_python.go
+++ b/internal/infrastructure/treesitter/lang_python.go
@@ -53,6 +53,12 @@ func (a *Analyzer) handlePythonImport(
 		return
 	}
 
+	// Skip imports inside `if TYPE_CHECKING:` blocks — they are type-only and
+	// never execute at runtime, so they should not count toward IBNC.
+	if isPythonTypeCheckingImport(parent, src) {
+		return
+	}
+
 	// Check if this import is inside a try/except ImportError block.
 	// This is often a Python feature-detection pattern where the import itself
 	// signals optional dependency detection. Record that fact like a Go blank
@@ -162,6 +168,57 @@ func hasPythonImportErrorHandler(tryStmt *sitter.Node, src []byte) bool {
 		// including ImportError.
 		if !hasExceptionType {
 			return true
+		}
+	}
+	return false
+}
+
+// isPythonTypeCheckingImport checks if a Python import-related node is inside an
+// `if TYPE_CHECKING:` or `if typing.TYPE_CHECKING:` block. Python's
+// typing.TYPE_CHECKING constant is False at runtime, so imports guarded by it
+// are type-only and never execute. These imports should not count toward IBNC.
+//
+// importStmt may be an import_statement, import_from_statement, or another
+// import-related node. src is the file source for reading node content.
+func isPythonTypeCheckingImport(importStmt *sitter.Node, src []byte) bool {
+	// Walk up from the import statement to find the nearest enclosing if_statement,
+	// tracking the child path to ensure the import is in the if body (consequence),
+	// not in an else clause.
+	child := importStmt
+	current := importStmt.Parent()
+	for depth := 0; current != nil && depth < maxAncestorWalkDepth; depth++ {
+		if current.Type() == "if_statement" {
+			// Only match imports in the if body (consequence), not else/elif.
+			body := current.ChildByFieldName("consequence")
+			if body == nil || body != child {
+				return false
+			}
+			return isTypeCheckingCondition(current, src)
+		}
+		child = current
+		current = current.Parent()
+	}
+	return false
+}
+
+// isTypeCheckingCondition checks if an if_statement's condition is
+// `TYPE_CHECKING` (bare identifier) or `typing.TYPE_CHECKING` (attribute access).
+func isTypeCheckingCondition(ifStmt *sitter.Node, src []byte) bool {
+	cond := ifStmt.ChildByFieldName("condition")
+	if cond == nil {
+		return false
+	}
+
+	switch cond.Type() {
+	case "identifier":
+		// `if TYPE_CHECKING:`
+		return cond.Content(src) == "TYPE_CHECKING"
+	case "attribute":
+		// `if typing.TYPE_CHECKING:`
+		obj := cond.ChildByFieldName("object")
+		attr := cond.ChildByFieldName("attribute")
+		if obj != nil && attr != nil {
+			return obj.Content(src) == "typing" && attr.Content(src) == "TYPE_CHECKING"
 		}
 	}
 	return false

--- a/internal/infrastructure/treesitter/lang_python.go
+++ b/internal/infrastructure/treesitter/lang_python.go
@@ -181,19 +181,21 @@ func hasPythonImportErrorHandler(tryStmt *sitter.Node, src []byte) bool {
 // importStmt may be an import_statement, import_from_statement, or another
 // import-related node. src is the file source for reading node content.
 func isPythonTypeCheckingImport(importStmt *sitter.Node, src []byte) bool {
-	// Walk up from the import statement to find the nearest enclosing if_statement,
-	// tracking the child path to ensure the import is in the if body (consequence),
-	// not in an else clause.
+	// Walk up from the import statement through enclosing ancestors, tracking the
+	// child path to ensure the import remains within an if body (consequence), not
+	// an else/elif branch. Keep walking past non-TYPE_CHECKING if-statements so
+	// nested imports inside a TYPE_CHECKING block are still detected.
 	child := importStmt
 	current := importStmt.Parent()
 	for depth := 0; current != nil && depth < maxAncestorWalkDepth; depth++ {
 		if current.Type() == "if_statement" {
-			// Only match imports in the if body (consequence), not else/elif.
+			// Only consider if-statements whose consequence directly contains the
+			// current child path. If this node is reached through an else/elif path,
+			// continue walking upward without matching this if-statement.
 			body := current.ChildByFieldName("consequence")
-			if body == nil || body != child {
-				return false
+			if body == child && isTypeCheckingCondition(current, src) {
+				return true
 			}
-			return isTypeCheckingCondition(current, src)
 		}
 		child = current
 		current = current.Parent()

--- a/internal/infrastructure/treesitter/lang_python.go
+++ b/internal/infrastructure/treesitter/lang_python.go
@@ -188,10 +188,10 @@ func isPythonTypeCheckingImport(importStmt *sitter.Node, src []byte) bool {
 	child := importStmt
 	current := importStmt.Parent()
 	for depth := 0; current != nil && depth < maxAncestorWalkDepth; depth++ {
-		if current.Type() == "if_statement" {
-			// Only consider if-statements whose consequence directly contains the
-			// current child path. If this node is reached through an else/elif path,
-			// continue walking upward without matching this if-statement.
+		if current.Type() == "if_statement" || current.Type() == "elif_clause" {
+			// Only consider if/elif nodes whose consequence directly contains the
+			// current child path. If this node is reached through an else path,
+			// continue walking upward without matching.
 			body := current.ChildByFieldName("consequence")
 			if body == child && isTypeCheckingCondition(current, src) {
 				return true
@@ -203,7 +203,7 @@ func isPythonTypeCheckingImport(importStmt *sitter.Node, src []byte) bool {
 	return false
 }
 
-// isTypeCheckingCondition checks if an if_statement's condition is
+// isTypeCheckingCondition checks if an if_statement or elif_clause's condition is
 // `TYPE_CHECKING` (bare identifier) or `typing.TYPE_CHECKING` (attribute access).
 func isTypeCheckingCondition(ifStmt *sitter.Node, src []byte) bool {
 	cond := ifStmt.ChildByFieldName("condition")

--- a/internal/infrastructure/treesitter/lang_python_test.go
+++ b/internal/infrastructure/treesitter/lang_python_test.go
@@ -426,3 +426,139 @@ except (ValueError, TypeError):
 		})
 	}
 }
+
+func TestAnalyzer_PythonTypeCheckingImport(t *testing.T) {
+	tests := []struct {
+		name            string
+		code            string
+		importPaths     map[string][]string
+		purl            string
+		wantImports     int
+		wantCalls       int
+		wantBreadth     int
+		wantBlankImport bool
+	}{
+		{
+			name: "if TYPE_CHECKING from-import skipped",
+			code: `from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from hpack import HeaderTuple
+
+def foo():
+    pass
+`,
+			importPaths: map[string][]string{
+				"pkg:pypi/hpack@4.0.0": {"hpack"},
+			},
+			purl:        "pkg:pypi/hpack@4.0.0",
+			wantImports: 0,
+			wantCalls:   0,
+			wantBreadth: 0,
+		},
+		{
+			name: "if typing.TYPE_CHECKING from-import skipped",
+			code: `import typing
+if typing.TYPE_CHECKING:
+    from hpack import HeaderTuple
+
+def foo():
+    pass
+`,
+			importPaths: map[string][]string{
+				"pkg:pypi/hpack@4.0.0": {"hpack"},
+			},
+			purl:        "pkg:pypi/hpack@4.0.0",
+			wantImports: 0,
+			wantCalls:   0,
+			wantBreadth: 0,
+		},
+		{
+			name: "mixed: TYPE_CHECKING import and normal import",
+			code: `from typing import TYPE_CHECKING
+import requests
+if TYPE_CHECKING:
+    from hpack import HeaderTuple
+
+requests.get("https://example.com")
+`,
+			importPaths: map[string][]string{
+				"pkg:pypi/hpack@4.0.0":     {"hpack"},
+				"pkg:pypi/requests@2.31.0": {"requests"},
+			},
+			purl:        "pkg:pypi/hpack@4.0.0",
+			wantImports: 0,
+			wantCalls:   0,
+			wantBreadth: 0,
+		},
+		{
+			name: "normal import not affected by TYPE_CHECKING",
+			code: `from typing import TYPE_CHECKING
+import requests
+if TYPE_CHECKING:
+    from hpack import HeaderTuple
+
+requests.get("https://example.com")
+`,
+			importPaths: map[string][]string{
+				"pkg:pypi/hpack@4.0.0":     {"hpack"},
+				"pkg:pypi/requests@2.31.0": {"requests"},
+			},
+			purl:        "pkg:pypi/requests@2.31.0",
+			wantImports: 1,
+			wantCalls:   1,
+			wantBreadth: 1,
+		},
+		{
+			name: "if TYPE_CHECKING bare import skipped",
+			code: `from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    import hpack
+`,
+			importPaths: map[string][]string{
+				"pkg:pypi/hpack@4.0.0": {"hpack"},
+			},
+			purl:        "pkg:pypi/hpack@4.0.0",
+			wantImports: 0,
+			wantCalls:   0,
+			wantBreadth: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			err := os.WriteFile(filepath.Join(dir, "main.py"), []byte(tt.code), 0644)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			analyzer := NewAnalyzer()
+			result, err := analyzer.AnalyzeCoupling(context.Background(), dir, tt.importPaths)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			ca, ok := result[tt.purl]
+			if tt.wantImports == 0 && tt.wantCalls == 0 && !ok {
+				// PURL not in result at all means 0 imports/calls — expected.
+				return
+			}
+			if !ok {
+				t.Fatalf("expected coupling analysis for %s", tt.purl)
+			}
+
+			if ca.ImportFileCount != tt.wantImports {
+				t.Errorf("ImportFileCount = %d, want %d", ca.ImportFileCount, tt.wantImports)
+			}
+			if ca.CallSiteCount != tt.wantCalls {
+				t.Errorf("CallSiteCount = %d, want %d", ca.CallSiteCount, tt.wantCalls)
+			}
+			if ca.APIBreadth != tt.wantBreadth {
+				t.Errorf("APIBreadth = %d, want %d", ca.APIBreadth, tt.wantBreadth)
+			}
+			if ca.HasBlankImport != tt.wantBlankImport {
+				t.Errorf("HasBlankImport = %v, want %v", ca.HasBlankImport, tt.wantBlankImport)
+			}
+		})
+	}
+}

--- a/internal/infrastructure/treesitter/lang_python_test.go
+++ b/internal/infrastructure/treesitter/lang_python_test.go
@@ -559,6 +559,39 @@ HeaderTuple()
 			wantCalls:   1,
 			wantBreadth: 1,
 		},
+		{
+			name: "elif TYPE_CHECKING from-import skipped",
+			code: `from typing import TYPE_CHECKING
+import sys
+if sys.platform == "win32":
+    from os import path
+elif TYPE_CHECKING:
+    from hpack import HeaderTuple
+`,
+			importPaths: map[string][]string{
+				"pkg:pypi/hpack@4.0.0": {"hpack"},
+			},
+			purl:        "pkg:pypi/hpack@4.0.0",
+			wantImports: 0,
+			wantCalls:   0,
+			wantBreadth: 0,
+		},
+		{
+			name: "if not TYPE_CHECKING not skipped",
+			code: `from typing import TYPE_CHECKING
+if not TYPE_CHECKING:
+    from hpack import HeaderTuple
+
+HeaderTuple()
+`,
+			importPaths: map[string][]string{
+				"pkg:pypi/hpack@4.0.0": {"hpack"},
+			},
+			purl:        "pkg:pypi/hpack@4.0.0",
+			wantImports: 1,
+			wantCalls:   1,
+			wantBreadth: 1,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/infrastructure/treesitter/lang_python_test.go
+++ b/internal/infrastructure/treesitter/lang_python_test.go
@@ -509,6 +509,25 @@ requests.get("https://example.com")
 			wantBreadth: 1,
 		},
 		{
+			name: "nested if inside TYPE_CHECKING skipped",
+			code: `from typing import TYPE_CHECKING
+import sys
+if TYPE_CHECKING:
+    if sys.version_info >= (3, 10):
+        from hpack import HeaderTuple
+
+def foo():
+    pass
+`,
+			importPaths: map[string][]string{
+				"pkg:pypi/hpack@4.0.0": {"hpack"},
+			},
+			purl:        "pkg:pypi/hpack@4.0.0",
+			wantImports: 0,
+			wantCalls:   0,
+			wantBreadth: 0,
+		},
+		{
 			name: "if TYPE_CHECKING bare import skipped",
 			code: `from typing import TYPE_CHECKING
 if TYPE_CHECKING:

--- a/internal/infrastructure/treesitter/lang_python_test.go
+++ b/internal/infrastructure/treesitter/lang_python_test.go
@@ -541,6 +541,24 @@ if TYPE_CHECKING:
 			wantCalls:   0,
 			wantBreadth: 0,
 		},
+		{
+			name: "else branch of TYPE_CHECKING not skipped",
+			code: `from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from typing import Protocol
+else:
+    from hpack import HeaderTuple
+
+HeaderTuple()
+`,
+			importPaths: map[string][]string{
+				"pkg:pypi/hpack@4.0.0": {"hpack"},
+			},
+			purl:        "pkg:pypi/hpack@4.0.0",
+			wantImports: 1,
+			wantCalls:   1,
+			wantBreadth: 1,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- Detect Python `if TYPE_CHECKING:` guards in tree-sitter import analysis
- Skip imports inside TYPE_CHECKING blocks — they are type-only and never execute at runtime
- Prevents false IBNC for well-typed Python projects (scrapy, pydantic, FastAPI, etc.)

## Before (reproduction test output)
```
=== RUN   TestAnalyzer_PythonTypeCheckingImport
=== RUN   TestAnalyzer_PythonTypeCheckingImport/if_TYPE_CHECKING_from-import_skipped
    lang_python_test.go:551: ImportFileCount = 1, want 0
=== RUN   TestAnalyzer_PythonTypeCheckingImport/if_typing.TYPE_CHECKING_from-import_skipped
    lang_python_test.go:551: ImportFileCount = 1, want 0
=== RUN   TestAnalyzer_PythonTypeCheckingImport/mixed:_TYPE_CHECKING_import_and_normal_import
    lang_python_test.go:551: ImportFileCount = 1, want 0
=== RUN   TestAnalyzer_PythonTypeCheckingImport/normal_import_not_affected_by_TYPE_CHECKING
=== RUN   TestAnalyzer_PythonTypeCheckingImport/if_TYPE_CHECKING_bare_import_skipped
    lang_python_test.go:551: ImportFileCount = 1, want 0
--- FAIL: TestAnalyzer_PythonTypeCheckingImport (0.17s)
    --- FAIL: TestAnalyzer_PythonTypeCheckingImport/if_TYPE_CHECKING_from-import_skipped (0.04s)
    --- FAIL: TestAnalyzer_PythonTypeCheckingImport/if_typing.TYPE_CHECKING_from-import_skipped (0.03s)
    --- FAIL: TestAnalyzer_PythonTypeCheckingImport/mixed:_TYPE_CHECKING_import_and_normal_import (0.03s)
    --- PASS: TestAnalyzer_PythonTypeCheckingImport/normal_import_not_affected_by_TYPE_CHECKING (0.03s)
    --- FAIL: TestAnalyzer_PythonTypeCheckingImport/if_TYPE_CHECKING_bare_import_skipped (0.03s)
FAIL
FAIL	github.com/future-architect/uzomuzo-oss/internal/infrastructure/treesitter	0.172s
FAIL
```

## After (verification test output)
```
=== RUN   TestAnalyzer_PythonTypeCheckingImport
=== RUN   TestAnalyzer_PythonTypeCheckingImport/if_TYPE_CHECKING_from-import_skipped
=== RUN   TestAnalyzer_PythonTypeCheckingImport/if_typing.TYPE_CHECKING_from-import_skipped
=== RUN   TestAnalyzer_PythonTypeCheckingImport/mixed:_TYPE_CHECKING_import_and_normal_import
=== RUN   TestAnalyzer_PythonTypeCheckingImport/normal_import_not_affected_by_TYPE_CHECKING
=== RUN   TestAnalyzer_PythonTypeCheckingImport/if_TYPE_CHECKING_bare_import_skipped
--- PASS: TestAnalyzer_PythonTypeCheckingImport (0.16s)
    --- PASS: TestAnalyzer_PythonTypeCheckingImport/if_TYPE_CHECKING_from-import_skipped (0.04s)
    --- PASS: TestAnalyzer_PythonTypeCheckingImport/if_typing.TYPE_CHECKING_from-import_skipped (0.03s)
    --- PASS: TestAnalyzer_PythonTypeCheckingImport/mixed:_TYPE_CHECKING_import_and_normal_import (0.03s)
    --- PASS: TestAnalyzer_PythonTypeCheckingImport/normal_import_not_affected_by_TYPE_CHECKING (0.03s)
    --- PASS: TestAnalyzer_PythonTypeCheckingImport/if_TYPE_CHECKING_bare_import_skipped (0.03s)
PASS
ok  	github.com/future-architect/uzomuzo-oss/internal/infrastructure/treesitter	0.167s
```

Closes #267

## Test plan
- [x] Test `if TYPE_CHECKING:` with `from x import Y`
- [x] Test `if typing.TYPE_CHECKING:` variant
- [x] Test mixed: some imports in TYPE_CHECKING, others outside
- [x] Test normal imports unaffected
- [x] Test bare `import x` inside TYPE_CHECKING block
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)