### PR TITLE
fix: capture Java generic type args, instanceof, casts, and type declarations in IBNC

### DIFF
--- a/internal/application/diet/coupling_integration_test.go
+++ b/internal/application/diet/coupling_integration_test.go
@@ -40,8 +40,9 @@ public class Main {
 }
 `,
 			wantImportCount: 1,
-			wantCallSites:   3,
-			wantUnused:      false,
+			// 4 call sites: Gson local var type (1) + new Gson() (1) + gson.toJson (1) + gson.fromJson (1)
+			wantCallSites: 4,
+			wantUnused:    false,
 		},
 		{
 			name:       "commons-lang3 via groupId heuristic",

--- a/internal/infrastructure/treesitter/analyzer_test.go
+++ b/internal/infrastructure/treesitter/analyzer_test.go
@@ -103,8 +103,9 @@ public class Main {
 		if ca.ImportFileCount != 1 {
 			t.Errorf("%s: ImportFileCount = %d, want 1", purl, ca.ImportFileCount)
 		}
-		if ca.CallSiteCount != 2 {
-			t.Errorf("%s: CallSiteCount = %d, want 2 (new Gson, toJson)", purl, ca.CallSiteCount)
+		// 3 call sites: Gson local var type (1) + new Gson() (1) + gson.toJson (1)
+		if ca.CallSiteCount != 3 {
+			t.Errorf("%s: CallSiteCount = %d, want 3 (Gson type decl, new Gson, toJson)", purl, ca.CallSiteCount)
 		}
 	}
 }

--- a/internal/infrastructure/treesitter/lang_java.go
+++ b/internal/infrastructure/treesitter/lang_java.go
@@ -56,32 +56,52 @@ func registerJavaConfig(a *Analyzer) {
 			// --- Type checks and casts ---
 			// instanceof: obj instanceof Foo
 			`(instanceof_expression (type_identifier) @func)`,
+			// instanceof: obj instanceof Map.Entry
+			`(instanceof_expression (scoped_type_identifier) @func)`,
 			// Cast: (Foo) obj
 			`(cast_expression type: (type_identifier) @func)`,
+			// Cast: (Map.Entry) obj
+			`(cast_expression type: (scoped_type_identifier) @func)`,
 
 			// --- Type declarations ---
 			// Field declaration: private Foo field
 			`(field_declaration type: (type_identifier) @func)`,
+			// Field declaration: private Map.Entry field
+			`(field_declaration type: (scoped_type_identifier) @func)`,
 			// Field with generic type: private List<Foo> field — outer type
 			`(field_declaration type: (generic_type (type_identifier) @func))`,
+			// Field with generic type: private Outer.Inner<Foo> field — outer type
+			`(field_declaration type: (generic_type (scoped_type_identifier) @func))`,
 			// Field generic type argument: private List<Foo> field — captures Foo
 			`(field_declaration type: (generic_type (type_arguments (type_identifier) @func)))`,
 			// Method return type: public Foo method()
 			`(method_declaration type: (type_identifier) @func)`,
+			// Method return type: public Map.Entry method()
+			`(method_declaration type: (scoped_type_identifier) @func)`,
 			// Method return generic type: public List<Foo> method() — outer type
 			`(method_declaration type: (generic_type (type_identifier) @func))`,
+			// Method return generic type: public Outer.Inner<Foo> method() — outer type
+			`(method_declaration type: (generic_type (scoped_type_identifier) @func))`,
 			// Method return generic type argument: public List<Foo> method() — captures Foo
 			`(method_declaration type: (generic_type (type_arguments (type_identifier) @func)))`,
 			// Formal parameter: method(Foo param)
 			`(formal_parameter type: (type_identifier) @func)`,
+			// Formal parameter: method(Map.Entry param)
+			`(formal_parameter type: (scoped_type_identifier) @func)`,
 			// Formal parameter generic type: method(List<Foo> param) — outer type
 			`(formal_parameter type: (generic_type (type_identifier) @func))`,
+			// Formal parameter generic type: method(Outer.Inner<Foo> param) — outer type
+			`(formal_parameter type: (generic_type (scoped_type_identifier) @func))`,
 			// Formal parameter generic type argument: method(List<Foo> param) — captures Foo
 			`(formal_parameter type: (generic_type (type_arguments (type_identifier) @func)))`,
 			// Local variable: Foo local = ...
 			`(local_variable_declaration type: (type_identifier) @func)`,
+			// Local variable: Map.Entry local = ...
+			`(local_variable_declaration type: (scoped_type_identifier) @func)`,
 			// Local variable generic type: List<Foo> local = ... — outer type
 			`(local_variable_declaration type: (generic_type (type_identifier) @func))`,
+			// Local variable generic type: Outer.Inner<Foo> local = ... — outer type
+			`(local_variable_declaration type: (generic_type (scoped_type_identifier) @func))`,
 			// Local variable generic type argument: List<Foo> local = ... — captures Foo
 			`(local_variable_declaration type: (generic_type (type_arguments (type_identifier) @func)))`,
 

--- a/internal/infrastructure/treesitter/lang_java.go
+++ b/internal/infrastructure/treesitter/lang_java.go
@@ -32,9 +32,12 @@ func registerJavaConfig(a *Analyzer) {
 			`(object_creation_expression type: (generic_type (type_identifier) @func))`,
 			// Type arguments in generic constructors: new Foo<Bar>() captures Bar
 			`(object_creation_expression type: (generic_type (type_arguments (type_identifier) @func)))`,
+			// Type arguments with qualified type: new Foo<Map.Entry>() captures Map, Entry
+			`(object_creation_expression type: (generic_type (type_arguments (scoped_type_identifier (type_identifier) @func))))`,
 			// Qualified constructors: new Outer.Inner()
-			// Single @func capture; countCallSites matches each captured
-			// type_identifier against aliasMap as a bare identifier.
+			// Each type_identifier child of scoped_type_identifier produces a
+			// separate single-capture match, so countCallSites treats each as a
+			// bare identifier lookup in aliasMap.
 			`(object_creation_expression type: (scoped_type_identifier (type_identifier) @func))`,
 			// Qualified generic constructors: new Outer.Inner<T>()
 			`(object_creation_expression type: (generic_type (scoped_type_identifier (type_identifier) @func)))`,
@@ -46,12 +49,16 @@ func registerJavaConfig(a *Analyzer) {
 			`(super_interfaces (type_list (generic_type (type_identifier) @func)))`,
 			// Generic implements type argument: implements Foo<Bar> — captures Bar
 			`(super_interfaces (type_list (generic_type (type_arguments (type_identifier) @func))))`,
+			// Generic implements type argument with qualified type: implements Foo<Map.Entry>
+			`(super_interfaces (type_list (generic_type (type_arguments (scoped_type_identifier (type_identifier) @func)))))`,
 			// Bare extends: extends Foo
 			`(superclass (type_identifier) @func)`,
 			// Generic extends: extends Foo<T> — outer type
 			`(superclass (generic_type (type_identifier) @func))`,
 			// Generic extends type argument: extends Foo<Bar> — captures Bar
 			`(superclass (generic_type (type_arguments (type_identifier) @func)))`,
+			// Generic extends type argument with qualified type: extends Foo<Map.Entry>
+			`(superclass (generic_type (type_arguments (scoped_type_identifier (type_identifier) @func))))`,
 
 			// --- Type checks and casts ---
 			// instanceof: obj instanceof Foo
@@ -74,6 +81,8 @@ func registerJavaConfig(a *Analyzer) {
 			`(field_declaration type: (generic_type (scoped_type_identifier (type_identifier) @func)))`,
 			// Field generic type argument: private List<Foo> field — captures Foo
 			`(field_declaration type: (generic_type (type_arguments (type_identifier) @func)))`,
+			// Field generic type argument with qualified type: private List<Map.Entry> field
+			`(field_declaration type: (generic_type (type_arguments (scoped_type_identifier (type_identifier) @func))))`,
 			// Method return type: public Foo method()
 			`(method_declaration type: (type_identifier) @func)`,
 			// Method return type: public Map.Entry method() — capture bare identifiers for aliasMap lookup
@@ -84,6 +93,8 @@ func registerJavaConfig(a *Analyzer) {
 			`(method_declaration type: (generic_type (scoped_type_identifier (type_identifier) @func)))`,
 			// Method return generic type argument: public List<Foo> method() — captures Foo
 			`(method_declaration type: (generic_type (type_arguments (type_identifier) @func)))`,
+			// Method return generic type argument with qualified type: public List<Map.Entry> method()
+			`(method_declaration type: (generic_type (type_arguments (scoped_type_identifier (type_identifier) @func))))`,
 			// Formal parameter: method(Foo param)
 			`(formal_parameter type: (type_identifier) @func)`,
 			// Formal parameter: method(Map.Entry param) — capture bare identifiers for aliasMap lookup
@@ -94,6 +105,8 @@ func registerJavaConfig(a *Analyzer) {
 			`(formal_parameter type: (generic_type (scoped_type_identifier (type_identifier) @func)))`,
 			// Formal parameter generic type argument: method(List<Foo> param) — captures Foo
 			`(formal_parameter type: (generic_type (type_arguments (type_identifier) @func)))`,
+			// Formal parameter generic type argument with qualified type: method(List<Map.Entry> param)
+			`(formal_parameter type: (generic_type (type_arguments (scoped_type_identifier (type_identifier) @func))))`,
 			// Local variable: Foo local = ...
 			`(local_variable_declaration type: (type_identifier) @func)`,
 			// Local variable: Map.Entry local = ... — capture bare identifiers for aliasMap lookup
@@ -104,6 +117,8 @@ func registerJavaConfig(a *Analyzer) {
 			`(local_variable_declaration type: (generic_type (scoped_type_identifier (type_identifier) @func)))`,
 			// Local variable generic type argument: List<Foo> local = ... — captures Foo
 			`(local_variable_declaration type: (generic_type (type_arguments (type_identifier) @func)))`,
+			// Local variable generic type argument with qualified type: List<Map.Entry> local = ...
+			`(local_variable_declaration type: (generic_type (type_arguments (scoped_type_identifier (type_identifier) @func))))`,
 
 			// --- Method references ---
 			// Method reference: Foo::bar — capture simple qualifiers directly

--- a/internal/infrastructure/treesitter/lang_java.go
+++ b/internal/infrastructure/treesitter/lang_java.go
@@ -17,45 +17,83 @@ func registerJavaConfig(a *Analyzer) {
 		language:    java.GetLanguage(),
 		importQuery: `(import_declaration (scoped_identifier) @import)`,
 		callQuery: strings.Join([]string{
+			// --- Method calls ---
 			`(method_invocation object: (identifier) @obj name: (identifier) @method)`,
 			`(method_invocation !object name: (identifier) @func)`,
+
+			// --- Annotations ---
 			`(marker_annotation name: (identifier) @func)`,
 			`(annotation name: (identifier) @func)`,
+
+			// --- Constructors ---
 			// Bare constructors: new Foo()
 			`(object_creation_expression type: (type_identifier) @func)`,
 			// Generic constructors: new Foo<T>(), new Foo<>()
 			`(object_creation_expression type: (generic_type (type_identifier) @func))`,
+			// Type arguments in generic constructors: new Foo<Bar>() captures Bar
+			`(object_creation_expression type: (generic_type (type_arguments (type_identifier) @func)))`,
 			// Qualified constructors: new Outer.Inner()
 			// Single @func capture; countCallSites matches each captured
 			// type_identifier against aliasMap as a bare identifier.
 			`(object_creation_expression type: (scoped_type_identifier (type_identifier) @func))`,
 			// Qualified generic constructors: new Outer.Inner<T>()
 			`(object_creation_expression type: (generic_type (scoped_type_identifier (type_identifier) @func)))`,
+
+			// --- Inheritance ---
 			// Bare implements: implements Foo
 			`(super_interfaces (type_list (type_identifier) @func))`,
-			// Generic implements: implements Foo<T>
+			// Generic implements: implements Foo<T> — outer type
 			`(super_interfaces (type_list (generic_type (type_identifier) @func)))`,
+			// Generic implements type argument: implements Foo<Bar> — captures Bar
+			`(super_interfaces (type_list (generic_type (type_arguments (type_identifier) @func))))`,
 			// Bare extends: extends Foo
 			`(superclass (type_identifier) @func)`,
-			// Generic extends: extends Foo<T>
+			// Generic extends: extends Foo<T> — outer type
 			`(superclass (generic_type (type_identifier) @func))`,
+			// Generic extends type argument: extends Foo<Bar> — captures Bar
+			`(superclass (generic_type (type_arguments (type_identifier) @func)))`,
+
+			// --- Type checks and casts ---
+			// instanceof: obj instanceof Foo
+			`(instanceof_expression (type_identifier) @func)`,
+			// Cast: (Foo) obj
+			`(cast_expression type: (type_identifier) @func)`,
+
+			// --- Type declarations ---
+			// Field declaration: private Foo field
+			`(field_declaration type: (type_identifier) @func)`,
+			// Field with generic type: private List<Foo> field — outer type
+			`(field_declaration type: (generic_type (type_identifier) @func))`,
+			// Field generic type argument: private List<Foo> field — captures Foo
+			`(field_declaration type: (generic_type (type_arguments (type_identifier) @func)))`,
+			// Method return type: public Foo method()
+			`(method_declaration type: (type_identifier) @func)`,
+			// Method return generic type: public List<Foo> method() — outer type
+			`(method_declaration type: (generic_type (type_identifier) @func))`,
+			// Method return generic type argument: public List<Foo> method() — captures Foo
+			`(method_declaration type: (generic_type (type_arguments (type_identifier) @func)))`,
+			// Formal parameter: method(Foo param)
+			`(formal_parameter type: (type_identifier) @func)`,
+			// Formal parameter generic type: method(List<Foo> param) — outer type
+			`(formal_parameter type: (generic_type (type_identifier) @func))`,
+			// Formal parameter generic type argument: method(List<Foo> param) — captures Foo
+			`(formal_parameter type: (generic_type (type_arguments (type_identifier) @func)))`,
+			// Local variable: Foo local = ...
+			`(local_variable_declaration type: (type_identifier) @func)`,
+			// Local variable generic type: List<Foo> local = ... — outer type
+			`(local_variable_declaration type: (generic_type (type_identifier) @func))`,
+			// Local variable generic type argument: List<Foo> local = ... — captures Foo
+			`(local_variable_declaration type: (generic_type (type_arguments (type_identifier) @func)))`,
+
+			// --- Method references ---
 			// Method reference: Foo::bar — capture simple qualifiers directly
 			// so alias lookup remains consistent with method_invocation.
 			`(method_reference . (identifier) @obj . (identifier) @method)`,
 			// Scoped method reference: Outer.Inner::bar, Map.Entry::getKey.
-			// tree-sitter-java represents the qualifier as a field_access node;
-			// capture the first identifier child (e.g., "ImmutableList" from
-			// "ImmutableList.Builder") for aliasMap lookup.
 			`(method_reference . (field_access (identifier) @obj) . (identifier) @method)`,
-			// Constructor reference: Foo::new — tree-sitter-java represents
-			// "new" as a token, not an identifier, so match it explicitly,
-			// but record the qualifier/type as the symbol to keep constructor
-			// references consistent with constructor calls (new Foo()).
+			// Constructor reference: Foo::new
 			`(method_reference . (identifier) @obj @method . "new")`,
 			// Scoped constructor reference: Outer.Inner::new.
-			// Capture the imported qualifier identifier for alias-based
-			// attribution, and capture the inner type identifier as the
-			// recorded symbol to align with scoped constructor calls.
 			`(method_reference . (field_access (identifier) @obj (identifier) @method) . "new")`,
 		}, "\n"),
 		stripQuotes: false,

--- a/internal/infrastructure/treesitter/lang_java.go
+++ b/internal/infrastructure/treesitter/lang_java.go
@@ -56,52 +56,52 @@ func registerJavaConfig(a *Analyzer) {
 			// --- Type checks and casts ---
 			// instanceof: obj instanceof Foo
 			`(instanceof_expression (type_identifier) @func)`,
-			// instanceof: obj instanceof Map.Entry
-			`(instanceof_expression (scoped_type_identifier) @func)`,
+			// instanceof: obj instanceof Map.Entry — capture bare identifiers for aliasMap lookup
+			`(instanceof_expression (scoped_type_identifier (type_identifier) @func))`,
 			// Cast: (Foo) obj
 			`(cast_expression type: (type_identifier) @func)`,
-			// Cast: (Map.Entry) obj
-			`(cast_expression type: (scoped_type_identifier) @func)`,
+			// Cast: (Map.Entry) obj — capture bare identifiers for aliasMap lookup
+			`(cast_expression type: (scoped_type_identifier (type_identifier) @func))`,
 
 			// --- Type declarations ---
 			// Field declaration: private Foo field
 			`(field_declaration type: (type_identifier) @func)`,
-			// Field declaration: private Map.Entry field
-			`(field_declaration type: (scoped_type_identifier) @func)`,
+			// Field declaration: private Map.Entry field — capture bare identifiers for aliasMap lookup
+			`(field_declaration type: (scoped_type_identifier (type_identifier) @func))`,
 			// Field with generic type: private List<Foo> field — outer type
 			`(field_declaration type: (generic_type (type_identifier) @func))`,
-			// Field with generic type: private Outer.Inner<Foo> field — outer type
-			`(field_declaration type: (generic_type (scoped_type_identifier) @func))`,
+			// Field with generic type: private Outer.Inner<Foo> field — capture bare identifiers
+			`(field_declaration type: (generic_type (scoped_type_identifier (type_identifier) @func)))`,
 			// Field generic type argument: private List<Foo> field — captures Foo
 			`(field_declaration type: (generic_type (type_arguments (type_identifier) @func)))`,
 			// Method return type: public Foo method()
 			`(method_declaration type: (type_identifier) @func)`,
-			// Method return type: public Map.Entry method()
-			`(method_declaration type: (scoped_type_identifier) @func)`,
+			// Method return type: public Map.Entry method() — capture bare identifiers for aliasMap lookup
+			`(method_declaration type: (scoped_type_identifier (type_identifier) @func))`,
 			// Method return generic type: public List<Foo> method() — outer type
 			`(method_declaration type: (generic_type (type_identifier) @func))`,
-			// Method return generic type: public Outer.Inner<Foo> method() — outer type
-			`(method_declaration type: (generic_type (scoped_type_identifier) @func))`,
+			// Method return generic type: public Outer.Inner<Foo> method() — capture bare identifiers
+			`(method_declaration type: (generic_type (scoped_type_identifier (type_identifier) @func)))`,
 			// Method return generic type argument: public List<Foo> method() — captures Foo
 			`(method_declaration type: (generic_type (type_arguments (type_identifier) @func)))`,
 			// Formal parameter: method(Foo param)
 			`(formal_parameter type: (type_identifier) @func)`,
-			// Formal parameter: method(Map.Entry param)
-			`(formal_parameter type: (scoped_type_identifier) @func)`,
+			// Formal parameter: method(Map.Entry param) — capture bare identifiers for aliasMap lookup
+			`(formal_parameter type: (scoped_type_identifier (type_identifier) @func))`,
 			// Formal parameter generic type: method(List<Foo> param) — outer type
 			`(formal_parameter type: (generic_type (type_identifier) @func))`,
-			// Formal parameter generic type: method(Outer.Inner<Foo> param) — outer type
-			`(formal_parameter type: (generic_type (scoped_type_identifier) @func))`,
+			// Formal parameter generic type: method(Outer.Inner<Foo> param) — capture bare identifiers
+			`(formal_parameter type: (generic_type (scoped_type_identifier (type_identifier) @func)))`,
 			// Formal parameter generic type argument: method(List<Foo> param) — captures Foo
 			`(formal_parameter type: (generic_type (type_arguments (type_identifier) @func)))`,
 			// Local variable: Foo local = ...
 			`(local_variable_declaration type: (type_identifier) @func)`,
-			// Local variable: Map.Entry local = ...
-			`(local_variable_declaration type: (scoped_type_identifier) @func)`,
+			// Local variable: Map.Entry local = ... — capture bare identifiers for aliasMap lookup
+			`(local_variable_declaration type: (scoped_type_identifier (type_identifier) @func))`,
 			// Local variable generic type: List<Foo> local = ... — outer type
 			`(local_variable_declaration type: (generic_type (type_identifier) @func))`,
-			// Local variable generic type: Outer.Inner<Foo> local = ... — outer type
-			`(local_variable_declaration type: (generic_type (scoped_type_identifier) @func))`,
+			// Local variable generic type: Outer.Inner<Foo> local = ... — capture bare identifiers
+			`(local_variable_declaration type: (generic_type (scoped_type_identifier (type_identifier) @func)))`,
 			// Local variable generic type argument: List<Foo> local = ... — captures Foo
 			`(local_variable_declaration type: (generic_type (type_arguments (type_identifier) @func)))`,
 

--- a/internal/infrastructure/treesitter/lang_java_test.go
+++ b/internal/infrastructure/treesitter/lang_java_test.go
@@ -709,11 +709,11 @@ public class Service {
 	// Map.Entry in: field type (1), return type (1), param (1), local var (1) = 4.
 	// Each scoped_type_identifier captures "Map" and "Entry" as separate type_identifiers,
 	// but only "Map" matches aliasMap, so 4 call sites for "Map".
-	if ca.CallSiteCount < 4 {
-		t.Errorf("CallSiteCount = %d, want >= 4 (Map.Entry in field, return, param, local)", ca.CallSiteCount)
+	if ca.CallSiteCount != 4 {
+		t.Errorf("CallSiteCount = %d, want 4 (Map.Entry in field, return, param, local)", ca.CallSiteCount)
 	}
-	if ca.APIBreadth < 1 {
-		t.Errorf("APIBreadth = %d, want >= 1", ca.APIBreadth)
+	if ca.APIBreadth != 1 {
+		t.Errorf("APIBreadth = %d, want 1", ca.APIBreadth)
 	}
 	if ca.IsUnused {
 		t.Error("IsUnused = true, want false")

--- a/internal/infrastructure/treesitter/lang_java_test.go
+++ b/internal/infrastructure/treesitter/lang_java_test.go
@@ -44,8 +44,10 @@ public class Main {
 	if ca.ImportFileCount != 1 {
 		t.Errorf("ImportFileCount = %d, want 1", ca.ImportFileCount)
 	}
-	if ca.CallSiteCount != 3 {
-		t.Errorf("CallSiteCount = %d, want 3 (new Gson, toJson, fromJson)", ca.CallSiteCount)
+	// 4 call sites: "Gson" as local var type (1) + new Gson() constructor (1) +
+	// gson.toJson (1) + gson.fromJson (1)
+	if ca.CallSiteCount != 4 {
+		t.Errorf("CallSiteCount = %d, want 4 (Gson type decl, new Gson, toJson, fromJson)", ca.CallSiteCount)
 	}
 	if ca.APIBreadth != 3 {
 		t.Errorf("APIBreadth = %d, want 3 (Gson, toJson, fromJson)", ca.APIBreadth)
@@ -400,20 +402,22 @@ class MyList extends ImmutableList<String> {
 		wantBreadth int
 	}{
 		{
-			// bare "new Gson()" — already works with existing type_identifier pattern
-			name:        "bare constructor new Gson()",
+			// "Gson gson = new Gson()" = local var type (1) + constructor (1) = 2
+			name:        "bare constructor new Gson() + local var type",
 			purl:        "pkg:maven/com.google.code.gson/gson@2.10",
 			wantImports: 1,
-			wantCalls:   1,
+			wantCalls:   2,
 			wantBreadth: 1,
 		},
 		{
-			// "new ImmutableList<>()" and "new ImmutableList<Integer>()" are generic_type,
-			// plus "extends ImmutableList<String>" is also generic_type in superclass
-			name:        "generic constructors and generic extends",
+			// ImmutableList<String> list = new ImmutableList<>() → local var generic_type (1) + constructor generic_type (1)
+			// ImmutableList<Integer> list2 = new ImmutableList<Integer>() → local var generic_type (1) + constructor generic_type (1)
+			// class MyList extends ImmutableList<String> → superclass generic_type (1)
+			// Total: 5 call sites
+			name:        "generic constructors + local var types + generic extends",
 			purl:        "pkg:maven/com.google.guava/guava@33.0",
 			wantImports: 1,
-			wantCalls:   3,
+			wantCalls:   5,
 			wantBreadth: 1,
 		},
 		{
@@ -544,8 +548,6 @@ func TestAnalyzer_JavaMethodReference(t *testing.T) {
 	dir := t.TempDir()
 	// Java method references (Foo::bar) produce method_reference AST nodes.
 	// These should be counted as call sites when the type is from an external dependency.
-	// Without a method_reference query pattern, deps used ONLY via method references
-	// are undercounted (call_site_count = 0 despite active usage).
 	err := os.WriteFile(filepath.Join(dir, "Main.java"), []byte(`import com.google.gson.Gson;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
@@ -556,35 +558,25 @@ import java.util.Arrays;
 import java.util.stream.Collectors;
 
 public class Main {
-    // Method reference to external type's static method
     List<Boolean> blanks = Arrays.asList("a", "b").stream()
         .map(StringUtils::isBlank)
         .collect(Collectors.toList());
 
-    // Method reference to external type's instance method
     List<String> jsons = Arrays.asList("a", "b").stream()
         .map(new Gson()::toJson)
         .collect(Collectors.toList());
 
-    // Constructor reference (Type::new)
     Gson gson = Arrays.asList("config").stream()
         .map(Gson::new)
         .findFirst().orElse(null);
 
-    // Method reference with qualified static method
     List<Boolean> nullOrEmpty = Arrays.asList("a", null).stream()
         .map(Strings::isNullOrEmpty)
         .collect(Collectors.toList());
 
-    // Scoped qualifier method reference: ImmutableList.Builder::add
-    // The qualifier is represented as field_access; in this fixture,
-    // aliasMap matching is performed against "ImmutableList".
     java.util.function.Function<String, ImmutableList.Builder<String>> adder =
         ImmutableList.Builder::add;
 
-    // Scoped constructor reference: ImmutableList.Builder::new
-    // field_access + "new" pattern captures "ImmutableList" for alias lookup
-    // and "Builder" as the recorded symbol (consistent with scoped constructor calls).
     java.util.function.Supplier<ImmutableList.Builder<String>> factory =
         ImmutableList.Builder::new;
 }
@@ -625,11 +617,12 @@ public class Main {
 			// "Gson::new" is matched by the constructor reference pattern
 			// (method_reference with "new" token), recording the qualifier "Gson"
 			// as the symbol — consistent with how new Foo() records "Foo".
-			// Total: 2 call sites, 1 unique symbol ("Gson").
+			// new Gson() (constructor) + Gson::new (constructor ref) +
+			// Gson gson = ... (local var type declaration) = 3 calls.
 			name:        "gson constructor reference and object creation",
 			purl:        "pkg:maven/com.google.code.gson/gson@2.10",
 			wantImports: 1,
-			wantCalls:   2,
+			wantCalls:   3,
 			wantBreadth: 1,
 		},
 		{

--- a/internal/infrastructure/treesitter/lang_java_test.go
+++ b/internal/infrastructure/treesitter/lang_java_test.go
@@ -720,6 +720,59 @@ public class Service {
 	}
 }
 
+func TestAnalyzer_JavaScopedInstanceofCastAndGenericArg(t *testing.T) {
+	dir := t.TempDir()
+	// Scoped types in instanceof, cast, and generic type arguments must be
+	// detected as call sites via their type_identifier children.
+	err := os.WriteFile(filepath.Join(dir, "Processor.java"), []byte(`import java.util.Map;
+import java.util.List;
+
+public class Processor {
+    public void process(Object obj) {
+        // scoped instanceof
+        if (obj instanceof Map.Entry) {
+            // scoped cast
+            Map.Entry entry = (Map.Entry) obj;
+        }
+        // scoped type in generic type argument
+        List<Map.Entry> entries = null;
+    }
+}
+`), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	analyzer := NewAnalyzer()
+	importPaths := map[string][]string{
+		"pkg:maven/java/jdk@17": {"java.util"},
+	}
+	result, err := analyzer.AnalyzeCoupling(context.Background(), dir, importPaths)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ca, ok := result["pkg:maven/java/jdk@17"]
+	if !ok {
+		t.Fatal("expected coupling analysis for jdk")
+	}
+
+	// Map.Entry in: instanceof (1), cast (1), local var scoped type (1),
+	// Map.Entry in: generic type argument (1) = 4 call sites for "Map".
+	// List in: generic local var outer type (1) = 1 call site for "List".
+	// Total = 5. APIBreadth = 2 (Map + List).
+	// Note: "Entry" is also captured but does not match aliasMap.
+	if ca.CallSiteCount != 5 {
+		t.Errorf("CallSiteCount = %d, want 5", ca.CallSiteCount)
+	}
+	if ca.APIBreadth != 2 {
+		t.Errorf("APIBreadth = %d, want 2 (Map + List)", ca.APIBreadth)
+	}
+	if ca.IsUnused {
+		t.Error("IsUnused = true, want false")
+	}
+}
+
 func TestAnalyzer_JavaConstructorCall(t *testing.T) {
 	dir := t.TempDir()
 	// Constructor calls (new Type()) should count as call sites.

--- a/internal/infrastructure/treesitter/lang_java_test.go
+++ b/internal/infrastructure/treesitter/lang_java_test.go
@@ -505,19 +505,25 @@ public class Main {
 		wantBreadth int
 	}{
 		{
-			// "new ImmutableList.Builder()" (non-generic) + "new ImmutableList.Builder<>()" (generic)
-			name:        "guava scoped constructors (generic + non-generic)",
+			// "ImmutableList.Builder builder" local var scoped type captures "ImmutableList" (1)
+			// + "new ImmutableList.Builder()" constructor scoped (1)
+			// + "ImmutableList.Builder<String> typedBuilder" local var generic scoped captures "ImmutableList" (1)
+			// + "new ImmutableList.Builder<>()" constructor generic scoped (1)
+			// = 4 total call sites
+			name:        "guava scoped constructors + local var types",
 			purl:        "pkg:maven/com.google.guava/guava@33.0",
 			wantImports: 1,
-			wantCalls:   2,
+			wantCalls:   4,
 			wantBreadth: 1,
 		},
 		{
-			// "new Map.Entry()" — non-generic scoped constructor
-			name:        "jdk non-generic scoped constructor",
+			// "Map.Entry entry" local var scoped type captures "Map" (1)
+			// + "new Map.Entry()" constructor scoped (1)
+			// = 2 total call sites
+			name:        "jdk scoped constructor + local var type",
 			purl:        "pkg:maven/java/jdk@17",
 			wantImports: 1,
-			wantCalls:   1,
+			wantCalls:   2,
 			wantBreadth: 1,
 		},
 	}
@@ -660,6 +666,57 @@ public class Main {
 				t.Error("IsUnused = true, want false")
 			}
 		})
+	}
+}
+
+func TestAnalyzer_JavaScopedTypeDeclaration(t *testing.T) {
+	dir := t.TempDir()
+	// Qualified/nested types used in declarations (e.g., Map.Entry) must be
+	// detected as call sites via their individual type_identifier children,
+	// not as a whole "Map.Entry" string that won't match aliasMap.
+	err := os.WriteFile(filepath.Join(dir, "Service.java"), []byte(`import java.util.Map;
+
+public class Service {
+    private Map.Entry field;
+
+    public Map.Entry getEntry(Map.Entry param) {
+        Map.Entry local = null;
+        return local;
+    }
+}
+`), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	analyzer := NewAnalyzer()
+	importPaths := map[string][]string{
+		"pkg:maven/java/jdk@17": {"java.util"},
+	}
+	result, err := analyzer.AnalyzeCoupling(context.Background(), dir, importPaths)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ca, ok := result["pkg:maven/java/jdk@17"]
+	if !ok {
+		t.Fatal("expected coupling analysis for jdk")
+	}
+
+	if ca.ImportFileCount != 1 {
+		t.Errorf("ImportFileCount = %d, want 1", ca.ImportFileCount)
+	}
+	// Map.Entry in: field type (1), return type (1), param (1), local var (1) = 4.
+	// Each scoped_type_identifier captures "Map" and "Entry" as separate type_identifiers,
+	// but only "Map" matches aliasMap, so 4 call sites for "Map".
+	if ca.CallSiteCount < 4 {
+		t.Errorf("CallSiteCount = %d, want >= 4 (Map.Entry in field, return, param, local)", ca.CallSiteCount)
+	}
+	if ca.APIBreadth < 1 {
+		t.Errorf("APIBreadth = %d, want >= 1", ca.APIBreadth)
+	}
+	if ca.IsUnused {
+		t.Error("IsUnused = true, want false")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add tree-sitter query patterns for Java generic type arguments (`extends Foo<Bar>`, `implements Foo<Bar>`, `new Foo<Bar>()`) to capture the type argument as usage (#286)
- Add query patterns for `instanceof` and cast expressions (#286)
- Add query patterns for type declarations: field types, method return types, formal parameters, and local variable declarations -- both bare and generic forms (#288)
- Annotation patterns (`@NotNull`, `@Size`, `@Min`) were already present from a prior commit; added a dedicated test to verify coverage (#287)
- Update existing test expectations to account for the increased call site counts from newly detected type declaration patterns

## Before (reproduction test output)
```
=== RUN   TestAnalyzer_JavaGenericTypeArgument
=== RUN   TestAnalyzer_JavaGenericTypeArgument/outer_generic_type_in_extends
=== RUN   TestAnalyzer_JavaGenericTypeArgument/type_argument_+_instanceof_+_cast
    lang_java_test.go:614: CallSiteCount = 0, want 3
    lang_java_test.go:617: APIBreadth = 0, want 1
--- FAIL: TestAnalyzer_JavaGenericTypeArgument (0.08s)
    --- PASS: TestAnalyzer_JavaGenericTypeArgument/outer_generic_type_in_extends (0.00s)
    --- FAIL: TestAnalyzer_JavaGenericTypeArgument/type_argument_+_instanceof_+_cast (0.00s)
=== RUN   TestAnalyzer_JavaAnnotationUsage
--- PASS: TestAnalyzer_JavaAnnotationUsage (0.06s)
=== RUN   TestAnalyzer_JavaTypeDeclaration
=== RUN   TestAnalyzer_JavaTypeDeclaration/ByteBuf_field_+_param_+_local_+_generic_arg_+_method_call
    lang_java_test.go:763: CallSiteCount = 0, want 5
    lang_java_test.go:766: APIBreadth = 0, want 2
=== RUN   TestAnalyzer_JavaTypeDeclaration/HttpRequest_return_type
    lang_java_test.go:763: CallSiteCount = 0, want 1
    lang_java_test.go:766: APIBreadth = 0, want 1
=== RUN   TestAnalyzer_JavaTypeDeclaration/List_generic_type_in_local_variable
    lang_java_test.go:763: CallSiteCount = 0, want 1
    lang_java_test.go:766: APIBreadth = 0, want 1
--- FAIL: TestAnalyzer_JavaTypeDeclaration (0.06s)
    --- FAIL: TestAnalyzer_JavaTypeDeclaration/ByteBuf_field_+_param_+_local_+_generic_arg_+_method_call (0.00s)
    --- FAIL: TestAnalyzer_JavaTypeDeclaration/HttpRequest_return_type (0.00s)
    --- FAIL: TestAnalyzer_JavaTypeDeclaration/List_generic_type_in_local_variable (0.00s)
FAIL
```

## After (verification test output)
```
=== RUN   TestAnalyzer_JavaGenericTypeArgument
=== RUN   TestAnalyzer_JavaGenericTypeArgument/outer_generic_type_in_extends
=== RUN   TestAnalyzer_JavaGenericTypeArgument/type_argument_+_instanceof_+_cast_+_local_var_type
--- PASS: TestAnalyzer_JavaGenericTypeArgument (0.05s)
    --- PASS: TestAnalyzer_JavaGenericTypeArgument/outer_generic_type_in_extends (0.00s)
    --- PASS: TestAnalyzer_JavaGenericTypeArgument/type_argument_+_instanceof_+_cast_+_local_var_type (0.00s)
=== RUN   TestAnalyzer_JavaAnnotationUsage
--- PASS: TestAnalyzer_JavaAnnotationUsage (0.05s)
=== RUN   TestAnalyzer_JavaTypeDeclaration
=== RUN   TestAnalyzer_JavaTypeDeclaration/ByteBuf_field_+_param_+_local_+_generic_arg
=== RUN   TestAnalyzer_JavaTypeDeclaration/HttpRequest_return_type
=== RUN   TestAnalyzer_JavaTypeDeclaration/List_generic_type_in_local_variable
--- PASS: TestAnalyzer_JavaTypeDeclaration (0.05s)
    --- PASS: TestAnalyzer_JavaTypeDeclaration/ByteBuf_field_+_param_+_local_+_generic_arg (0.00s)
    --- PASS: TestAnalyzer_JavaTypeDeclaration/HttpRequest_return_type (0.00s)
    --- PASS: TestAnalyzer_JavaTypeDeclaration/List_generic_type_in_local_variable (0.00s)
PASS
ok  	github.com/future-architect/uzomuzo-oss/internal/infrastructure/treesitter	0.162s
```

Closes #286
Closes #287
Closes #288

## Test plan
- [x] Reproduction tests written before fix, confirming CallSiteCount=0 for affected patterns
- [x] Fix applied, all 3 new tests pass
- [x] Existing tests updated for increased call site counts (type declarations now counted)
- [x] Full test suite passes: `GOWORK=off go test ./...`
- [x] `GOWORK=off go vet ./...` clean
- [x] `goimports -w . && GOWORK=off golangci-lint run` clean (0 issues)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)