### PR TITLE
fix: extract bindings from CommonJS destructured require patterns

### DIFF
--- a/internal/infrastructure/treesitter/lang_javascript.go
+++ b/internal/infrastructure/treesitter/lang_javascript.go
@@ -162,8 +162,15 @@ func extractJSBindings(node *sitter.Node, src []byte) []string {
 			declarator := findAncestorVariableDeclarator(callExpr)
 			if declarator != nil {
 				nameNode := declarator.ChildByFieldName("name")
-				if nameNode != nil && nameNode.Type() == "identifier" {
+				if nameNode == nil {
+					return nil
+				}
+				switch nameNode.Type() {
+				case "identifier":
 					return []string{nameNode.Content(src)}
+				case "object_pattern":
+					// Destructured: const { X, Y } = require('pkg')
+					return extractCJSDestructuredBindings(nameNode, src)
 				}
 			}
 		}
@@ -305,6 +312,35 @@ func extractNamedImportBindings(namedImports *sitter.Node, src []byte) []string 
 		nameNode := spec.ChildByFieldName("name")
 		if nameNode != nil {
 			bindings = append(bindings, nameNode.Content(src))
+		}
+	}
+	return bindings
+}
+
+// extractCJSDestructuredBindings extracts binding names from a CJS destructured
+// require pattern. For `const { foo, bar: baz } = require("pkg")`, the AST has
+// an object_pattern with children:
+//   - shorthand_property_identifier_pattern for `{ foo }` (name == foo, local binding == foo)
+//   - pair_pattern for `{ bar: baz }` (key == bar, value == baz, local binding == baz)
+//
+// This mirrors extractNamedImportBindings for ESM named imports.
+func extractCJSDestructuredBindings(objectPattern *sitter.Node, src []byte) []string {
+	var bindings []string
+	for i := 0; i < int(objectPattern.ChildCount()); i++ {
+		child := objectPattern.Child(i)
+		if child == nil {
+			continue
+		}
+		switch child.Type() {
+		case "shorthand_property_identifier_pattern":
+			// { X } — the identifier itself is the local binding.
+			bindings = append(bindings, child.Content(src))
+		case "pair_pattern":
+			// { X: alias } — the value side is the local binding.
+			valueNode := child.ChildByFieldName("value")
+			if valueNode != nil && valueNode.Type() == "identifier" {
+				bindings = append(bindings, valueNode.Content(src))
+			}
 		}
 	}
 	return bindings

--- a/internal/infrastructure/treesitter/lang_javascript_test.go
+++ b/internal/infrastructure/treesitter/lang_javascript_test.go
@@ -775,6 +775,131 @@ const x: Foo = {} as any;
 	}
 }
 
+func TestAnalyzer_CJSDestructuredRequire(t *testing.T) {
+	tests := []struct {
+		name        string
+		filename    string
+		code        string
+		importPaths map[string][]string
+		purl        string
+		wantImports int
+		wantCalls   int
+		wantBreadth int
+		wantSymbols []string
+	}{
+		{
+			name:     "shorthand destructuring: const { X } = require('pkg')",
+			filename: "index.js",
+			code: `const { RawSource, ConcatSource } = require("webpack-sources");
+
+const x = new RawSource("hello");
+`,
+			importPaths: map[string][]string{
+				"pkg:npm/webpack-sources@3.0.0": {"webpack-sources"},
+			},
+			purl:        "pkg:npm/webpack-sources@3.0.0",
+			wantImports: 1,
+			wantCalls:   1,
+			wantBreadth: 1,
+			wantSymbols: []string{"RawSource"},
+		},
+		{
+			name:     "renamed destructuring: const { X: alias } = require('pkg')",
+			filename: "index.js",
+			code: `const { Tapable: tap } = require("tapable");
+
+tap.init();
+tap.run();
+`,
+			importPaths: map[string][]string{
+				"pkg:npm/tapable@2.0.0": {"tapable"},
+			},
+			purl:        "pkg:npm/tapable@2.0.0",
+			wantImports: 1,
+			wantCalls:   2,
+			wantBreadth: 2,
+			wantSymbols: []string{"init", "run"},
+		},
+		{
+			name:     "multiple destructured bindings with usage",
+			filename: "index.js",
+			code: `const { join, resolve, basename } = require("path");
+
+const p = join("a", "b");
+const abs = resolve(".");
+const name = basename("/foo/bar.txt");
+`,
+			importPaths: map[string][]string{
+				"pkg:npm/path@1.0.0": {"path"},
+			},
+			purl:        "pkg:npm/path@1.0.0",
+			wantImports: 1,
+			wantCalls:   3,
+			wantBreadth: 3,
+			wantSymbols: []string{"basename", "join", "resolve"},
+		},
+		{
+			name:     "simple CJS require still works alongside destructured",
+			filename: "index.js",
+			code: `const axios = require("axios");
+
+axios.get("https://example.com");
+axios.post("https://example.com");
+`,
+			importPaths: map[string][]string{
+				"pkg:npm/axios@1.6.0": {"axios"},
+			},
+			purl:        "pkg:npm/axios@1.6.0",
+			wantImports: 1,
+			wantCalls:   2,
+			wantBreadth: 2,
+			wantSymbols: []string{"get", "post"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			err := os.WriteFile(filepath.Join(dir, tt.filename), []byte(tt.code), 0644)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			analyzer := NewAnalyzer()
+			result, err := analyzer.AnalyzeCoupling(context.Background(), dir, tt.importPaths)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			ca, ok := result[tt.purl]
+			if !ok {
+				t.Fatalf("expected coupling analysis for %s", tt.purl)
+			}
+
+			if ca.ImportFileCount != tt.wantImports {
+				t.Errorf("ImportFileCount = %d, want %d", ca.ImportFileCount, tt.wantImports)
+			}
+			if ca.CallSiteCount != tt.wantCalls {
+				t.Errorf("CallSiteCount = %d, want %d", ca.CallSiteCount, tt.wantCalls)
+			}
+			if ca.APIBreadth != tt.wantBreadth {
+				t.Errorf("APIBreadth = %d, want %d", ca.APIBreadth, tt.wantBreadth)
+			}
+
+			sort.Strings(tt.wantSymbols)
+			if len(ca.Symbols) != len(tt.wantSymbols) {
+				t.Errorf("Symbols = %v, want %v", ca.Symbols, tt.wantSymbols)
+			} else {
+				for i, s := range ca.Symbols {
+					if s != tt.wantSymbols[i] {
+						t.Errorf("Symbols[%d] = %q, want %q", i, s, tt.wantSymbols[i])
+					}
+				}
+			}
+		})
+	}
+}
+
 func TestAnalyzer_JSInlineRequireCallSites(t *testing.T) {
 	tests := []struct {
 		name         string


### PR DESCRIPTION
## Summary
- Add `object_pattern` handling to CJS `require()` binding extraction in the tree-sitter JS analyzer
- Destructured `const { X, Y } = require('pkg')` now correctly extracts named bindings (shorthand and renamed)
- Fixes false IBNC for webpack (webpack-sources, tapable), npm/cli, and other CJS-heavy projects

## Before (reproduction test output)
```
=== RUN   TestAnalyzer_CJSDestructuredRequire
=== RUN   TestAnalyzer_CJSDestructuredRequire/shorthand_destructuring:_const_{_X_}_=_require('pkg')
    lang_javascript_test.go:883: CallSiteCount = 0, want 1
    lang_javascript_test.go:886: APIBreadth = 0, want 1
    lang_javascript_test.go:891: Symbols = [], want [RawSource]
=== RUN   TestAnalyzer_CJSDestructuredRequire/renamed_destructuring:_const_{_X:_alias_}_=_require('pkg')
    lang_javascript_test.go:883: CallSiteCount = 0, want 2
    lang_javascript_test.go:886: APIBreadth = 0, want 2
    lang_javascript_test.go:891: Symbols = [], want [init run]
=== RUN   TestAnalyzer_CJSDestructuredRequire/multiple_destructured_bindings_with_usage
    lang_javascript_test.go:883: CallSiteCount = 0, want 3
    lang_javascript_test.go:886: APIBreadth = 0, want 3
    lang_javascript_test.go:891: Symbols = [], want [basename join resolve]
=== RUN   TestAnalyzer_CJSDestructuredRequire/simple_CJS_require_still_works_alongside_destructured
--- FAIL: TestAnalyzer_CJSDestructuredRequire (0.14s)
    --- FAIL: TestAnalyzer_CJSDestructuredRequire/shorthand_destructuring:_const_{_X_}_=_require('pkg') (0.04s)
    --- FAIL: TestAnalyzer_CJSDestructuredRequire/renamed_destructuring:_const_{_X:_alias_}_=_require('pkg') (0.03s)
    --- FAIL: TestAnalyzer_CJSDestructuredRequire/multiple_destructured_bindings_with_usage (0.03s)
    --- PASS: TestAnalyzer_CJSDestructuredRequire/simple_CJS_require_still_works_alongside_destructured (0.03s)
FAIL
```

## After (verification test output)
```
=== RUN   TestAnalyzer_CJSDestructuredRequire
=== RUN   TestAnalyzer_CJSDestructuredRequire/shorthand_destructuring:_const_{_X_}_=_require('pkg')
=== RUN   TestAnalyzer_CJSDestructuredRequire/renamed_destructuring:_const_{_X:_alias_}_=_require('pkg')
=== RUN   TestAnalyzer_CJSDestructuredRequire/multiple_destructured_bindings_with_usage
=== RUN   TestAnalyzer_CJSDestructuredRequire/simple_CJS_require_still_works_alongside_destructured
--- PASS: TestAnalyzer_CJSDestructuredRequire (0.23s)
    --- PASS: TestAnalyzer_CJSDestructuredRequire/shorthand_destructuring:_const_{_X_}_=_require('pkg') (0.08s)
    --- PASS: TestAnalyzer_CJSDestructuredRequire/renamed_destructuring:_const_{_X:_alias_}_=_require('pkg') (0.06s)
    --- PASS: TestAnalyzer_CJSDestructuredRequire/multiple_destructured_bindings_with_usage (0.05s)
    --- PASS: TestAnalyzer_CJSDestructuredRequire/simple_CJS_require_still_works_alongside_destructured (0.04s)
PASS
```

Closes #274

## Test plan
- [x] Test `const { X } = require('pkg')` -- shorthand destructuring
- [x] Test `const { X: alias } = require('pkg')` -- renamed destructuring
- [x] Test `const { X, Y, Z } = require('pkg')` -- multiple bindings
- [x] Test existing `const X = require('pkg')` still works (regression guard)
- [x] Full treesitter test suite passes (46 tests)
- [x] `go vet ./...` clean
- [x] `golangci-lint run` clean (0 issues)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)