### PR TITLE
docs: lowercase uzomuzo in headings and prose

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Uzomuzo
+# uzomuzo
 
 [![CI](https://github.com/future-architect/uzomuzo-oss/actions/workflows/ci.yml/badge.svg)](https://github.com/future-architect/uzomuzo-oss/actions/workflows/ci.yml) [![Dependency Scan](https://github.com/future-architect/uzomuzo-oss/actions/workflows/dependency-scan.yml/badge.svg)](https://github.com/future-architect/uzomuzo-oss/actions/workflows/dependency-scan.yml) [![Go Report Card](https://goreportcard.com/badge/github.com/future-architect/uzomuzo-oss)](https://goreportcard.com/report/github.com/future-architect/uzomuzo-oss) [![Go Reference](https://pkg.go.dev/badge/github.com/future-architect/uzomuzo-oss.svg)](https://pkg.go.dev/github.com/future-architect/uzomuzo-oss) [![Release](https://img.shields.io/github/v/release/future-architect/uzomuzo-oss)](https://github.com/future-architect/uzomuzo-oss/releases/latest) [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -4,7 +4,7 @@
 
 ## SPDX Data Update (`update-spdx` Subcommand)
 
-Uzomuzo vendors the upstream SPDX License List (JSON) and generates a fast lookup table for license normalization. The `update-spdx` subcommand provides end-to-end automation:
+uzomuzo vendors the upstream SPDX License List (JSON) and generates a fast lookup table for license normalization. The `update-spdx` subcommand provides end-to-end automation:
 
 1. Downloads the latest `licenses.json` from the official SPDX repository (fails on truncation if size < ~2KB)
 2. Atomically writes to `third_party/spdx/licenses.json` (temp file + rename)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -573,7 +573,7 @@ Operational tuning without code changes (low risk, reversible).
 
 ## Logging
 
-Uzomuzo outputs structured logs via Go's `slog`. Designed for batch/cron operation and incident investigation.
+uzomuzo outputs structured logs via Go's `slog`. Designed for batch/cron operation and incident investigation.
 
 For automated monthly scanning with GitHub Actions, see [Integration Examples: GitHub Actions Scheduled Scanning](/docs/integration-examples.md#github-actions-scheduled-scanning).
 


### PR DESCRIPTION
## Summary
- Lowercase `Uzomuzo` → `uzomuzo` in README heading, `docs/development.md`, and `docs/usage.md`
- CLI tool names are conventionally lowercase (`git`, `docker`, `trivy`)
- The "Why Uzomuzo?" section retains capitalization (etymological proper noun)

## Test plan
- [x] No code changes — docs only
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)