### PR TITLE
fix: handle hyphenated and .go-suffixed Go module names in aliasFromPkg

### DIFF
--- a/.claude/rules/copilot-learned-coding.md
+++ b/.claude/rules/copilot-learned-coding.md
@@ -100,6 +100,11 @@ pending_patterns:
     pr: 276
     file: "internal/infrastructure/pypi/client.go"
     date: "2026-04-11"
+  - category: "defensive-coding"
+    summary: "In chained heuristic pipelines where each step transforms an intermediate result, fallback on empty must return the original input — not the intermediate value from a prior step — to match the documented contract"
+    pr: 281
+    file: "internal/infrastructure/treesitter/lang_go.go"
+    date: "2026-04-11"
   - category: "testing"
     summary: "When code merges results into a map that may be nil (e.g., initialized only on non-empty results), add a test where the initial map is nil and the merge path still executes — catches nil map assignment panics"
     pr: 276
@@ -259,4 +264,5 @@ pending_patterns:
   # defensive-coding (PR #227): already covered by "Validate Generated Strings Against Target-Language Syntax" — add isPythonIdentifierSafe validation for PyPI import path candidates
   # defensive-coding (PR #227 round 2): already covered by "Validate Generated Strings Against Target-Language Syntax" — validate dotted module paths (e.g., zope.interface) by splitting on "." and checking each segment independently
   # comment-doc-drift (PR #227 round 2): WONT_FIX — PR description reflects initial implementation; code and tests were updated in prior commit
+  # duplicate-parsing (PR #281): already covered by promoted "Extract Shared Helpers for Near-Duplicate Code Paths" rule — aliasFromPkg closure inconsistent with handleGoImport; extracted goAliasFromImportPath shared helper
 -->

--- a/.github/instructions/copilot-learned-coding.instructions.md
+++ b/.github/instructions/copilot-learned-coding.instructions.md
@@ -98,6 +98,11 @@ pending_patterns:
     pr: 276
     file: "internal/infrastructure/pypi/client.go"
     date: "2026-04-11"
+  - category: "defensive-coding"
+    summary: "In chained heuristic pipelines where each step transforms an intermediate result, fallback on empty must return the original input — not the intermediate value from a prior step — to match the documented contract"
+    pr: 281
+    file: "internal/infrastructure/treesitter/lang_go.go"
+    date: "2026-04-11"
   - category: "testing"
     summary: "When code merges results into a map that may be nil (e.g., initialized only on non-empty results), add a test where the initial map is nil and the merge path still executes — catches nil map assignment panics"
     pr: 276
@@ -257,4 +262,5 @@ pending_patterns:
   # defensive-coding (PR #227): already covered by "Validate Generated Strings Against Target-Language Syntax" — add isPythonIdentifierSafe validation for PyPI import path candidates
   # defensive-coding (PR #227 round 2): already covered by "Validate Generated Strings Against Target-Language Syntax" — validate dotted module paths (e.g., zope.interface) by splitting on "." and checking each segment independently
   # comment-doc-drift (PR #227 round 2): WONT_FIX — PR description reflects initial implementation; code and tests were updated in prior commit
+  # duplicate-parsing (PR #281): already covered by promoted "Extract Shared Helpers for Near-Duplicate Code Paths" rule — aliasFromPkg closure inconsistent with handleGoImport; extracted goAliasFromImportPath shared helper
 -->

--- a/internal/infrastructure/treesitter/lang_go.go
+++ b/internal/infrastructure/treesitter/lang_go.go
@@ -99,6 +99,13 @@ func (a *Analyzer) handleGoImport(
 			alias = alias[:idx]
 		}
 
+		// Handle .go suffix in module names (e.g., "miscreant.go" → "miscreant").
+		// Some Go modules use ".go" as a suffix in their repository/module name,
+		// but the actual Go package name omits the suffix.
+		if trimmed := strings.TrimSuffix(alias, ".go"); trimmed != "" && trimmed != alias {
+			alias = trimmed
+		}
+
 		// Handle hyphenated package names. Go identifiers cannot contain hyphens,
 		// so the actual package name differs from the directory name.
 		// Common conventions: "opentracing-go" → "opentracing", "go-loser" → "loser",
@@ -114,11 +121,12 @@ func (a *Analyzer) handleGoImport(
 // "go-loser", or "mmap-go" map to package names "opentracing", "loser", "mmap".
 //
 // Heuristics (applied in order, short-circuiting when no hyphens remain):
-//  1. Strip "-go" suffix (e.g., "opentracing-go" → "opentracing", "mmap-go" → "mmap")
-//  2. Strip "go-" prefix (e.g., "go-loser" → "loser", "go-spew" → "spew")
-//     Only reached if hyphens remain after step 1.
-//  3. Remove remaining hyphens (e.g., "some-pkg" → "somepkg")
+//  1. Strip "-golang" suffix (e.g., "geoip2-golang" → "geoip2")
+//  2. Strip "-go" suffix (e.g., "opentracing-go" → "opentracing", "mmap-go" → "mmap")
+//  3. Strip "go-" prefix (e.g., "go-loser" → "loser", "go-spew" → "spew")
 //     Only reached if hyphens remain after steps 1-2.
+//  4. Remove remaining hyphens (e.g., "some-pkg" → "somepkg")
+//     Only reached if hyphens remain after steps 1-3.
 //
 // If the input contains no hyphens, it is returned unchanged.
 // If a step produces an empty string (e.g., input is "-go"), the original name
@@ -128,8 +136,8 @@ func goPackageFromHyphenated(name string) string {
 		return name
 	}
 
-	// Strip "-go" suffix first (more specific).
-	result := strings.TrimSuffix(name, "-go")
+	// Strip "-golang" suffix first (most specific).
+	result := strings.TrimSuffix(name, "-golang")
 	if result == "" {
 		return name
 	}
@@ -137,8 +145,18 @@ func goPackageFromHyphenated(name string) string {
 		return result
 	}
 
-	// Strip "go-" prefix (only reached if hyphens remain after step 1).
-	trimmed := strings.TrimPrefix(result, "go-")
+	// Strip "-go" suffix (e.g., "opentracing-go" → "opentracing", "mmap-go" → "mmap").
+	trimmed := strings.TrimSuffix(result, "-go")
+	if trimmed == "" {
+		return result
+	}
+	result = trimmed
+	if !strings.Contains(result, "-") {
+		return result
+	}
+
+	// Strip "go-" prefix (only reached if hyphens remain after steps 1-2).
+	trimmed = strings.TrimPrefix(result, "go-")
 	if trimmed == "" {
 		return result
 	}

--- a/internal/infrastructure/treesitter/lang_go.go
+++ b/internal/infrastructure/treesitter/lang_go.go
@@ -18,13 +18,41 @@ func registerGoConfig(a *Analyzer) {
 			`(selector_expression operand: (identifier) @pkg field: (field_identifier) @field)`,
 			`(qualified_type package: (package_identifier) @pkg name: (type_identifier) @field)`,
 		}, "\n"),
-		stripQuotes: true,
-		aliasFromPkg: func(importPath string) string {
-			parts := strings.Split(importPath, "/")
-			return parts[len(parts)-1]
-		},
+		stripQuotes:  true,
+		aliasFromPkg: goAliasFromImportPath,
 	}
 	compileQueries(a.configs[langGo])
+}
+
+// goAliasFromImportPath derives the default Go package alias from an import path.
+// It applies Go-specific heuristics: major-version suffixes, gopkg.in version
+// suffixes, ".go" module name suffixes, and hyphenated directory names.
+func goAliasFromImportPath(importPath string) string {
+	parts := strings.Split(importPath, "/")
+	alias := parts[len(parts)-1]
+
+	// Handle major-version suffixes (e.g., "example.com/foo/v2" → "foo").
+	if len(parts) >= 2 && len(alias) >= 2 && alias[0] == 'v' && alias[1] >= '0' && alias[1] <= '9' {
+		alias = parts[len(parts)-2]
+	}
+
+	// Handle gopkg.in version suffixes (e.g., "yaml.v3" → "yaml").
+	if idx := strings.LastIndex(alias, ".v"); idx > 0 && idx+2 < len(alias) && alias[idx+2] >= '0' && alias[idx+2] <= '9' {
+		alias = alias[:idx]
+	}
+
+	// Handle .go suffix in module names (e.g., "miscreant.go" → "miscreant").
+	// Some Go modules use ".go" as a suffix in their repository/module name,
+	// but the actual Go package name omits the suffix.
+	if trimmed := strings.TrimSuffix(alias, ".go"); trimmed != "" && trimmed != alias {
+		alias = trimmed
+	}
+
+	// Handle hyphenated package names. Go identifiers cannot contain hyphens,
+	// so the actual package name differs from the directory name.
+	alias = goPackageFromHyphenated(alias)
+
+	return alias
 }
 
 // handleGoImport processes a Go import spec node.
@@ -85,32 +113,7 @@ func (a *Analyzer) handleGoImport(
 	}
 
 	if alias == "" {
-		// Default: last path component, with heuristics for Go conventions.
-		parts := strings.Split(importPath, "/")
-		alias = parts[len(parts)-1]
-
-		// Handle major-version suffixes (e.g., "example.com/foo/v2" → "foo").
-		if len(parts) >= 2 && len(alias) >= 2 && alias[0] == 'v' && alias[1] >= '0' && alias[1] <= '9' {
-			alias = parts[len(parts)-2]
-		}
-
-		// Handle gopkg.in version suffixes (e.g., "yaml.v3" → "yaml").
-		if idx := strings.LastIndex(alias, ".v"); idx > 0 && idx+2 < len(alias) && alias[idx+2] >= '0' && alias[idx+2] <= '9' {
-			alias = alias[:idx]
-		}
-
-		// Handle .go suffix in module names (e.g., "miscreant.go" → "miscreant").
-		// Some Go modules use ".go" as a suffix in their repository/module name,
-		// but the actual Go package name omits the suffix.
-		if trimmed := strings.TrimSuffix(alias, ".go"); trimmed != "" && trimmed != alias {
-			alias = trimmed
-		}
-
-		// Handle hyphenated package names. Go identifiers cannot contain hyphens,
-		// so the actual package name differs from the directory name.
-		// Common conventions: "opentracing-go" → "opentracing", "go-loser" → "loser",
-		// "go-spew" → "spew", "mmap-go" → "mmap".
-		alias = goPackageFromHyphenated(alias)
+		alias = goAliasFromImportPath(importPath)
 	}
 
 	aliasMap[alias] = appendUniquePURLs(aliasMap[alias], purls)
@@ -148,7 +151,7 @@ func goPackageFromHyphenated(name string) string {
 	// Strip "-go" suffix (e.g., "opentracing-go" → "opentracing", "mmap-go" → "mmap").
 	trimmed := strings.TrimSuffix(result, "-go")
 	if trimmed == "" {
-		return result
+		return name
 	}
 	result = trimmed
 	if !strings.Contains(result, "-") {
@@ -158,7 +161,7 @@ func goPackageFromHyphenated(name string) string {
 	// Strip "go-" prefix (only reached if hyphens remain after steps 1-2).
 	trimmed = strings.TrimPrefix(result, "go-")
 	if trimmed == "" {
-		return result
+		return name
 	}
 	result = trimmed
 	if !strings.Contains(result, "-") {

--- a/internal/infrastructure/treesitter/lang_go_test.go
+++ b/internal/infrastructure/treesitter/lang_go_test.go
@@ -694,6 +694,88 @@ func create() bar.MyType { return bar.MyType{} }
 	}
 }
 
+func TestAnalyzer_GoSuffixedModuleNames(t *testing.T) {
+	tests := []struct {
+		name        string
+		code        string
+		importPaths map[string][]string
+		purl        string
+		wantImports int
+		wantCalls   int
+		wantBreadth int
+	}{
+		{
+			name: ".go suffix stripped (miscreant.go)",
+			code: `package main
+
+import "github.com/miscreant/miscreant.go"
+
+func main() {
+	miscreant.NewAEAD("AES-SIV", nil)
+	miscreant.NewAEAD("AES-PMAC-SIV", nil)
+}
+`,
+			importPaths: map[string][]string{
+				"pkg:golang/github.com/miscreant/miscreant.go@v0.3.0": {"github.com/miscreant/miscreant.go"},
+			},
+			purl:        "pkg:golang/github.com/miscreant/miscreant.go@v0.3.0",
+			wantImports: 1,
+			wantCalls:   2,
+			wantBreadth: 1,
+		},
+		{
+			name: "-golang suffix stripped (geoip2-golang)",
+			code: `package main
+
+import "github.com/oschwald/geoip2-golang"
+
+func main() {
+	geoip2.Open("test.mmdb")
+	geoip2.FromBytes(nil)
+	geoip2.Open("test2.mmdb")
+}
+`,
+			importPaths: map[string][]string{
+				"pkg:golang/github.com/oschwald/geoip2-golang@v1.9.0": {"github.com/oschwald/geoip2-golang"},
+			},
+			purl:        "pkg:golang/github.com/oschwald/geoip2-golang@v1.9.0",
+			wantImports: 1,
+			wantCalls:   3,
+			wantBreadth: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte(tt.code), 0644); err != nil {
+				t.Fatal(err)
+			}
+
+			analyzer := NewAnalyzer()
+			result, err := analyzer.AnalyzeCoupling(context.Background(), dir, tt.importPaths)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			ca, ok := result[tt.purl]
+			if !ok {
+				t.Fatalf("expected coupling analysis for %s", tt.purl)
+			}
+
+			if ca.ImportFileCount != tt.wantImports {
+				t.Errorf("ImportFileCount = %d, want %d", ca.ImportFileCount, tt.wantImports)
+			}
+			if ca.CallSiteCount != tt.wantCalls {
+				t.Errorf("CallSiteCount = %d, want %d", ca.CallSiteCount, tt.wantCalls)
+			}
+			if ca.APIBreadth != tt.wantBreadth {
+				t.Errorf("APIBreadth = %d, want %d", ca.APIBreadth, tt.wantBreadth)
+			}
+		})
+	}
+}
+
 func TestGoPackageFromHyphenated(t *testing.T) {
 	tests := []struct {
 		input string
@@ -709,6 +791,9 @@ func TestGoPackageFromHyphenated(t *testing.T) {
 		{"proto-go-sql", "protogosql"},
 		{"go-foo-go", "foo"},
 		{"testify", "testify"},
+		{"geoip2-golang", "geoip2"},
+		{"maxminddb-golang", "maxminddb"},
+		{"foo-golang", "foo"},
 	}
 
 	for _, tt := range tests {

--- a/internal/infrastructure/treesitter/lang_go_test.go
+++ b/internal/infrastructure/treesitter/lang_go_test.go
@@ -776,6 +776,31 @@ func main() {
 	}
 }
 
+func TestGoAliasFromImportPath(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"github.com/miscreant/miscreant.go", "miscreant"},             // .go suffix stripped
+		{"github.com/oschwald/geoip2-golang", "geoip2"},               // -golang suffix stripped
+		{"github.com/stretchr/testify", "testify"},                     // normal path
+		{"example.com/foo/v2", "foo"},                                  // major version peeled
+		{"gopkg.in/yaml.v3", "yaml"},                                   // gopkg.in version stripped
+		{"gopkg.in/foo.go.v2", "foo"},                                  // gopkg.in + .go suffix
+		{"github.com/go-redis/redis/v9", "redis"},                      // major version + go- prefix
+		{"github.com/opentracing/opentracing-go", "opentracing"},       // -go suffix stripped
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := goAliasFromImportPath(tt.input)
+			if got != tt.want {
+				t.Errorf("goAliasFromImportPath(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestGoPackageFromHyphenated(t *testing.T) {
 	tests := []struct {
 		input string
@@ -798,8 +823,9 @@ func TestGoPackageFromHyphenated(t *testing.T) {
 		{"-go", "-go"},             // empty after strip; guard preserves original
 		{"go-", "go-"},             // empty after prefix strip; guard preserves original
 		{"go-golang", "go"},        // strip -golang -> "go" (no hyphens)
-		{"go-redis", "redis"},      // real package: prefix go- stripped
-		{"go-sqlite3", "sqlite3"},  // real package: prefix go- stripped
+		{"go-redis", "redis"},          // real package: prefix go- stripped
+		{"go-sqlite3", "sqlite3"},      // real package: prefix go- stripped
+		{"foo-bar-golang", "foobar"},   // -golang stripped, remaining hyphen removed
 	}
 
 	for _, tt := range tests {

--- a/internal/infrastructure/treesitter/lang_go_test.go
+++ b/internal/infrastructure/treesitter/lang_go_test.go
@@ -794,6 +794,12 @@ func TestGoPackageFromHyphenated(t *testing.T) {
 		{"geoip2-golang", "geoip2"},
 		{"maxminddb-golang", "maxminddb"},
 		{"foo-golang", "foo"},
+		{"-golang", "-golang"},     // empty after strip; guard preserves original
+		{"-go", "-go"},             // empty after strip; guard preserves original
+		{"go-", "go-"},             // empty after prefix strip; guard preserves original
+		{"go-golang", "go"},        // strip -golang -> "go" (no hyphens)
+		{"go-redis", "redis"},      // real package: prefix go- stripped
+		{"go-sqlite3", "sqlite3"},  // real package: prefix go- stripped
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- Fix `aliasFromPkg` to strip `.go` suffix from module path last segments (e.g., `miscreant.go` -> `miscreant`)
- Fix `goPackageFromHyphenated` to strip `-golang` suffix (e.g., `geoip2-golang` -> `geoip2`)
- Fixes false IBNC (imported-but-not-called) for packages like `miscreant.go` and `geoip2-golang`

## Before (reproduction test output)
```
=== RUN   TestAnalyzer_GoSuffixedModuleNames
=== RUN   TestAnalyzer_GoSuffixedModuleNames/.go_suffix_stripped_(miscreant.go)
    lang_go_test.go:770: CallSiteCount = 0, want 2
    lang_go_test.go:773: APIBreadth = 0, want 1
=== RUN   TestAnalyzer_GoSuffixedModuleNames/-golang_suffix_stripped_(geoip2-golang)
    lang_go_test.go:770: CallSiteCount = 0, want 3
    lang_go_test.go:773: APIBreadth = 0, want 2
--- FAIL: TestAnalyzer_GoSuffixedModuleNames (0.07s)
    --- FAIL: TestAnalyzer_GoSuffixedModuleNames/.go_suffix_stripped_(miscreant.go) (0.04s)
    --- FAIL: TestAnalyzer_GoSuffixedModuleNames/-golang_suffix_stripped_(geoip2-golang) (0.03s)
FAIL
```

## After (verification test output)
```
=== RUN   TestAnalyzer_GoSuffixedModuleNames
=== RUN   TestAnalyzer_GoSuffixedModuleNames/.go_suffix_stripped_(miscreant.go)
=== RUN   TestAnalyzer_GoSuffixedModuleNames/-golang_suffix_stripped_(geoip2-golang)
--- PASS: TestAnalyzer_GoSuffixedModuleNames (0.07s)
    --- PASS: TestAnalyzer_GoSuffixedModuleNames/.go_suffix_stripped_(miscreant.go) (0.04s)
    --- PASS: TestAnalyzer_GoSuffixedModuleNames/-golang_suffix_stripped_(geoip2-golang) (0.03s)
PASS
```

Closes #266

## Test plan
- [x] Test `.go` suffix stripping (`miscreant.go` -> `miscreant`)
- [x] Test `-golang` suffix stripping (`geoip2-golang` -> `geoip2`)
- [x] Test `-go` suffix stripping still works
- [x] Test normal module names unaffected
- [x] Unit tests for `goPackageFromHyphenated` with new cases
- [x] All existing treesitter tests pass (51 tests)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)