### PR TITLE
fix: handle CJS require() assigned to object property in call site tracking

### DIFF
--- a/internal/infrastructure/treesitter/lang_javascript.go
+++ b/internal/infrastructure/treesitter/lang_javascript.go
@@ -186,8 +186,8 @@ func extractJSBindings(node *sitter.Node, src []byte) []string {
 			}
 
 			// Check for property assignment: obj.prop = require('pkg')
-			// The property name becomes the binding alias so that call sites
-			// like obj.prop.method() or obj.prop() can be tracked.
+			// The qualified member expression becomes the binding alias (for example, `file.glob`)
+			// to avoid collisions and so that call sites like obj.prop.method() or obj.prop() can be tracked.
 			if binding := extractPropertyAssignBinding(callExpr, src); binding != "" {
 				return []string{binding}
 			}

--- a/internal/infrastructure/treesitter/lang_javascript.go
+++ b/internal/infrastructure/treesitter/lang_javascript.go
@@ -38,8 +38,16 @@ func newJSLikeConfig(lang *sitter.Language, includeJSX bool) *langConfig {
 	}, "\n")
 	callPatterns := []string{
 		`(member_expression object: (identifier) @obj property: (property_identifier) @prop)`,
+		// obj.alias.method() — nested member access where alias was assigned via
+		// `obj.alias = require('pkg')`. Matches the outer member_expression with
+		// the inner's property as @obj and the outer's property as @prop.
+		`(member_expression object: (member_expression property: (property_identifier) @obj) property: (property_identifier) @prop)`,
 		// foo() — bare function call on an imported named binding
 		`(call_expression function: (identifier) @func)`,
+		// obj.alias() — direct call on a property-assigned require binding.
+		// Captures just the property name so it can match aliases registered from
+		// `obj.alias = require('pkg')`.
+		`(call_expression function: (member_expression property: (property_identifier) @func))`,
 		// new Foo() — constructor call on an imported named binding
 		`(new_expression constructor: (identifier) @func)`,
 		// { [ATTR]: val } — imported constant used as computed property key
@@ -159,6 +167,7 @@ func extractJSBindings(node *sitter.Node, src []byte) []string {
 	if parent.Type() == "arguments" {
 		callExpr := parent.Parent()
 		if callExpr != nil && callExpr.Type() == "call_expression" {
+			// Check for variable declarator: const x = require('pkg')
 			declarator := findAncestorVariableDeclarator(callExpr)
 			if declarator != nil {
 				nameNode := declarator.ChildByFieldName("name")
@@ -172,6 +181,13 @@ func extractJSBindings(node *sitter.Node, src []byte) []string {
 					// Destructured: const { X, Y } = require('pkg')
 					return extractCJSDestructuredBindings(nameNode, src)
 				}
+			}
+
+			// Check for property assignment: obj.prop = require('pkg')
+			// The property name becomes the binding alias so that call sites
+			// like obj.prop.method() or obj.prop() can be tracked.
+			if binding := extractPropertyAssignBinding(callExpr, src); binding != "" {
+				return []string{binding}
 			}
 		}
 	}
@@ -344,6 +360,40 @@ func extractCJSDestructuredBindings(objectPattern *sitter.Node, src []byte) []st
 		}
 	}
 	return bindings
+}
+
+// extractPropertyAssignBinding extracts the property name from a CJS require()
+// assigned to an object property. For `obj.prop = require('pkg')`, the AST is:
+//
+//	assignment_expression
+//	  left: member_expression
+//	    object: identifier (obj)
+//	    property: property_identifier (prop)
+//	  right: call_expression (require('pkg'))
+//
+// This function walks up from the call_expression through intermediate
+// expression nodes (e.g., binary_expression) to find the assignment_expression,
+// then extracts the property name from the member_expression on the left side.
+// Returns empty string if the pattern does not match.
+func extractPropertyAssignBinding(callExpr *sitter.Node, src []byte) string {
+	current := callExpr.Parent()
+	for depth := 0; current != nil && depth < maxAncestorWalkDepth; depth++ {
+		if current.Type() == "assignment_expression" {
+			left := current.ChildByFieldName("left")
+			if left != nil && left.Type() == "member_expression" {
+				propNode := left.ChildByFieldName("property")
+				if propNode != nil {
+					return propNode.Content(src)
+				}
+			}
+			return ""
+		}
+		if !jsExpressionTypes[current.Type()] {
+			return ""
+		}
+		current = current.Parent()
+	}
+	return ""
 }
 
 // isTypeOnlyImport checks if a node's parent import_statement is a TypeScript

--- a/internal/infrastructure/treesitter/lang_javascript.go
+++ b/internal/infrastructure/treesitter/lang_javascript.go
@@ -143,7 +143,8 @@ func (a *Analyzer) handleJSImport(
 // extractJSBindings walks the AST from an import source node to find all JS binding names.
 //
 // ESM: import_statement → import_clause → identifier / namespace_import
-// CJS: string → arguments → call_expression → variable_declarator → name
+// CJS (variable): string → arguments → call_expression → variable_declarator → name
+// CJS (property): string → arguments → call_expression → assignment_expression → member_expression → property
 //
 // Combined imports (e.g., `import def, * as ns from "pkg"`) produce multiple bindings.
 func extractJSBindings(node *sitter.Node, src []byte) []string {

--- a/internal/infrastructure/treesitter/lang_javascript.go
+++ b/internal/infrastructure/treesitter/lang_javascript.go
@@ -38,16 +38,17 @@ func newJSLikeConfig(lang *sitter.Language, includeJSX bool) *langConfig {
 	}, "\n")
 	callPatterns := []string{
 		`(member_expression object: (identifier) @obj property: (property_identifier) @prop)`,
-		// obj.alias.method() — nested member access where alias was assigned via
-		// `obj.alias = require('pkg')`. Matches the outer member_expression with
-		// the inner's property as @obj and the outer's property as @prop.
-		`(member_expression object: (member_expression property: (property_identifier) @obj) property: (property_identifier) @prop)`,
+		// obj.alias.method() — nested member access where a qualified alias such as
+		// `obj.alias` was assigned via `obj.alias = require('pkg')`. Capture the full
+		// inner member_expression as @obj so chained property access is keyed by
+		// its qualified receiver instead of only the trailing property name.
+		`(member_expression object: (member_expression) @obj property: (property_identifier) @prop)`,
 		// foo() — bare function call on an imported named binding
 		`(call_expression function: (identifier) @func)`,
-		// obj.alias() — direct call on a property-assigned require binding.
-		// Captures just the property name so it can match aliases registered from
-		// `obj.alias = require('pkg')`.
-		`(call_expression function: (member_expression property: (property_identifier) @func))`,
+		// obj.alias() — direct call on a qualified require binding. Capture the full
+		// member_expression so aliases remain qualified and do not collide with
+		// unrelated plain identifiers that share the same property name.
+		`(call_expression function: (member_expression) @func)`,
 		// new Foo() — constructor call on an imported named binding
 		`(new_expression constructor: (identifier) @func)`,
 		// { [ATTR]: val } — imported constant used as computed property key
@@ -363,8 +364,9 @@ func extractCJSDestructuredBindings(objectPattern *sitter.Node, src []byte) []st
 	return bindings
 }
 
-// extractPropertyAssignBinding extracts the property name from a CJS require()
-// assigned to an object property. For `obj.prop = require('pkg')`, the AST is:
+// extractPropertyAssignBinding extracts the full member_expression text from a
+// CJS require() assigned to an object property. For `obj.prop = require('pkg')`,
+// the AST is:
 //
 //	assignment_expression
 //	  left: member_expression
@@ -374,18 +376,16 @@ func extractCJSDestructuredBindings(objectPattern *sitter.Node, src []byte) []st
 //
 // This function walks up from the call_expression through intermediate
 // expression nodes (e.g., binary_expression) to find the assignment_expression,
-// then extracts the property name from the member_expression on the left side.
-// Returns empty string if the pattern does not match.
+// then extracts the full member_expression text from the left side (for example,
+// `obj.prop` rather than only `prop`). Returns empty string if the pattern does
+// not match.
 func extractPropertyAssignBinding(callExpr *sitter.Node, src []byte) string {
 	current := callExpr.Parent()
 	for depth := 0; current != nil && depth < maxAncestorWalkDepth; depth++ {
 		if current.Type() == "assignment_expression" {
 			left := current.ChildByFieldName("left")
 			if left != nil && left.Type() == "member_expression" {
-				propNode := left.ChildByFieldName("property")
-				if propNode != nil {
-					return propNode.Content(src)
-				}
+				return left.Content(src)
 			}
 			return ""
 		}

--- a/internal/infrastructure/treesitter/lang_javascript_test.go
+++ b/internal/infrastructure/treesitter/lang_javascript_test.go
@@ -1241,7 +1241,7 @@ file.minimatch(pattern, '*.js');
 			wantImports: 1,
 			wantCalls:   1,
 			wantBreadth: 1,
-			wantSymbols: []string{"minimatch"},
+			wantSymbols: []string{"file.minimatch"},
 		},
 		{
 			name:     "property assign with dateformat pattern: template.date = require('dateformat')",
@@ -1257,7 +1257,7 @@ var result = template.date(new Date(), "yyyy-mm-dd");
 			wantImports: 1,
 			wantCalls:   1,
 			wantBreadth: 1,
-			wantSymbols: []string{"date"},
+			wantSymbols: []string{"template.date"},
 		},
 		{
 			name:     "property assign with findup pattern: file.findup = require('findup-sync')",
@@ -1273,7 +1273,26 @@ var fp = file.findup('Gruntfile.js');
 			wantImports: 1,
 			wantCalls:   1,
 			wantBreadth: 1,
-			wantSymbols: []string{"findup"},
+			wantSymbols: []string{"file.findup"},
+		},
+		{
+			name:     "no false positive: method name does not collide with separate import alias",
+			filename: "index.js",
+			code: `file.glob = require('glob');
+const sync = require('sync');
+
+file.glob.sync(pattern);
+sync();
+`,
+			importPaths: map[string][]string{
+				"pkg:npm/glob@7.0.0": {"glob"},
+				"pkg:npm/sync@1.0.0": {"sync"},
+			},
+			purl:        "pkg:npm/sync@1.0.0",
+			wantImports: 1,
+			wantCalls:   1,
+			wantBreadth: 1,
+			wantSymbols: []string{"sync"},
 		},
 	}
 

--- a/internal/infrastructure/treesitter/lang_javascript_test.go
+++ b/internal/infrastructure/treesitter/lang_javascript_test.go
@@ -1195,8 +1195,9 @@ serialize(document);
 
 // TestAnalyzer_CJSPropertyAssignRequire verifies that require() assigned to an
 // object property (e.g., `file.glob = require('glob')`) is tracked correctly.
-// The property name becomes an alias so that subsequent usage like
-// `file.glob.sync()` or `file.glob()` is counted as a call site.
+// The full qualified member expression (for example, `file.glob`) becomes an
+// alias so that subsequent usage like `file.glob.sync()` or `file.glob()` is
+// counted as a call site.
 // Closes #290.
 func TestAnalyzer_CJSPropertyAssignRequire(t *testing.T) {
 	tests := []struct {

--- a/internal/infrastructure/treesitter/lang_javascript_test.go
+++ b/internal/infrastructure/treesitter/lang_javascript_test.go
@@ -1192,3 +1192,130 @@ serialize(document);
 		})
 	}
 }
+
+// TestAnalyzer_CJSPropertyAssignRequire verifies that require() assigned to an
+// object property (e.g., `file.glob = require('glob')`) is tracked correctly.
+// The property name becomes an alias so that subsequent usage like
+// `file.glob.sync()` or `file.glob()` is counted as a call site.
+// Closes #290.
+func TestAnalyzer_CJSPropertyAssignRequire(t *testing.T) {
+	tests := []struct {
+		name        string
+		filename    string
+		code        string
+		importPaths map[string][]string
+		purl        string
+		wantImports int
+		wantCalls   int
+		wantBreadth int
+		wantSymbols []string
+	}{
+		{
+			name:     "property assign with method call: file.glob = require('glob')",
+			filename: "index.js",
+			code: `file.glob = require('glob');
+
+file.glob.sync(pattern);
+file.glob.hasMagic(pattern);
+`,
+			importPaths: map[string][]string{
+				"pkg:npm/glob@7.0.0": {"glob"},
+			},
+			purl:        "pkg:npm/glob@7.0.0",
+			wantImports: 1,
+			wantCalls:   2,
+			wantBreadth: 2,
+			wantSymbols: []string{"hasMagic", "sync"},
+		},
+		{
+			name:     "property assign with direct call: file.minimatch = require('minimatch')",
+			filename: "index.js",
+			code: `file.minimatch = require('minimatch');
+
+file.minimatch(pattern, '*.js');
+`,
+			importPaths: map[string][]string{
+				"pkg:npm/minimatch@3.0.0": {"minimatch"},
+			},
+			purl:        "pkg:npm/minimatch@3.0.0",
+			wantImports: 1,
+			wantCalls:   1,
+			wantBreadth: 1,
+			wantSymbols: []string{"minimatch"},
+		},
+		{
+			name:     "property assign with dateformat pattern: template.date = require('dateformat')",
+			filename: "index.js",
+			code: `template.date = require('dateformat');
+
+var result = template.date(new Date(), "yyyy-mm-dd");
+`,
+			importPaths: map[string][]string{
+				"pkg:npm/dateformat@4.0.0": {"dateformat"},
+			},
+			purl:        "pkg:npm/dateformat@4.0.0",
+			wantImports: 1,
+			wantCalls:   1,
+			wantBreadth: 1,
+			wantSymbols: []string{"date"},
+		},
+		{
+			name:     "property assign with findup pattern: file.findup = require('findup-sync')",
+			filename: "index.js",
+			code: `file.findup = require('findup-sync');
+
+var fp = file.findup('Gruntfile.js');
+`,
+			importPaths: map[string][]string{
+				"pkg:npm/findup-sync@5.0.0": {"findup-sync"},
+			},
+			purl:        "pkg:npm/findup-sync@5.0.0",
+			wantImports: 1,
+			wantCalls:   1,
+			wantBreadth: 1,
+			wantSymbols: []string{"findup"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			err := os.WriteFile(filepath.Join(dir, tt.filename), []byte(tt.code), 0644)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			analyzer := NewAnalyzer()
+			result, err := analyzer.AnalyzeCoupling(context.Background(), dir, tt.importPaths)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			ca, ok := result[tt.purl]
+			if !ok {
+				t.Fatalf("expected coupling analysis for %s", tt.purl)
+			}
+
+			if ca.ImportFileCount != tt.wantImports {
+				t.Errorf("ImportFileCount = %d, want %d", ca.ImportFileCount, tt.wantImports)
+			}
+			if ca.CallSiteCount != tt.wantCalls {
+				t.Errorf("CallSiteCount = %d, want %d", ca.CallSiteCount, tt.wantCalls)
+			}
+			if ca.APIBreadth != tt.wantBreadth {
+				t.Errorf("APIBreadth = %d, want %d", ca.APIBreadth, tt.wantBreadth)
+			}
+
+			sort.Strings(tt.wantSymbols)
+			if len(ca.Symbols) != len(tt.wantSymbols) {
+				t.Errorf("Symbols = %v, want %v", ca.Symbols, tt.wantSymbols)
+			} else {
+				for i, s := range ca.Symbols {
+					if s != tt.wantSymbols[i] {
+						t.Errorf("Symbols[%d] = %q, want %q", i, s, tt.wantSymbols[i])
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Fix call site tracking for CommonJS `require()` assigned to object properties (e.g., `file.glob = require('glob')`)
- Add `extractPropertyAssignBinding()` to extract the property name from `assignment_expression` with `member_expression` LHS as the binding alias
- Add nested `member_expression` call query pattern to match `obj.alias.method()` (e.g., `file.glob.sync()`)
- Add `call_expression` via `member_expression` pattern to match direct calls like `obj.alias()` (e.g., `file.minimatch()`)

## Before (reproduction test output)
```
=== RUN   TestAnalyzer_CJSPropertyAssignRequire
=== RUN   TestAnalyzer_CJSPropertyAssignRequire/property_assign_with_method_call:_file.glob_=_require('glob')
    lang_javascript_test.go:1303: CallSiteCount = 0, want 2
    lang_javascript_test.go:1306: APIBreadth = 0, want 2
    lang_javascript_test.go:1311: Symbols = [], want [hasMagic sync]
=== RUN   TestAnalyzer_CJSPropertyAssignRequire/property_assign_with_direct_call:_file.minimatch_=_require('minimatch')
    lang_javascript_test.go:1303: CallSiteCount = 0, want 1
    lang_javascript_test.go:1306: APIBreadth = 0, want 1
    lang_javascript_test.go:1311: Symbols = [], want [minimatch]
=== RUN   TestAnalyzer_CJSPropertyAssignRequire/property_assign_with_dateformat_pattern:_template.date_=_require('dateformat')
    lang_javascript_test.go:1303: CallSiteCount = 0, want 1
    lang_javascript_test.go:1306: APIBreadth = 0, want 1
    lang_javascript_test.go:1311: Symbols = [], want [date]
=== RUN   TestAnalyzer_CJSPropertyAssignRequire/property_assign_with_findup_pattern:_file.findup_=_require('findup-sync')
    lang_javascript_test.go:1303: CallSiteCount = 0, want 1
    lang_javascript_test.go:1306: APIBreadth = 0, want 1
    lang_javascript_test.go:1311: Symbols = [], want [findup]
--- FAIL: TestAnalyzer_CJSPropertyAssignRequire (0.19s)
```

## After (verification test output)
```
=== RUN   TestAnalyzer_CJSPropertyAssignRequire
=== RUN   TestAnalyzer_CJSPropertyAssignRequire/property_assign_with_method_call:_file.glob_=_require('glob')
=== RUN   TestAnalyzer_CJSPropertyAssignRequire/property_assign_with_direct_call:_file.minimatch_=_require('minimatch')
=== RUN   TestAnalyzer_CJSPropertyAssignRequire/property_assign_with_dateformat_pattern:_template.date_=_require('dateformat')
=== RUN   TestAnalyzer_CJSPropertyAssignRequire/property_assign_with_findup_pattern:_file.findup_=_require('findup-sync')
--- PASS: TestAnalyzer_CJSPropertyAssignRequire (0.35s)
    --- PASS: TestAnalyzer_CJSPropertyAssignRequire/property_assign_with_method_call:_file.glob_=_require('glob') (0.09s)
    --- PASS: TestAnalyzer_CJSPropertyAssignRequire/property_assign_with_direct_call:_file.minimatch_=_require('minimatch') (0.09s)
    --- PASS: TestAnalyzer_CJSPropertyAssignRequire/property_assign_with_dateformat_pattern:_template.date_=_require('dateformat') (0.09s)
    --- PASS: TestAnalyzer_CJSPropertyAssignRequire/property_assign_with_findup_pattern:_file.findup_=_require('findup-sync') (0.09s)
PASS
ok  	github.com/future-architect/uzomuzo-oss/internal/infrastructure/treesitter	0.354s
```

Closes #290

## Test plan
- [x] Reproduction test confirms CallSiteCount=0 before fix
- [x] All 4 property-assign patterns pass after fix (glob, minimatch, dateformat, findup-sync)
- [x] Full treesitter test suite passes with no regressions (48 tests)
- [x] `go vet ./...` clean
- [x] `golangci-lint run` clean (0 issues)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)