### PR TITLE
fix: side-effect import scoring gap and bare identifier IBNC detection

### DIFF
--- a/.claude/rules/copilot-learned-coding.md
+++ b/.claude/rules/copilot-learned-coding.md
@@ -265,4 +265,5 @@ pending_patterns:
   # comment-doc-drift (PR #283): already covered by "Comment-Code Consistency" rule — test comment incorrectly attributed scoped constructor match to method_invocation pattern
   # testing (PR #283): already covered by "Cover New Control Flow Branches with Tests" and "Verify Tree-Sitter Query Patterns Do Not Overlap" — each tree-sitter query pattern variant (generic vs non-generic scoped constructor) needs its own test case
   # comment-doc-drift (PR #283 round 4): already covered by "Comment-Code Consistency" rule — scoped constructor comment described 2-capture positional behavior but queries only have a single @func capture
+  # comment-doc-drift (PR #285): already covered by "Comment-Code Consistency" rule — HasBlankImport comments/docs said "no callable API" but flag covers broader patterns (Python feature-detection) that may have callable APIs; aliasMap comment claimed safety without noting lack of scope resolution
 -->

--- a/.github/instructions/copilot-learned-coding.instructions.md
+++ b/.github/instructions/copilot-learned-coding.instructions.md
@@ -263,4 +263,5 @@ pending_patterns:
   # comment-doc-drift (PR #283): already covered by "Comment-Code Consistency" rule — test comment incorrectly attributed scoped constructor match to method_invocation pattern
   # testing (PR #283): already covered by "Cover New Control Flow Branches with Tests" and "Verify Tree-Sitter Query Patterns Do Not Overlap" — each tree-sitter query pattern variant (generic vs non-generic scoped constructor) needs its own test case
   # comment-doc-drift (PR #283 round 4): already covered by "Comment-Code Consistency" rule — scoped constructor comment described 2-capture positional behavior but queries only have a single @func capture
+  # comment-doc-drift (PR #285): already covered by "Comment-Code Consistency" rule — HasBlankImport comments/docs said "no callable API" but flag covers broader patterns (Python feature-detection) that may have callable APIs; aliasMap comment claimed safety without noting lack of scope resolution
 -->

--- a/internal/domain/diet/scoring.go
+++ b/internal/domain/diet/scoring.go
@@ -139,12 +139,14 @@ func normalizeCouplingEffort(c CouplingAnalysis) float64 {
 	if c.IsUnused {
 		return 0.0
 	}
-	// Side-effect-only imports (Go blank imports, JS bare imports, CJS bare
-	// require) have no callable API — their coupling effort is zero. The
-	// baseline CallSiteCount=1 from the analyzer marks them as "used" but
+	// Imports with no attributed symbol usage in the file (for example Go
+	// blank imports, JS/CJS side-effect imports, or Python feature-detection
+	// imports) should contribute zero coupling effort. The dependency may
+	// expose an API, but this file does not reference it. The baseline
+	// CallSiteCount=1 from the analyzer marks these imports as "used" but
 	// should not inflate the coupling score. Without this guard, the
 	// logistic on ImportFileCount produces a small but misleading non-zero
-	// effort that misclassifies side-effect deps as "easy" instead of "trivial".
+	// effort that misclassifies these deps as "easy" instead of "trivial".
 	if c.HasBlankImport && c.CallSiteCount <= 1 && c.APIBreadth == 0 {
 		return 0.0
 	}

--- a/internal/domain/diet/scoring.go
+++ b/internal/domain/diet/scoring.go
@@ -139,6 +139,15 @@ func normalizeCouplingEffort(c CouplingAnalysis) float64 {
 	if c.IsUnused {
 		return 0.0
 	}
+	// Side-effect-only imports (Go blank imports, JS bare imports, CJS bare
+	// require) have no callable API — their coupling effort is zero. The
+	// baseline CallSiteCount=1 from the analyzer marks them as "used" but
+	// should not inflate the coupling score. Without this guard, the
+	// logistic on ImportFileCount produces a small but misleading non-zero
+	// effort that misclassifies side-effect deps as "easy" instead of "trivial".
+	if c.HasBlankImport && c.CallSiteCount <= 1 && c.APIBreadth == 0 {
+		return 0.0
+	}
 	// When all coupling counts are zero and IsUnused is false, no coupling
 	// data is available, typically because source analysis was not performed.
 	// Treat this as zero effort so that the difficulty label ("trivial") is

--- a/internal/domain/diet/scoring_test.go
+++ b/internal/domain/diet/scoring_test.go
@@ -415,8 +415,8 @@ func TestComputeImpactScore_LifecycleScoreFloor(t *testing.T) {
 func TestNormalizeCouplingEffort_BlankImportSideEffect(t *testing.T) {
 	// Regression test for #261: side-effect-only imports (Go blank import,
 	// JS bare import, CJS bare require) should produce zero coupling effort.
-	// Before the fix, ImportFileCount > 0 caused non-zero effort even though
-	// the dependency has no callable API (CallSiteCount=0, APIBreadth=0).
+	// Before the fix, ImportFileCount > 0 caused non-zero effort even when
+	// there were no attributed API symbols/breadth for the dependency.
 	tests := []struct {
 		name        string
 		c           CouplingAnalysis

--- a/internal/domain/diet/scoring_test.go
+++ b/internal/domain/diet/scoring_test.go
@@ -412,6 +412,72 @@ func TestComputeImpactScore_LifecycleScoreFloor(t *testing.T) {
 	}
 }
 
+func TestNormalizeCouplingEffort_BlankImportSideEffect(t *testing.T) {
+	// Regression test for #261: side-effect-only imports (Go blank import,
+	// JS bare import, CJS bare require) should produce zero coupling effort.
+	// Before the fix, ImportFileCount > 0 caused non-zero effort even though
+	// the dependency has no callable API (CallSiteCount=0, APIBreadth=0).
+	tests := []struct {
+		name string
+		c    CouplingAnalysis
+		want float64
+	}{
+		{
+			name: "Go blank import: side-effect only, no calls",
+			c: CouplingAnalysis{
+				ImportFileCount: 1,
+				CallSiteCount:   1,
+				HasBlankImport:  true,
+			},
+			want: 0.0,
+		},
+		{
+			name: "JS side-effect import: import 'reflect-metadata'",
+			c: CouplingAnalysis{
+				ImportFileCount: 1,
+				CallSiteCount:   1,
+				HasBlankImport:  true,
+			},
+			want: 0.0,
+		},
+		{
+			name: "CJS bare require: require('pkg')",
+			c: CouplingAnalysis{
+				ImportFileCount: 1,
+				CallSiteCount:   1,
+				HasBlankImport:  true,
+			},
+			want: 0.0,
+		},
+		{
+			name: "blank import with actual API usage should NOT be zero",
+			c: CouplingAnalysis{
+				ImportFileCount: 2,
+				CallSiteCount:   5,
+				APIBreadth:      3,
+				HasBlankImport:  true,
+			},
+			want: -1, // non-zero; use wantNonZero check
+		},
+	}
+	const tolerance = 0.001
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeCouplingEffort(tt.c)
+			if tt.want < 0 {
+				// expect non-zero
+				if got < 0.01 {
+					t.Errorf("normalizeCouplingEffort() = %f, expected > 0 for blank import with API usage", got)
+				}
+				return
+			}
+			if got < tt.want-tolerance || got > tt.want+tolerance {
+				t.Errorf("normalizeCouplingEffort() = %f, want %f (±%f)", got, tt.want, tolerance)
+			}
+		})
+	}
+}
+
 func TestComputeSummary_StaysAsIndirectCount(t *testing.T) {
 	entries := []DietEntry{
 		{

--- a/internal/domain/diet/scoring_test.go
+++ b/internal/domain/diet/scoring_test.go
@@ -418,30 +418,13 @@ func TestNormalizeCouplingEffort_BlankImportSideEffect(t *testing.T) {
 	// Before the fix, ImportFileCount > 0 caused non-zero effort even though
 	// the dependency has no callable API (CallSiteCount=0, APIBreadth=0).
 	tests := []struct {
-		name string
-		c    CouplingAnalysis
-		want float64
+		name        string
+		c           CouplingAnalysis
+		want        float64
+		wantNonZero bool
 	}{
 		{
-			name: "Go blank import: side-effect only, no calls",
-			c: CouplingAnalysis{
-				ImportFileCount: 1,
-				CallSiteCount:   1,
-				HasBlankImport:  true,
-			},
-			want: 0.0,
-		},
-		{
-			name: "JS side-effect import: import 'reflect-metadata'",
-			c: CouplingAnalysis{
-				ImportFileCount: 1,
-				CallSiteCount:   1,
-				HasBlankImport:  true,
-			},
-			want: 0.0,
-		},
-		{
-			name: "CJS bare require: require('pkg')",
+			name: "side-effect import with baseline call site",
 			c: CouplingAnalysis{
 				ImportFileCount: 1,
 				CallSiteCount:   1,
@@ -457,17 +440,25 @@ func TestNormalizeCouplingEffort_BlankImportSideEffect(t *testing.T) {
 				APIBreadth:      3,
 				HasBlankImport:  true,
 			},
-			want: -1, // non-zero; use wantNonZero check
+			wantNonZero: true,
+		},
+		{
+			name: "blank import with CallSiteCount=2 but no API breadth",
+			c: CouplingAnalysis{
+				ImportFileCount: 1,
+				CallSiteCount:   2,
+				HasBlankImport:  true,
+			},
+			wantNonZero: true,
 		},
 	}
 	const tolerance = 0.001
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := normalizeCouplingEffort(tt.c)
-			if tt.want < 0 {
-				// expect non-zero
+			if tt.wantNonZero {
 				if got < 0.01 {
-					t.Errorf("normalizeCouplingEffort() = %f, expected > 0 for blank import with API usage", got)
+					t.Errorf("normalizeCouplingEffort() = %f, expected > 0", got)
 				}
 				return
 			}

--- a/internal/domain/diet/types.go
+++ b/internal/domain/diet/types.go
@@ -69,7 +69,10 @@ type CouplingAnalysis struct {
 	IsUnused        bool
 
 	// Import style flags — affect call-site tracking accuracy.
-	HasBlankImport    bool // Go: import _ "pkg" (side-effect only, no callable API)
+	// HasBlankImport indicates a side-effect-only import with no callable API.
+	// Go: import _ "pkg", JS: import 'x' (bare), CJS: require('x') (inline).
+	// Scoring treats these as zero coupling effort.
+	HasBlankImport    bool
 	HasDotImport      bool // Go: import . "pkg" (symbols callable without prefix — undercounted)
 	HasWildcardImport bool // Python: from x import * / Java: import static x.* (undercounted)
 }

--- a/internal/domain/diet/types.go
+++ b/internal/domain/diet/types.go
@@ -69,9 +69,10 @@ type CouplingAnalysis struct {
 	IsUnused        bool
 
 	// Import style flags — affect call-site tracking accuracy.
-	// HasBlankImport indicates a side-effect-only import with no callable API.
-	// Go: import _ "pkg", JS: import 'x' (bare), CJS: require('x') (inline).
-	// Scoring treats these as zero coupling effort.
+	// HasBlankImport indicates side-effect-oriented or feature-detection import patterns.
+	// Examples: Go: import _ "pkg", JS: import 'x', CJS: require('x'),
+	// Python: try/except import checks. This flag can co-exist with callable API
+	// usage elsewhere and should not be interpreted as implying zero coupling effort.
 	HasBlankImport    bool
 	HasDotImport      bool // Go: import . "pkg" (symbols callable without prefix — undercounted)
 	HasWildcardImport bool // Python: from x import * / Java: import static x.* (undercounted)

--- a/internal/infrastructure/treesitter/analyzer.go
+++ b/internal/infrastructure/treesitter/analyzer.go
@@ -281,6 +281,16 @@ func (a *Analyzer) AnalyzeCoupling(
 			}
 		}
 
+		// Blank/side-effect imports (Go: import _ "pkg", JS: import 'x',
+		// CJS: require('x')) have no callable API. Set a baseline call site
+		// count so that scoring does not penalize them as "imported but no calls".
+		if acc.hasBlankImport && !acc.hasDotImport {
+			isUnused = false
+			if callSites == 0 {
+				callSites = 1
+			}
+		}
+
 		symbols := make([]string, 0, len(acc.symbols))
 		for s := range acc.symbols {
 			symbols = append(symbols, s)

--- a/internal/infrastructure/treesitter/analyzer.go
+++ b/internal/infrastructure/treesitter/analyzer.go
@@ -272,19 +272,11 @@ func (a *Analyzer) AnalyzeCoupling(
 		callSites := acc.callSites
 		isUnused := len(acc.importFiles) == 0
 
-		// Dot imports are used but uncountable via selector queries.
-		// Mark as used with a baseline call site count.
-		if acc.hasDotImport {
-			isUnused = false
-			if callSites == 0 {
-				callSites = 1
-			}
-		}
-
-		// Blank/side-effect imports (Go: import _ "pkg", JS: import 'x',
-		// CJS: require('x')) may have implicit or otherwise uncountable usage.
-		// Set a baseline call site count when usage cannot be reliably attributed.
-		if acc.hasBlankImport && !acc.hasDotImport {
+		// Dot imports and blank/side-effect imports (Go: import _ "pkg",
+		// JS: import 'x', CJS: require('x')) are used but uncountable via
+		// standard call-site queries. Mark as used with a baseline call
+		// site count so scoring does not penalize them.
+		if acc.hasDotImport || acc.hasBlankImport {
 			isUnused = false
 			if callSites == 0 {
 				callSites = 1

--- a/internal/infrastructure/treesitter/analyzer.go
+++ b/internal/infrastructure/treesitter/analyzer.go
@@ -282,8 +282,8 @@ func (a *Analyzer) AnalyzeCoupling(
 		}
 
 		// Blank/side-effect imports (Go: import _ "pkg", JS: import 'x',
-		// CJS: require('x')) have no callable API. Set a baseline call site
-		// count so that scoring does not penalize them as "imported but no calls".
+		// CJS: require('x')) may have implicit or otherwise uncountable usage.
+		// Set a baseline call site count when usage cannot be reliably attributed.
 		if acc.hasBlankImport && !acc.hasDotImport {
 			isUnused = false
 			if callSites == 0 {

--- a/internal/infrastructure/treesitter/lang_go_test.go
+++ b/internal/infrastructure/treesitter/lang_go_test.go
@@ -201,7 +201,8 @@ func TestAnalyzer_GoBlankImportBaselineCallSite(t *testing.T) {
 	// Regression test for #261: blank imports should get CallSiteCount=1
 	// as a baseline (mirrors the existing dot-import behavior). Before the
 	// fix, blank imports had CallSiteCount=0, causing them to be scored as
-	// "imported but no calls" even though they have no callable API.
+	// "imported but no calls" even though side-effect imports have no
+	// attributable call sites in the importing file.
 	dir := t.TempDir()
 	err := os.WriteFile(filepath.Join(dir, "main.go"), []byte(`package main
 

--- a/internal/infrastructure/treesitter/lang_go_test.go
+++ b/internal/infrastructure/treesitter/lang_go_test.go
@@ -197,6 +197,61 @@ func main() {
 	}
 }
 
+func TestAnalyzer_GoBlankImportBaselineCallSite(t *testing.T) {
+	// Regression test for #261: blank imports should get CallSiteCount=1
+	// as a baseline (mirrors the existing dot-import behavior). Before the
+	// fix, blank imports had CallSiteCount=0, causing them to be scored as
+	// "imported but no calls" even though they have no callable API.
+	dir := t.TempDir()
+	err := os.WriteFile(filepath.Join(dir, "main.go"), []byte(`package main
+
+import (
+	_ "github.com/lib/pq"
+	"github.com/foo/bar"
+)
+
+func main() {
+	bar.Do()
+}
+`), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	analyzer := NewAnalyzer()
+	importPaths := map[string][]string{
+		"pkg:golang/github.com/lib/pq@v1.10.0": {"github.com/lib/pq"},
+		"pkg:golang/github.com/foo/bar@v1.0.0": {"github.com/foo/bar"},
+	}
+	result, err := analyzer.AnalyzeCoupling(context.Background(), dir, importPaths)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	caPQ, ok := result["pkg:golang/github.com/lib/pq@v1.10.0"]
+	if !ok {
+		t.Fatal("expected coupling analysis for blank import pq")
+	}
+	if !caPQ.HasBlankImport {
+		t.Error("pq: HasBlankImport = false, want true")
+	}
+	if caPQ.CallSiteCount != 1 {
+		t.Errorf("pq: CallSiteCount = %d, want 1 (blank import baseline)", caPQ.CallSiteCount)
+	}
+	if caPQ.IsUnused {
+		t.Error("pq: IsUnused = true, want false")
+	}
+
+	// Verify regular import still works normally alongside blank import.
+	caBar, ok := result["pkg:golang/github.com/foo/bar@v1.0.0"]
+	if !ok {
+		t.Fatal("expected coupling analysis for regular import bar")
+	}
+	if caBar.CallSiteCount != 1 {
+		t.Errorf("bar: CallSiteCount = %d, want 1", caBar.CallSiteCount)
+	}
+}
+
 func TestAnalyzer_GoMultipleFiles(t *testing.T) {
 	dir := t.TempDir()
 	for _, f := range []struct {
@@ -781,14 +836,14 @@ func TestGoAliasFromImportPath(t *testing.T) {
 		input string
 		want  string
 	}{
-		{"github.com/miscreant/miscreant.go", "miscreant"},             // .go suffix stripped
-		{"github.com/oschwald/geoip2-golang", "geoip2"},               // -golang suffix stripped
-		{"github.com/stretchr/testify", "testify"},                     // normal path
-		{"example.com/foo/v2", "foo"},                                  // major version peeled
-		{"gopkg.in/yaml.v3", "yaml"},                                   // gopkg.in version stripped
-		{"gopkg.in/foo.go.v2", "foo"},                                  // gopkg.in + .go suffix
-		{"github.com/go-redis/redis/v9", "redis"},                      // major version + go- prefix
-		{"github.com/opentracing/opentracing-go", "opentracing"},       // -go suffix stripped
+		{"github.com/miscreant/miscreant.go", "miscreant"},       // .go suffix stripped
+		{"github.com/oschwald/geoip2-golang", "geoip2"},          // -golang suffix stripped
+		{"github.com/stretchr/testify", "testify"},               // normal path
+		{"example.com/foo/v2", "foo"},                            // major version peeled
+		{"gopkg.in/yaml.v3", "yaml"},                             // gopkg.in version stripped
+		{"gopkg.in/foo.go.v2", "foo"},                            // gopkg.in + .go suffix
+		{"github.com/go-redis/redis/v9", "redis"},                // major version + go- prefix
+		{"github.com/opentracing/opentracing-go", "opentracing"}, // -go suffix stripped
 	}
 
 	for _, tt := range tests {
@@ -819,13 +874,13 @@ func TestGoPackageFromHyphenated(t *testing.T) {
 		{"geoip2-golang", "geoip2"},
 		{"maxminddb-golang", "maxminddb"},
 		{"foo-golang", "foo"},
-		{"-golang", "-golang"},     // empty after strip; guard preserves original
-		{"-go", "-go"},             // empty after strip; guard preserves original
-		{"go-", "go-"},             // empty after prefix strip; guard preserves original
-		{"go-golang", "go"},        // strip -golang -> "go" (no hyphens)
-		{"go-redis", "redis"},          // real package: prefix go- stripped
-		{"go-sqlite3", "sqlite3"},      // real package: prefix go- stripped
-		{"foo-bar-golang", "foobar"},   // -golang stripped, remaining hyphen removed
+		{"-golang", "-golang"},       // empty after strip; guard preserves original
+		{"-go", "-go"},               // empty after strip; guard preserves original
+		{"go-", "go-"},               // empty after prefix strip; guard preserves original
+		{"go-golang", "go"},          // strip -golang -> "go" (no hyphens)
+		{"go-redis", "redis"},        // real package: prefix go- stripped
+		{"go-sqlite3", "sqlite3"},    // real package: prefix go- stripped
+		{"foo-bar-golang", "foobar"}, // -golang stripped, remaining hyphen removed
 	}
 
 	for _, tt := range tests {

--- a/internal/infrastructure/treesitter/lang_javascript.go
+++ b/internal/infrastructure/treesitter/lang_javascript.go
@@ -46,7 +46,9 @@ func newJSLikeConfig(lang *sitter.Language, includeJSX bool) *langConfig {
 		`(computed_property_name (identifier) @func)`,
 		// Bare identifier usage patterns for constant-only packages (#278).
 		// These detect imported identifiers used as values rather than in calls.
-		// Safe because countCallSites filters by aliasMap (only imported names match).
+		// countCallSites filters matches by aliasMap, so this is limited to identifiers
+		// whose names match imported aliases. This is name-based matching and does
+		// not resolve lexical scope, so shadowed locals with the same name may also match.
 		// if (DEV) { ... }
 		`(if_statement condition: (parenthesized_expression (identifier) @func))`,
 		// DEV ? x : y (condition, consequence, or alternative)

--- a/internal/infrastructure/treesitter/lang_javascript.go
+++ b/internal/infrastructure/treesitter/lang_javascript.go
@@ -44,6 +44,24 @@ func newJSLikeConfig(lang *sitter.Language, includeJSX bool) *langConfig {
 		`(new_expression constructor: (identifier) @func)`,
 		// { [ATTR]: val } — imported constant used as computed property key
 		`(computed_property_name (identifier) @func)`,
+		// Bare identifier usage patterns for constant-only packages (#278).
+		// These detect imported identifiers used as values rather than in calls.
+		// Safe because countCallSites filters by aliasMap (only imported names match).
+		// if (DEV) { ... }
+		`(if_statement condition: (parenthesized_expression (identifier) @func))`,
+		// DEV ? x : y (condition, consequence, or alternative)
+		`(ternary_expression condition: (identifier) @func)`,
+		`(ternary_expression consequence: (identifier) @func)`,
+		`(ternary_expression alternative: (identifier) @func)`,
+		// DEV && x, x || DEV
+		`(binary_expression left: (identifier) @func)`,
+		`(binary_expression right: (identifier) @func)`,
+		// const x = DEV
+		`(variable_declarator value: (identifier) @func)`,
+		// return DEV
+		`(return_statement (identifier) @func)`,
+		// x = DEV
+		`(assignment_expression right: (identifier) @func)`,
 	}
 	if includeJSX {
 		callPatterns = append(callPatterns,

--- a/internal/infrastructure/treesitter/lang_javascript_test.go
+++ b/internal/infrastructure/treesitter/lang_javascript_test.go
@@ -915,6 +915,276 @@ bar();
 	}
 }
 
+// TestAnalyzer_JSConditionalRequire verifies that require() calls inside
+// try/catch and switch/case blocks are correctly detected. Closes #260.
+func TestAnalyzer_JSConditionalRequire(t *testing.T) {
+	tests := []struct {
+		name        string
+		filename    string
+		code        string
+		importPaths map[string][]string
+		purl        string
+		wantImports int
+		wantCalls   int
+		wantBlank   bool
+	}{
+		{
+			name:     "require inside try/catch block",
+			filename: "db.js",
+			code: `try {
+  var pg = require('pg');
+  pg.connect('postgres://localhost/mydb');
+} catch(e) {
+  console.log('pg not available');
+}
+`,
+			importPaths: map[string][]string{
+				"pkg:npm/pg@8.0.0": {"pg"},
+			},
+			purl:        "pkg:npm/pg@8.0.0",
+			wantImports: 1,
+			wantCalls:   1,
+			wantBlank:   false,
+		},
+		{
+			name:     "require inside switch/case block",
+			filename: "driver.js",
+			code: `switch (dbType) {
+  case 'pg':
+    var driver = require('pg');
+    driver.Pool();
+    break;
+  case 'mysql':
+    break;
+}
+`,
+			importPaths: map[string][]string{
+				"pkg:npm/pg@8.0.0": {"pg"},
+			},
+			purl:        "pkg:npm/pg@8.0.0",
+			wantImports: 1,
+			wantCalls:   1,
+			wantBlank:   false,
+		},
+		{
+			name:     "bare require inside try/catch (side-effect)",
+			filename: "polyfill.js",
+			code: `try {
+  require('optional-polyfill');
+} catch(e) {}
+`,
+			importPaths: map[string][]string{
+				"pkg:npm/optional-polyfill@1.0.0": {"optional-polyfill"},
+			},
+			purl:        "pkg:npm/optional-polyfill@1.0.0",
+			wantImports: 1,
+			wantCalls:   1, // baseline for blank/side-effect import (#261)
+			wantBlank:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			err := os.WriteFile(filepath.Join(dir, tt.filename), []byte(tt.code), 0644)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			analyzer := NewAnalyzer()
+			result, err := analyzer.AnalyzeCoupling(context.Background(), dir, tt.importPaths)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			ca, ok := result[tt.purl]
+			if !ok {
+				t.Fatalf("expected coupling analysis for %s", tt.purl)
+			}
+
+			if ca.ImportFileCount != tt.wantImports {
+				t.Errorf("ImportFileCount = %d, want %d", ca.ImportFileCount, tt.wantImports)
+			}
+			if ca.CallSiteCount != tt.wantCalls {
+				t.Errorf("CallSiteCount = %d, want %d", ca.CallSiteCount, tt.wantCalls)
+			}
+			if ca.HasBlankImport != tt.wantBlank {
+				t.Errorf("HasBlankImport = %v, want %v", ca.HasBlankImport, tt.wantBlank)
+			}
+			if ca.IsUnused {
+				t.Error("IsUnused = true, want false")
+			}
+		})
+	}
+}
+
+// TestAnalyzer_JSBareIdentifierUsage verifies that imported constants used as
+// bare identifiers (not in function calls or member expressions) are counted
+// as call sites. Closes #278.
+func TestAnalyzer_JSBareIdentifierUsage(t *testing.T) {
+	tests := []struct {
+		name        string
+		filename    string
+		code        string
+		importPaths map[string][]string
+		purl        string
+		wantCalls   int
+		wantBreadth int
+	}{
+		{
+			name:     "constant in if condition",
+			filename: "app.js",
+			code: `import { DEV } from 'esm-env';
+
+if (DEV) {
+  console.log('dev mode');
+}
+`,
+			importPaths: map[string][]string{
+				"pkg:npm/esm-env@1.0.0": {"esm-env"},
+			},
+			purl:        "pkg:npm/esm-env@1.0.0",
+			wantCalls:   1,
+			wantBreadth: 1,
+		},
+		{
+			name:     "constant in ternary condition",
+			filename: "app.js",
+			code: `import { DEV } from 'esm-env';
+
+const url = DEV ? 'http://localhost' : 'https://prod.com';
+`,
+			importPaths: map[string][]string{
+				"pkg:npm/esm-env@1.0.0": {"esm-env"},
+			},
+			purl:        "pkg:npm/esm-env@1.0.0",
+			wantCalls:   1,
+			wantBreadth: 1,
+		},
+		{
+			name:     "constant in binary expression",
+			filename: "app.js",
+			code: `import { DEV } from 'esm-env';
+
+const debug = DEV && true;
+`,
+			importPaths: map[string][]string{
+				"pkg:npm/esm-env@1.0.0": {"esm-env"},
+			},
+			purl:        "pkg:npm/esm-env@1.0.0",
+			wantCalls:   1,
+			wantBreadth: 1,
+		},
+		{
+			name:     "constant assigned to variable",
+			filename: "config.js",
+			code: `import { DEV } from 'esm-env';
+
+const isDev = DEV;
+`,
+			importPaths: map[string][]string{
+				"pkg:npm/esm-env@1.0.0": {"esm-env"},
+			},
+			purl:        "pkg:npm/esm-env@1.0.0",
+			wantCalls:   1,
+			wantBreadth: 1,
+		},
+		{
+			name:     "constant in return statement",
+			filename: "helper.js",
+			code: `import { DEV } from 'esm-env';
+
+function isDev() {
+  return DEV;
+}
+`,
+			importPaths: map[string][]string{
+				"pkg:npm/esm-env@1.0.0": {"esm-env"},
+			},
+			purl:        "pkg:npm/esm-env@1.0.0",
+			wantCalls:   1,
+			wantBreadth: 1,
+		},
+		{
+			name:     "constant in assignment RHS",
+			filename: "config.js",
+			code: `import { DEV } from 'esm-env';
+
+let mode;
+mode = DEV;
+`,
+			importPaths: map[string][]string{
+				"pkg:npm/esm-env@1.0.0": {"esm-env"},
+			},
+			purl:        "pkg:npm/esm-env@1.0.0",
+			wantCalls:   1,
+			wantBreadth: 1,
+		},
+		{
+			name:     "multiple bare identifier patterns combined",
+			filename: "complex.js",
+			code: `import { DEV, BROWSER } from 'esm-env';
+
+if (DEV) {
+  console.log('dev');
+}
+const isBrowser = BROWSER;
+`,
+			importPaths: map[string][]string{
+				"pkg:npm/esm-env@1.0.0": {"esm-env"},
+			},
+			purl:        "pkg:npm/esm-env@1.0.0",
+			wantCalls:   2,
+			wantBreadth: 2,
+		},
+		{
+			name:     "non-imported identifier not counted",
+			filename: "app.js",
+			code: `import { DEV } from 'esm-env';
+
+if (DEV) {
+  console.log('dev');
+}
+const x = UNRELATED_CONST;
+`,
+			importPaths: map[string][]string{
+				"pkg:npm/esm-env@1.0.0": {"esm-env"},
+			},
+			purl:        "pkg:npm/esm-env@1.0.0",
+			wantCalls:   1,
+			wantBreadth: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			err := os.WriteFile(filepath.Join(dir, tt.filename), []byte(tt.code), 0644)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			analyzer := NewAnalyzer()
+			result, err := analyzer.AnalyzeCoupling(context.Background(), dir, tt.importPaths)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			ca, ok := result[tt.purl]
+			if !ok {
+				t.Fatalf("expected coupling analysis for %s", tt.purl)
+			}
+
+			if ca.CallSiteCount != tt.wantCalls {
+				t.Errorf("CallSiteCount = %d, want %d", ca.CallSiteCount, tt.wantCalls)
+			}
+			if ca.APIBreadth != tt.wantBreadth {
+				t.Errorf("APIBreadth = %d, want %d", ca.APIBreadth, tt.wantBreadth)
+			}
+		})
+	}
+}
+
 func TestAnalyzer_CJSDestructuredRequire(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -1064,7 +1334,7 @@ func TestAnalyzer_JSInlineRequireCallSites(t *testing.T) {
 			},
 			purl:         "pkg:npm/dom-serialize@2.0.0",
 			wantImports:  1,
-			wantCalls:    0,
+			wantCalls:    1, // baseline for blank/side-effect import (#261)
 			wantIsUnused: false,
 			wantBlank:    true,
 			wantBreadth:  0,
@@ -1079,7 +1349,7 @@ func TestAnalyzer_JSInlineRequireCallSites(t *testing.T) {
 			},
 			purl:         "pkg:npm/browser-stdout@1.3.1",
 			wantImports:  1,
-			wantCalls:    0,
+			wantCalls:    1, // baseline for blank/side-effect import (#261)
 			wantIsUnused: false,
 			wantBlank:    true,
 			wantBreadth:  0,
@@ -1094,7 +1364,7 @@ func TestAnalyzer_JSInlineRequireCallSites(t *testing.T) {
 			},
 			purl:         "pkg:npm/depd@2.0.0",
 			wantImports:  1,
-			wantCalls:    0,
+			wantCalls:    1, // baseline for blank/side-effect import (#261)
 			wantIsUnused: false,
 			wantBlank:    true,
 			wantBreadth:  0,
@@ -1109,7 +1379,7 @@ func TestAnalyzer_JSInlineRequireCallSites(t *testing.T) {
 			},
 			purl:         "pkg:npm/side-effect-only@1.0.0",
 			wantImports:  1,
-			wantCalls:    0,
+			wantCalls:    1, // baseline for blank/side-effect import (#261)
 			wantIsUnused: false,
 			wantBlank:    true,
 			wantBreadth:  0,
@@ -1141,7 +1411,7 @@ serialize(document);
 			},
 			purl:         "pkg:npm/some-pkg@1.0.0",
 			wantImports:  1,
-			wantCalls:    0,
+			wantCalls:    1, // baseline for blank/side-effect import (#261)
 			wantIsUnused: false,
 			wantBlank:    true,
 			wantBreadth:  0,

--- a/internal/infrastructure/treesitter/lang_javascript_test.go
+++ b/internal/infrastructure/treesitter/lang_javascript_test.go
@@ -1181,6 +1181,12 @@ const x = UNRELATED_CONST;
 			if ca.APIBreadth != tt.wantBreadth {
 				t.Errorf("APIBreadth = %d, want %d", ca.APIBreadth, tt.wantBreadth)
 			}
+			if ca.HasBlankImport {
+				t.Error("HasBlankImport = true, want false (named import, not side-effect)")
+			}
+			if ca.IsUnused {
+				t.Error("IsUnused = true, want false")
+			}
 		})
 	}
 }

--- a/internal/infrastructure/treesitter/lang_python_test.go
+++ b/internal/infrastructure/treesitter/lang_python_test.go
@@ -261,7 +261,7 @@ except ImportError:
 			wantBlankImport: true,
 			wantUnused:      false,
 			wantImportCount: 1,
-			wantCallSites:   0,
+			wantCallSites:   1, // baseline for blank/side-effect import (#261)
 		},
 		{
 			name: "try/except ModuleNotFoundError",
@@ -273,7 +273,7 @@ except ModuleNotFoundError:
 			wantBlankImport: true,
 			wantUnused:      false,
 			wantImportCount: 1,
-			wantCallSites:   0,
+			wantCallSites:   1, // baseline for blank/side-effect import (#261)
 		},
 		{
 			name: "try/except bare except",
@@ -285,7 +285,7 @@ except:
 			wantBlankImport: true,
 			wantUnused:      false,
 			wantImportCount: 1,
-			wantCallSites:   0,
+			wantCallSites:   1, // baseline for blank/side-effect import (#261)
 		},
 		{
 			name: "try/except with from-import",
@@ -297,7 +297,7 @@ except ImportError:
 			wantBlankImport: true,
 			wantUnused:      false,
 			wantImportCount: 1,
-			wantCallSites:   0,
+			wantCallSites:   1, // baseline for blank/side-effect import (#261)
 		},
 		{
 			name: "regular import not in try/except",
@@ -373,7 +373,7 @@ except (ImportError, ValueError):
 			wantBlankImport: true,
 			wantUnused:      false,
 			wantImportCount: 1,
-			wantCallSites:   0,
+			wantCallSites:   1, // baseline for blank/side-effect import (#261)
 		},
 		{
 			name: "try/except with tuple of unrelated exceptions",


### PR DESCRIPTION
## Summary
- Fix side-effect imports (Go blank `import _ "pkg"`, JS bare `import 'x'`, CJS `require('x')`) being scored with non-zero coupling effort despite having no callable API
- Add baseline `CallSiteCount=1` for blank imports in analyzer, mirroring existing dot-import treatment
- Add early return in `normalizeCouplingEffort` for blank imports with no real API usage
- Add 9 tree-sitter call query patterns for JS/TS bare identifier usage (if condition, ternary, binary expression, variable assignment, return, assignment RHS) so constant-only packages like `esm-env` are detected
- Add documentation tests confirming `require()` inside try/catch and switch/case already works

## Before (reproduction test output)
```
=== RUN   TestNormalizeCouplingEffort_BlankImportSideEffect
=== RUN   TestNormalizeCouplingEffort_BlankImportSideEffect/Go_blank_import:_side-effect_only,_no_calls
    scoring_test.go:475: normalizeCouplingEffort() = 0.028016, want 0.000000 (±0.001000)
=== RUN   TestNormalizeCouplingEffort_BlankImportSideEffect/JS_side-effect_import:_import_'reflect-metadata'
    scoring_test.go:475: normalizeCouplingEffort() = 0.028016, want 0.000000 (±0.001000)
=== RUN   TestNormalizeCouplingEffort_BlankImportSideEffect/CJS_bare_require:_require('pkg')
    scoring_test.go:475: normalizeCouplingEffort() = 0.028016, want 0.000000 (±0.001000)
--- FAIL: TestNormalizeCouplingEffort_BlankImportSideEffect (0.00s)

=== RUN   TestAnalyzer_GoBlankImportBaselineCallSite
    lang_go_test.go:239: pq: CallSiteCount = 0, want 1 (blank import baseline)
--- FAIL: TestAnalyzer_GoBlankImportBaselineCallSite (0.05s)

=== RUN   TestAnalyzer_JSBareIdentifierUsage
=== RUN   TestAnalyzer_JSBareIdentifierUsage/constant_in_if_condition
    lang_javascript_test.go:1179: CallSiteCount = 0, want 1
    lang_javascript_test.go:1182: APIBreadth = 0, want 1
=== RUN   TestAnalyzer_JSBareIdentifierUsage/constant_in_ternary_condition
    lang_javascript_test.go:1179: CallSiteCount = 0, want 1
=== RUN   TestAnalyzer_JSBareIdentifierUsage/constant_in_binary_expression
    lang_javascript_test.go:1179: CallSiteCount = 0, want 1
=== RUN   TestAnalyzer_JSBareIdentifierUsage/constant_assigned_to_variable
    lang_javascript_test.go:1179: CallSiteCount = 0, want 1
=== RUN   TestAnalyzer_JSBareIdentifierUsage/constant_in_return_statement
    lang_javascript_test.go:1179: CallSiteCount = 0, want 1
=== RUN   TestAnalyzer_JSBareIdentifierUsage/constant_in_assignment_RHS
    lang_javascript_test.go:1179: CallSiteCount = 0, want 1
=== RUN   TestAnalyzer_JSBareIdentifierUsage/multiple_bare_identifier_patterns_combined
    lang_javascript_test.go:1179: CallSiteCount = 0, want 2
--- FAIL: TestAnalyzer_JSBareIdentifierUsage (0.29s)
```

## After (verification test output)
```
=== RUN   TestNormalizeCouplingEffort_BlankImportSideEffect
=== RUN   TestNormalizeCouplingEffort_BlankImportSideEffect/Go_blank_import:_side-effect_only,_no_calls
=== RUN   TestNormalizeCouplingEffort_BlankImportSideEffect/JS_side-effect_import:_import_'reflect-metadata'
=== RUN   TestNormalizeCouplingEffort_BlankImportSideEffect/CJS_bare_require:_require('pkg')
=== RUN   TestNormalizeCouplingEffort_BlankImportSideEffect/blank_import_with_actual_API_usage_should_NOT_be_zero
--- PASS: TestNormalizeCouplingEffort_BlankImportSideEffect (0.00s)
PASS

=== RUN   TestAnalyzer_GoBlankImportBaselineCallSite
--- PASS: TestAnalyzer_GoBlankImportBaselineCallSite (0.14s)

=== RUN   TestAnalyzer_JSConditionalRequire
=== RUN   TestAnalyzer_JSConditionalRequire/require_inside_try/catch_block
=== RUN   TestAnalyzer_JSConditionalRequire/require_inside_switch/case_block
=== RUN   TestAnalyzer_JSConditionalRequire/bare_require_inside_try/catch_(side-effect)
--- PASS: TestAnalyzer_JSConditionalRequire (0.34s)

=== RUN   TestAnalyzer_JSBareIdentifierUsage
=== RUN   TestAnalyzer_JSBareIdentifierUsage/constant_in_if_condition
=== RUN   TestAnalyzer_JSBareIdentifierUsage/constant_in_ternary_condition
=== RUN   TestAnalyzer_JSBareIdentifierUsage/constant_in_binary_expression
=== RUN   TestAnalyzer_JSBareIdentifierUsage/constant_assigned_to_variable
=== RUN   TestAnalyzer_JSBareIdentifierUsage/constant_in_return_statement
=== RUN   TestAnalyzer_JSBareIdentifierUsage/constant_in_assignment_RHS
=== RUN   TestAnalyzer_JSBareIdentifierUsage/multiple_bare_identifier_patterns_combined
=== RUN   TestAnalyzer_JSBareIdentifierUsage/non-imported_identifier_not_counted
--- PASS: TestAnalyzer_JSBareIdentifierUsage (0.79s)
PASS
```

Closes #261
Closes #278
Refs #260 (conditional require already worked; documentation tests added to confirm)

## Test plan
- [x] Reproduction tests fail before fix, pass after
- [x] Scoring: blank imports with no API produce zero coupling effort
- [x] Scoring: blank imports with actual API usage still produce non-zero effort
- [x] Analyzer: Go blank imports get baseline CallSiteCount=1
- [x] Analyzer: JS/TS bare identifier patterns detect constant-only usage
- [x] Analyzer: non-imported identifiers are NOT falsely counted
- [x] Conditional require (try/catch, switch/case) passes with existing code
- [x] Existing tests for inline require, side-effect imports, Python try/except updated
- [x] `go test ./...` passes (all packages)
- [x] `go vet ./...` passes
- [x] `golangci-lint run` passes (0 issues)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
