### PR TITLE
test: add comprehensive import type exclusion tests for #268

### DIFF
--- a/.claude/rules/copilot-learned-coding.md
+++ b/.claude/rules/copilot-learned-coding.md
@@ -105,6 +105,11 @@ pending_patterns:
     pr: 276
     file: "internal/application/diet/service_test.go"
     date: "2026-04-11"
+  - category: "testing"
+    summary: "When a test asserts wantNoResult for one item in a multi-item input set, also assert that sibling items produce expected coupling — otherwise a regression that drops all items passes silently"
+    pr: 282
+    file: "internal/infrastructure/treesitter/lang_javascript_test.go"
+    date: "2026-04-11"
   - category: "security"
     summary: "Validate URL host non-empty alongside scheme check — hostless URLs like https:///path pass scheme validation but fail later in uncontrolled ways"
     pr: 276

--- a/.github/instructions/copilot-learned-coding.instructions.md
+++ b/.github/instructions/copilot-learned-coding.instructions.md
@@ -103,6 +103,11 @@ pending_patterns:
     pr: 276
     file: "internal/application/diet/service_test.go"
     date: "2026-04-11"
+  - category: "testing"
+    summary: "When a test asserts wantNoResult for one item in a multi-item input set, also assert that sibling items produce expected coupling — otherwise a regression that drops all items passes silently"
+    pr: 282
+    file: "internal/infrastructure/treesitter/lang_javascript_test.go"
+    date: "2026-04-11"
   - category: "security"
     summary: "Validate URL host non-empty alongside scheme check — hostless URLs like https:///path pass scheme validation but fail later in uncontrolled ways"
     pr: 276

--- a/internal/infrastructure/treesitter/lang_javascript_test.go
+++ b/internal/infrastructure/treesitter/lang_javascript_test.go
@@ -886,6 +886,18 @@ bar();
 					t.Errorf("expected no coupling for type-only import, got ImportFileCount=%d CallSiteCount=%d",
 						ca.ImportFileCount, ca.CallSiteCount)
 				}
+
+				// Verify that other (runtime) imports in the same file still produce coupling.
+				for purl := range tt.importPaths {
+					if purl == tt.purlToCheck {
+						continue
+					}
+					if rca, rok := result[purl]; !rok {
+						t.Errorf("expected coupling for runtime import %s, got no result", purl)
+					} else if rca.ImportFileCount == 0 {
+						t.Errorf("expected ImportFileCount > 0 for runtime import %s, got 0", purl)
+					}
+				}
 				return
 			}
 

--- a/internal/infrastructure/treesitter/lang_javascript_test.go
+++ b/internal/infrastructure/treesitter/lang_javascript_test.go
@@ -748,30 +748,158 @@ func TestAnalyzer_TypeScriptSideEffectImport(t *testing.T) {
 	}
 }
 
-// TestAnalyzer_TypeScriptTypeOnlyImportExclusion verifies that `import type { ... }`
-// in a .ts file (not just .tsx) is excluded from coupling analysis.
-func TestAnalyzer_TypeScriptTypeOnlyImportExclusion(t *testing.T) {
-	dir := t.TempDir()
-	err := os.WriteFile(filepath.Join(dir, "types.ts"), []byte(`import type { Foo, Bar } from "some-lib";
+// TestAnalyzer_TypeScriptImportTypeExclusion verifies that all forms of TypeScript
+// `import type` statements are excluded from coupling analysis. Type-only imports
+// are erased at compile time and produce no runtime code, so counting them inflates
+// IBNC (imports-but-no-calls). Closes #268.
+func TestAnalyzer_TypeScriptImportTypeExclusion(t *testing.T) {
+	tests := []struct {
+		name            string
+		filename        string
+		code            string
+		importPaths     map[string][]string
+		purlToCheck     string
+		wantNoResult    bool // true if we expect no coupling result
+		wantImportFiles int
+		wantCallSites   int
+	}{
+		{
+			name:     "import type with named imports excluded",
+			filename: "types.ts",
+			code: `import type { Foo, Bar } from "some-lib";
 
-// Type-only import — no runtime coupling.
 const x: Foo = {} as any;
-`), 0644)
-	if err != nil {
-		t.Fatal(err)
+`,
+			importPaths: map[string][]string{
+				"pkg:npm/some-lib@1.0.0": {"some-lib"},
+			},
+			purlToCheck:  "pkg:npm/some-lib@1.0.0",
+			wantNoResult: true,
+		},
+		{
+			// Exact pattern from strapi: import type { Core, UID } from '@strapi/types'
+			name:     "import type scoped package excluded (strapi pattern)",
+			filename: "register.ts",
+			code: `import type { Core, UID } from "@strapi/types";
+
+// Type-only — no runtime coupling
+`,
+			importPaths: map[string][]string{
+				"pkg:npm/%40strapi/types@1.0.0": {"@strapi/types"},
+			},
+			purlToCheck:  "pkg:npm/%40strapi/types@1.0.0",
+			wantNoResult: true,
+		},
+		{
+			name:     "import type default import excluded",
+			filename: "types.ts",
+			code: `import type Foo from "some-lib";
+
+const x: Foo = {} as any;
+`,
+			importPaths: map[string][]string{
+				"pkg:npm/some-lib@1.0.0": {"some-lib"},
+			},
+			purlToCheck:  "pkg:npm/some-lib@1.0.0",
+			wantNoResult: true,
+		},
+		{
+			// Empty type import used for module augmentation
+			name:     "import type empty braces excluded",
+			filename: "augment.ts",
+			code: `import type {} from "@strapi/types";
+`,
+			importPaths: map[string][]string{
+				"pkg:npm/%40strapi/types@1.0.0": {"@strapi/types"},
+			},
+			purlToCheck:  "pkg:npm/%40strapi/types@1.0.0",
+			wantNoResult: true,
+		},
+		{
+			// Mixed import: `import { type X, Y }` has a runtime binding Y,
+			// so the import should still count.
+			name:     "mixed import with inline type specifier still counted",
+			filename: "app.ts",
+			code: `import { type Config, createApp } from "some-framework";
+
+createApp();
+`,
+			importPaths: map[string][]string{
+				"pkg:npm/some-framework@1.0.0": {"some-framework"},
+			},
+			purlToCheck:     "pkg:npm/some-framework@1.0.0",
+			wantNoResult:    false,
+			wantImportFiles: 1,
+			wantCallSites:   1,
+		},
+		{
+			name:     "regular named import unaffected",
+			filename: "app.ts",
+			code: `import { useState } from "react";
+
+useState(0);
+`,
+			importPaths: map[string][]string{
+				"pkg:npm/react@18.0.0": {"react"},
+			},
+			purlToCheck:     "pkg:npm/react@18.0.0",
+			wantNoResult:    false,
+			wantImportFiles: 1,
+			wantCallSites:   1,
+		},
+		{
+			// Type-only and regular import of different packages in the same file.
+			// Only the runtime import should produce coupling.
+			name:     "type-only and regular import coexist in same file",
+			filename: "mixed.ts",
+			code: `import type { Foo } from "type-only-pkg";
+import { bar } from "runtime-pkg";
+
+bar();
+`,
+			importPaths: map[string][]string{
+				"pkg:npm/type-only-pkg@1.0.0": {"type-only-pkg"},
+				"pkg:npm/runtime-pkg@1.0.0":   {"runtime-pkg"},
+			},
+			purlToCheck:  "pkg:npm/type-only-pkg@1.0.0",
+			wantNoResult: true,
+		},
 	}
 
-	analyzer := NewAnalyzer()
-	importPaths := map[string][]string{
-		"pkg:npm/some-lib@1.0.0": {"some-lib"},
-	}
-	result, err := analyzer.AnalyzeCoupling(context.Background(), dir, importPaths)
-	if err != nil {
-		t.Fatal(err)
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			err := os.WriteFile(filepath.Join(dir, tt.filename), []byte(tt.code), 0644)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	if len(result) != 0 {
-		t.Errorf("expected no coupling for type-only import in .ts file, got %d results", len(result))
+			analyzer := NewAnalyzer()
+			result, err := analyzer.AnalyzeCoupling(context.Background(), dir, tt.importPaths)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if tt.wantNoResult {
+				ca, ok := result[tt.purlToCheck]
+				if ok {
+					t.Errorf("expected no coupling for type-only import, got ImportFileCount=%d CallSiteCount=%d",
+						ca.ImportFileCount, ca.CallSiteCount)
+				}
+				return
+			}
+
+			ca, ok := result[tt.purlToCheck]
+			if !ok {
+				t.Fatalf("expected coupling analysis for %s", tt.purlToCheck)
+			}
+			if ca.ImportFileCount != tt.wantImportFiles {
+				t.Errorf("ImportFileCount = %d, want %d", ca.ImportFileCount, tt.wantImportFiles)
+			}
+			if ca.CallSiteCount != tt.wantCallSites {
+				t.Errorf("CallSiteCount = %d, want %d", ca.CallSiteCount, tt.wantCallSites)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- Expand test coverage for TypeScript `import type` exclusion to cover all edge cases from issue #268
- The implementation (`isTypeOnlyImport` + `extractImports` check in `analyzer.go`) was already correct
- This PR adds missing regression test coverage for: scoped packages (strapi pattern), default type imports, empty type braces for module augmentation, mixed inline type specifiers, regular imports unaffected, and coexisting type-only/runtime imports in the same file

## Context
The `isTypeOnlyImport` function and its integration in `extractImports` (lines 366-371 of `analyzer.go`) were added during the treesitter refactoring. The previous test only covered the basic `import type { Foo, Bar } from "pkg"` case. This PR replaces that single-case test with a comprehensive table-driven test covering 7 edge cases identified in issue #268.

## Test output
```
=== RUN   TestAnalyzer_TypeScriptImportTypeExclusion
=== RUN   TestAnalyzer_TypeScriptImportTypeExclusion/import_type_with_named_imports_excluded
=== RUN   TestAnalyzer_TypeScriptImportTypeExclusion/import_type_scoped_package_excluded_(strapi_pattern)
=== RUN   TestAnalyzer_TypeScriptImportTypeExclusion/import_type_default_import_excluded
=== RUN   TestAnalyzer_TypeScriptImportTypeExclusion/import_type_empty_braces_excluded
=== RUN   TestAnalyzer_TypeScriptImportTypeExclusion/mixed_import_with_inline_type_specifier_still_counted
=== RUN   TestAnalyzer_TypeScriptImportTypeExclusion/regular_named_import_unaffected
=== RUN   TestAnalyzer_TypeScriptImportTypeExclusion/type-only_and_regular_import_coexist_in_same_file
--- PASS: TestAnalyzer_TypeScriptImportTypeExclusion (0.31s)
    --- PASS: TestAnalyzer_TypeScriptImportTypeExclusion/import_type_with_named_imports_excluded (0.05s)
    --- PASS: TestAnalyzer_TypeScriptImportTypeExclusion/import_type_scoped_package_excluded_(strapi_pattern) (0.04s)
    --- PASS: TestAnalyzer_TypeScriptImportTypeExclusion/import_type_default_import_excluded (0.06s)
    --- PASS: TestAnalyzer_TypeScriptImportTypeExclusion/import_type_empty_braces_excluded (0.05s)
    --- PASS: TestAnalyzer_TypeScriptImportTypeExclusion/mixed_import_with_inline_type_specifier_still_counted (0.04s)
    --- PASS: TestAnalyzer_TypeScriptImportTypeExclusion/regular_named_import_unaffected (0.04s)
    --- PASS: TestAnalyzer_TypeScriptImportTypeExclusion/type-only_and_regular_import_coexist_in_same_file (0.03s)
PASS
```

Closes #268

## Test plan
- [x] Test `import type { X } from 'pkg'` excluded
- [x] Test `import type { Core, UID } from '@strapi/types'` excluded (exact strapi pattern)
- [x] Test `import type X from 'pkg'` (default type import) excluded
- [x] Test `import type {} from 'pkg'` (empty type import for module augmentation) excluded
- [x] Test mixed `import { type X, Y } from 'pkg'` still counted (has runtime binding Y)
- [x] Test regular `import { X } from 'pkg'` still counted
- [x] Test type-only and regular imports of different packages coexist correctly
- [x] go vet passes
- [x] golangci-lint passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)