### PR TITLE
fix: recognize Java reflection-loaded deps as runtime-scoped

### DIFF
--- a/internal/application/diet/service.go
+++ b/internal/application/diet/service.go
@@ -252,28 +252,11 @@ func (s *Service) buildEntries(
 			}
 		}
 
-		// Tool directive deps intentionally have zero source imports.
-		// Override IsUnused so they are not flagged as trivial removals.
-		//
-		// Also provide a minimal synthetic coupling signal when the analyzer has
-		// no source-coupling data for tool deps. Leaving IsUnused=false together
-		// with all coupling counts at zero can be interpreted downstream as
-		// zero-effort removal, which incorrectly surfaces tool deps as trivial/easy.
-		if entry.Scope == domaindiet.ScopeTool {
-			if entry.Coupling.IsUnused {
-				entry.Coupling.IsUnused = false
-			}
-			if entry.Coupling.ImportFileCount == 0 &&
-				entry.Coupling.CallSiteCount == 0 &&
-				entry.Coupling.APIBreadth == 0 {
-				entry.Coupling.APIBreadth = 1
-			}
-		}
-
-		// Runtime-scoped deps (JDBC drivers, logging backends, webjars) are
-		// loaded via reflection/ServiceLoader/classpath and intentionally have
-		// zero static imports. Same override pattern as ScopeTool above.
-		if entry.Scope == domaindiet.ScopeRuntime {
+		// Non-static-import scopes (tool directives, runtime/reflection deps)
+		// intentionally have zero source imports. Override IsUnused so they are
+		// not flagged as trivial removals, and provide a minimal synthetic
+		// coupling signal so downstream scoring does not treat them as zero-effort.
+		if entry.Scope == domaindiet.ScopeTool || entry.Scope == domaindiet.ScopeRuntime {
 			if entry.Coupling.IsUnused {
 				entry.Coupling.IsUnused = false
 			}

--- a/internal/application/diet/service.go
+++ b/internal/application/diet/service.go
@@ -233,6 +233,13 @@ func (s *Service) buildEntries(
 			}
 		}
 
+		// Check if this dependency is a Maven runtime dep (reflection-loaded).
+		if entry.Scope == "" && entry.Ecosystem == "maven" {
+			if _, ok := mavenRuntimeDeps[entry.Name]; ok {
+				entry.Scope = domaindiet.ScopeRuntime
+			}
+		}
+
 		if m, ok := graph.Metrics[purl]; ok {
 			entry.Graph = *m
 		}
@@ -253,6 +260,20 @@ func (s *Service) buildEntries(
 		// with all coupling counts at zero can be interpreted downstream as
 		// zero-effort removal, which incorrectly surfaces tool deps as trivial/easy.
 		if entry.Scope == domaindiet.ScopeTool {
+			if entry.Coupling.IsUnused {
+				entry.Coupling.IsUnused = false
+			}
+			if entry.Coupling.ImportFileCount == 0 &&
+				entry.Coupling.CallSiteCount == 0 &&
+				entry.Coupling.APIBreadth == 0 {
+				entry.Coupling.APIBreadth = 1
+			}
+		}
+
+		// Runtime-scoped deps (JDBC drivers, logging backends, webjars) are
+		// loaded via reflection/ServiceLoader/classpath and intentionally have
+		// zero static imports. Same override pattern as ScopeTool above.
+		if entry.Scope == domaindiet.ScopeRuntime {
 			if entry.Coupling.IsUnused {
 				entry.Coupling.IsUnused = false
 			}
@@ -565,6 +586,46 @@ var mavenPackageOverrides = map[string][]string{
 	// heuristic already produces the correct candidate, but an explicit override
 	// ensures stability.
 	"javax.inject/javax.inject": {"javax.inject"},
+}
+
+// mavenRuntimeDeps is a set of Maven "groupId/artifactId" coordinates for
+// dependencies that are loaded via runtime mechanisms (reflection, ServiceLoader,
+// classpath scanning) rather than static imports. Static source analysis cannot
+// detect their usage, so they are recognized as runtime-scoped to prevent
+// false-positive unused-dependency reports.
+var mavenRuntimeDeps = map[string]struct{}{
+	// JDBC drivers — loaded via java.sql.DriverManager / ServiceLoader.
+	"mysql/mysql-connector-java":           {},
+	"mysql/mysql-connector-j":              {},
+	"org.postgresql/postgresql":            {},
+	"com.h2database/h2":                    {},
+	"org.mariadb.jdbc/mariadb-java-client": {},
+	"com.oracle.database.jdbc/ojdbc11":     {},
+	"com.microsoft.sqlserver/mssql-jdbc":   {},
+	"org.xerial/sqlite-jdbc":               {},
+	"com.amazon.redshift/redshift-jdbc42":  {},
+	"org.hsqldb/hsqldb":                    {},
+	"org.apache.derby/derby":               {},
+	"com.ibm.db2/jcc":                      {},
+	"org.firebirdsql.jdbc/jaybird":         {},
+	"net.snowflake/snowflake-jdbc":         {},
+	"com.clickhouse/clickhouse-jdbc":       {},
+	"org.duckdb/duckdb_jdbc":               {},
+
+	// Logging backends — loaded via SLF4J ServiceLoader / classpath binding.
+	"ch.qos.logback/logback-classic":             {},
+	"org.apache.logging.log4j/log4j-core":        {},
+	"org.slf4j/slf4j-simple":                     {},
+	"org.apache.logging.log4j/log4j-slf4j-impl":  {},
+	"org.apache.logging.log4j/log4j-slf4j2-impl": {},
+
+	// WebJars — served as classpath resources, never imported in Java source.
+	"org.webjars/bootstrap":            {},
+	"org.webjars/font-awesome":         {},
+	"org.webjars/webjars-locator-lite": {},
+	"org.webjars/webjars-locator-core": {},
+	"org.webjars/jquery":               {},
+	"org.webjars.npm/htmx.org":         {},
 }
 
 // buildMavenImportPaths generates candidate import path prefixes for a Maven PURL.

--- a/internal/application/diet/service.go
+++ b/internal/application/diet/service.go
@@ -235,7 +235,7 @@ func (s *Service) buildEntries(
 
 		// Check if this dependency is a Maven runtime dep (reflection-loaded).
 		if entry.Scope == "" && entry.Ecosystem == "maven" {
-			if _, ok := mavenRuntimeDeps[entry.Name]; ok {
+			if _, ok := mavenRuntimeDeps[strings.ToLower(entry.Name)]; ok {
 				entry.Scope = domaindiet.ScopeRuntime
 			}
 		}

--- a/internal/application/diet/service_test.go
+++ b/internal/application/diet/service_test.go
@@ -914,51 +914,53 @@ func TestRun_RuntimeDepsNotFlaggedAsUnused(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name           string
-		purl           string
-		wantScope      string
-		wantIsUnused   bool
-		wantMinBreadth int
+		name            string
+		purl            string
+		wantScope       string
+		wantIsUnused    bool
+		wantAPIBreadth  int
 	}{
 		{
 			name:           "MySQL JDBC driver recognized as runtime",
 			purl:           "pkg:maven/mysql/mysql-connector-j@9.0.0",
 			wantScope:      domaindiet.ScopeRuntime,
 			wantIsUnused:   false,
-			wantMinBreadth: 1,
+			wantAPIBreadth: 1,
 		},
 		{
 			name:           "PostgreSQL JDBC driver recognized as runtime",
 			purl:           "pkg:maven/org.postgresql/postgresql@42.7.0",
 			wantScope:      domaindiet.ScopeRuntime,
 			wantIsUnused:   false,
-			wantMinBreadth: 1,
+			wantAPIBreadth: 1,
 		},
 		{
 			name:           "Logback logging backend recognized as runtime",
 			purl:           "pkg:maven/ch.qos.logback/logback-classic@1.5.6",
 			wantScope:      domaindiet.ScopeRuntime,
 			wantIsUnused:   false,
-			wantMinBreadth: 1,
+			wantAPIBreadth: 1,
 		},
 		{
 			name:           "WebJars bootstrap recognized as runtime",
 			purl:           "pkg:maven/org.webjars/bootstrap@5.3.3",
 			wantScope:      domaindiet.ScopeRuntime,
 			wantIsUnused:   false,
-			wantMinBreadth: 1,
+			wantAPIBreadth: 1,
 		},
 		{
-			name:         "Non-runtime Maven dep unaffected",
-			purl:         "pkg:maven/com.google.guava/guava@33.0.0",
-			wantScope:    "",
-			wantIsUnused: true,
+			name:           "Non-runtime Maven dep unaffected",
+			purl:           "pkg:maven/com.google.guava/guava@33.0.0",
+			wantScope:      "",
+			wantIsUnused:   true,
+			wantAPIBreadth: 0,
 		},
 		{
-			name:         "Non-Maven PURL unaffected",
-			purl:         "pkg:golang/github.com/gin-gonic/gin@v1.10.0",
-			wantScope:    "",
-			wantIsUnused: true,
+			name:           "Non-Maven PURL unaffected",
+			purl:           "pkg:golang/github.com/gin-gonic/gin@v1.10.0",
+			wantScope:      "",
+			wantIsUnused:   true,
+			wantAPIBreadth: 0,
 		},
 	}
 
@@ -1006,8 +1008,8 @@ func TestRun_RuntimeDepsNotFlaggedAsUnused(t *testing.T) {
 			if entry.Coupling.IsUnused != tt.wantIsUnused {
 				t.Errorf("IsUnused = %v, want %v", entry.Coupling.IsUnused, tt.wantIsUnused)
 			}
-			if tt.wantMinBreadth > 0 && entry.Coupling.APIBreadth < tt.wantMinBreadth {
-				t.Errorf("APIBreadth = %d, want >= %d", entry.Coupling.APIBreadth, tt.wantMinBreadth)
+			if entry.Coupling.APIBreadth != tt.wantAPIBreadth {
+				t.Errorf("APIBreadth = %d, want %d", entry.Coupling.APIBreadth, tt.wantAPIBreadth)
 			}
 			// Runtime deps should not be classified as trivial difficulty.
 			if tt.wantScope == domaindiet.ScopeRuntime && entry.Scores.Difficulty == domaindiet.DifficultyTrivial {

--- a/internal/application/diet/service_test.go
+++ b/internal/application/diet/service_test.go
@@ -910,3 +910,109 @@ func TestRun_WheelFallback_ResolverError(t *testing.T) {
 	}
 }
 
+func TestRun_RuntimeDepsNotFlaggedAsUnused(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		purl           string
+		wantScope      string
+		wantIsUnused   bool
+		wantMinBreadth int
+	}{
+		{
+			name:           "MySQL JDBC driver recognized as runtime",
+			purl:           "pkg:maven/mysql/mysql-connector-j@9.0.0",
+			wantScope:      domaindiet.ScopeRuntime,
+			wantIsUnused:   false,
+			wantMinBreadth: 1,
+		},
+		{
+			name:           "PostgreSQL JDBC driver recognized as runtime",
+			purl:           "pkg:maven/org.postgresql/postgresql@42.7.0",
+			wantScope:      domaindiet.ScopeRuntime,
+			wantIsUnused:   false,
+			wantMinBreadth: 1,
+		},
+		{
+			name:           "Logback logging backend recognized as runtime",
+			purl:           "pkg:maven/ch.qos.logback/logback-classic@1.5.6",
+			wantScope:      domaindiet.ScopeRuntime,
+			wantIsUnused:   false,
+			wantMinBreadth: 1,
+		},
+		{
+			name:           "WebJars bootstrap recognized as runtime",
+			purl:           "pkg:maven/org.webjars/bootstrap@5.3.3",
+			wantScope:      domaindiet.ScopeRuntime,
+			wantIsUnused:   false,
+			wantMinBreadth: 1,
+		},
+		{
+			name:         "Non-runtime Maven dep unaffected",
+			purl:         "pkg:maven/com.google.guava/guava@33.0.0",
+			wantScope:    "",
+			wantIsUnused: true,
+		},
+		{
+			name:         "Non-Maven PURL unaffected",
+			purl:         "pkg:golang/github.com/gin-gonic/gin@v1.10.0",
+			wantScope:    "",
+			wantIsUnused: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			graphResult := &domaindiet.GraphResult{
+				DirectDeps: []string{tt.purl},
+				Metrics: map[string]*domaindiet.GraphMetrics{
+					tt.purl: {
+						ExclusiveTransitiveCount: 3,
+						TotalTransitiveCount:     5,
+					},
+				},
+				TotalTransitive: 5,
+			}
+
+			// Source analysis returns no coupling — dep would normally be unused.
+			sourceResults := map[string]*domaindiet.CouplingAnalysis{}
+
+			svc := NewService(
+				&stubGraphAnalyzer{result: graphResult},
+				&stubSourceAnalyzer{result: sourceResults},
+				nil, // no PyPI resolver
+				nil, // no AnalysisService
+			)
+
+			plan, err := svc.Run(context.Background(), DietInput{
+				SBOMData:   []byte("fake-sbom"),
+				SBOMPath:   "test.sbom.json",
+				SourceRoot: "/tmp/src",
+			})
+			if err != nil {
+				t.Fatalf("Run() error: %v", err)
+			}
+			if len(plan.Entries) != 1 {
+				t.Fatalf("expected 1 entry, got %d", len(plan.Entries))
+			}
+
+			entry := plan.Entries[0]
+			if entry.Scope != tt.wantScope {
+				t.Errorf("Scope = %q, want %q", entry.Scope, tt.wantScope)
+			}
+			if entry.Coupling.IsUnused != tt.wantIsUnused {
+				t.Errorf("IsUnused = %v, want %v", entry.Coupling.IsUnused, tt.wantIsUnused)
+			}
+			if tt.wantMinBreadth > 0 && entry.Coupling.APIBreadth < tt.wantMinBreadth {
+				t.Errorf("APIBreadth = %d, want >= %d", entry.Coupling.APIBreadth, tt.wantMinBreadth)
+			}
+			// Runtime deps should not be classified as trivial difficulty.
+			if tt.wantScope == domaindiet.ScopeRuntime && entry.Scores.Difficulty == domaindiet.DifficultyTrivial {
+				t.Errorf("runtime dep should not be classified as trivial difficulty")
+			}
+		})
+	}
+}

--- a/internal/domain/diet/types.go
+++ b/internal/domain/diet/types.go
@@ -5,6 +5,13 @@ const (
 	// ScopeTool indicates a Go tool directive dependency (Go 1.24+).
 	// Tool deps are dev/CI executables that intentionally have zero source imports.
 	ScopeTool = "tool"
+
+	// ScopeRuntime indicates a dependency loaded via runtime mechanisms
+	// (reflection, ServiceLoader, classpath resources) rather than static imports.
+	// Examples: JDBC drivers, logging backends, Spring auto-config, webjars.
+	// These deps intentionally have zero source-level imports and should not
+	// be flagged as unused.
+	ScopeRuntime = "runtime"
 )
 
 // DietEntry represents a single dependency's removability analysis.
@@ -14,7 +21,7 @@ type DietEntry struct {
 	Ecosystem string
 	Version   string
 	Relation  string // "direct" or "transitive"
-	Scope     string // "" (runtime, default) or "tool" (Go tool directive)
+	Scope     string // "" (default), "tool" (Go tool directive), or "runtime" (reflection-loaded)
 
 	Graph    GraphMetrics
 	Coupling CouplingAnalysis

--- a/internal/domain/diet/types.go
+++ b/internal/domain/diet/types.go
@@ -21,7 +21,7 @@ type DietEntry struct {
 	Ecosystem string
 	Version   string
 	Relation  string // "direct" or "transitive"
-	Scope     string // "" (default), "tool" (Go tool directive), or "runtime" (reflection-loaded)
+	Scope     string // "" (default), "tool" (Go tool directive), or "runtime" (loaded via runtime mechanisms such as reflection, ServiceLoader, or classpath resources)
 
 	Graph    GraphMetrics
 	Coupling CouplingAnalysis

--- a/internal/infrastructure/treesitter/analyzer.go
+++ b/internal/infrastructure/treesitter/analyzer.go
@@ -387,6 +387,19 @@ func (a *Analyzer) extractImports(
 // nesting.
 const maxAncestorWalkDepth = 5
 
+// callSiteCaptureNames lists the tree-sitter capture names used for call-site
+// counting across all language configs. Captures not in this set (e.g., @decorator,
+// @metaKey used only for predicate filtering) are excluded from counting logic.
+var callSiteCaptureNames = map[string]bool{
+	"func":   true, // JS/TS/Python/Java: bare function or constructor call
+	"obj":    true, // JS: member_expression object
+	"prop":   true, // JS: member_expression property
+	"pkg":    true, // Go/Python: package or module identifier
+	"attr":   true, // Python: attribute access
+	"field":  true, // Go/Java: field or member access
+	"method": true, // Java: method invocation or reference
+}
+
 // countCallSites counts selector/member expressions matching known aliases.
 func (a *Analyzer) countCallSites(
 	cfg *langConfig,
@@ -413,11 +426,22 @@ func (a *Analyzer) countCallSites(
 		if !ok {
 			break
 		}
+		// Apply tree-sitter predicates (e.g., #eq?, #match?) to filter matches.
+		match = cursor.FilterPredicates(match, src)
 
-		if len(match.Captures) >= 2 {
+		// Extract only the captures relevant to call-site counting, skipping
+		// auxiliary captures used solely for predicate filtering (e.g., @decorator, @metaKey).
+		var relevant []sitter.QueryCapture
+		for _, c := range match.Captures {
+			if callSiteCaptureNames[query.CaptureNameForId(c.Index)] {
+				relevant = append(relevant, c)
+			}
+		}
+
+		if len(relevant) >= 2 {
 			// Two-capture match: pkg.field pattern (e.g., requests.get)
-			pkg := match.Captures[0].Node.Content(src)
-			field := match.Captures[1].Node.Content(src)
+			pkg := relevant[0].Node.Content(src)
+			field := relevant[1].Node.Content(src)
 
 			purls, ok := aliasMap[pkg]
 			if !ok {
@@ -431,9 +455,9 @@ func (a *Analyzer) countCallSites(
 				acc.callSites++
 				acc.symbols[field] = true
 			}
-		} else if len(match.Captures) == 1 {
+		} else if len(relevant) == 1 {
 			// Single-capture match: bare identifier call (e.g., get() from "from x import get")
-			funcName := match.Captures[0].Node.Content(src)
+			funcName := relevant[0].Node.Content(src)
 
 			purls, ok := aliasMap[funcName]
 			if !ok {

--- a/internal/infrastructure/treesitter/lang_javascript.go
+++ b/internal/infrastructure/treesitter/lang_javascript.go
@@ -77,6 +77,37 @@ func newJSLikeConfig(lang *sitter.Language, includeJSX bool) *langConfig {
 		`(return_statement (identifier) @func)`,
 		// x = DEV
 		`(assignment_expression right: (identifier) @func)`,
+
+		// Framework decorator/registration patterns (#262).
+		// Angular @NgModule/@Component: identifiers in decorator array arguments
+		// (imports, declarations, exports) are module/component registrations that
+		// prove the dependency is used, even though actual usage happens in HTML
+		// templates outside the TypeScript AST.
+		// Constrained to NgModule/Component decorators and imports/declarations/exports
+		// keys to avoid false positives from unrelated decorators (e.g., providers).
+		`((decorator
+			(call_expression
+				function: (identifier) @decorator
+				arguments: (arguments
+					(object
+						(pair
+							key: (property_identifier) @metaKey
+							value: (array (identifier) @func))))))
+			(#match? @decorator "^(NgModule|Component)$")
+			(#match? @metaKey "^(imports|declarations|exports)$"))`,
+		// Vue defineComponent / Options API: shorthand property identifiers inside
+		// the `components` option object (e.g., components: { MyChild }) register
+		// components for template use. Constrained to defineComponent({ components: { ... } })
+		// to avoid false positives from unrelated nested object literals.
+		`(call_expression
+			function: (identifier) @vueCallee
+			(#eq? @vueCallee "defineComponent")
+			arguments: (arguments
+				(object
+					(pair
+						key: (property_identifier) @vueComponentsKey
+						(#eq? @vueComponentsKey "components")
+						value: (object (shorthand_property_identifier) @func)))))`,
 	}
 	if includeJSX {
 		callPatterns = append(callPatterns,

--- a/internal/infrastructure/treesitter/lang_javascript_test.go
+++ b/internal/infrastructure/treesitter/lang_javascript_test.go
@@ -1952,3 +1952,194 @@ sync();
 		})
 	}
 }
+
+// TestAnalyzer_AngularDecoratorRegistrations verifies that identifiers inside
+// Angular decorator array arguments (@NgModule imports/declarations, standalone
+// @Component imports) are detected as call sites. This prevents false IBNC for
+// component-library dependencies that are only used via HTML template selectors.
+// Closes #262.
+func TestAnalyzer_AngularDecoratorRegistrations(t *testing.T) {
+	tests := []struct {
+		name        string
+		filename    string
+		code        string
+		importPaths map[string][]string
+		purl        string
+		wantCalls   int
+		wantBreadth int
+		wantSymbols []string
+	}{
+		{
+			name:     "NgModule imports array",
+			filename: "app.module.ts",
+			code: `import { NgModule } from "@angular/core";
+import { FormsModule } from "@angular/forms";
+import { HttpClientModule } from "@angular/common/http";
+import { AppComponent } from "./app.component";
+
+@NgModule({
+  imports: [FormsModule, HttpClientModule],
+  declarations: [AppComponent],
+})
+export class AppModule {}
+`,
+			importPaths: map[string][]string{
+				"pkg:npm/%40angular/forms@17.0.0": {"@angular/forms"},
+			},
+			purl:        "pkg:npm/%40angular/forms@17.0.0",
+			wantCalls:   1,
+			wantBreadth: 1,
+			wantSymbols: []string{"FormsModule"},
+		},
+		{
+			name:     "NgModule declarations array",
+			filename: "app.module.ts",
+			code: `import { NgModule } from "@angular/core";
+import { BrowserModule } from "@angular/platform-browser";
+import { AppComponent } from "./app.component";
+import { HeroComponent } from "./hero.component";
+
+@NgModule({
+  imports: [BrowserModule],
+  declarations: [AppComponent, HeroComponent],
+})
+export class AppModule {}
+`,
+			importPaths: map[string][]string{
+				"pkg:npm/%40angular/platform-browser@17.0.0": {"@angular/platform-browser"},
+			},
+			purl:        "pkg:npm/%40angular/platform-browser@17.0.0",
+			wantCalls:   1,
+			wantBreadth: 1,
+			wantSymbols: []string{"BrowserModule"},
+		},
+		{
+			name:     "standalone Component imports",
+			filename: "my.component.ts",
+			code: `import { Component } from "@angular/core";
+import { CommonModule } from "@angular/common";
+import { RouterModule } from "@angular/router";
+
+@Component({
+  standalone: true,
+  imports: [CommonModule, RouterModule],
+  template: '<div></div>',
+})
+export class MyComponent {}
+`,
+			importPaths: map[string][]string{
+				"pkg:npm/%40angular/common@17.0.0": {"@angular/common"},
+				"pkg:npm/%40angular/router@17.0.0": {"@angular/router"},
+			},
+			purl:        "pkg:npm/%40angular/common@17.0.0",
+			wantCalls:   1,
+			wantBreadth: 1,
+			wantSymbols: []string{"CommonModule"},
+		},
+		{
+			name:     "Injectable decorator NOT captured as extra call sites",
+			filename: "my.service.ts",
+			code: `import { Injectable } from "@angular/core";
+
+@Injectable({
+  providedIn: 'root',
+})
+export class MyService {}
+`,
+			importPaths: map[string][]string{
+				"pkg:npm/%40angular/core@17.0.0": {"@angular/core"},
+			},
+			purl: "pkg:npm/%40angular/core@17.0.0",
+			// Injectable() is captured as a bare call_expression by existing patterns.
+			// Its string argument ('root') should not produce extra call sites.
+			wantCalls:   1,
+			wantBreadth: 1,
+			wantSymbols: []string{"Injectable"},
+		},
+		{
+			name:     "Vue defineComponent with components option",
+			filename: "MyPage.ts",
+			code: `import { defineComponent } from "vue";
+import MyChild from "my-child-component";
+
+export default defineComponent({
+  components: {
+    MyChild,
+  },
+  setup() {
+    return {};
+  }
+});
+`,
+			importPaths: map[string][]string{
+				"pkg:npm/my-child-component@1.0.0": {"my-child-component"},
+			},
+			purl:        "pkg:npm/my-child-component@1.0.0",
+			wantCalls:   1,
+			wantBreadth: 1,
+			wantSymbols: []string{"MyChild"},
+		},
+		{
+			name:     "multiple modules in NgModule imports and exports",
+			filename: "shared.module.ts",
+			code: `import { NgModule } from "@angular/core";
+import { CommonModule } from "@angular/common";
+import { FormsModule, ReactiveFormsModule } from "@angular/forms";
+
+@NgModule({
+  imports: [CommonModule, FormsModule, ReactiveFormsModule],
+  exports: [CommonModule, FormsModule, ReactiveFormsModule],
+})
+export class SharedModule {}
+`,
+			importPaths: map[string][]string{
+				"pkg:npm/%40angular/forms@17.0.0": {"@angular/forms"},
+			},
+			purl: "pkg:npm/%40angular/forms@17.0.0",
+			// FormsModule appears in both imports and exports (2 sites),
+			// ReactiveFormsModule appears in both imports and exports (2 sites).
+			wantCalls:   4,
+			wantBreadth: 2,
+			wantSymbols: []string{"FormsModule", "ReactiveFormsModule"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			err := os.WriteFile(filepath.Join(dir, tt.filename), []byte(tt.code), 0644)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			analyzer := NewAnalyzer()
+			result, err := analyzer.AnalyzeCoupling(context.Background(), dir, tt.importPaths)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			ca, ok := result[tt.purl]
+			if !ok {
+				t.Fatalf("expected coupling analysis for %s", tt.purl)
+			}
+
+			if ca.CallSiteCount != tt.wantCalls {
+				t.Errorf("CallSiteCount = %d, want %d", ca.CallSiteCount, tt.wantCalls)
+			}
+			if ca.APIBreadth != tt.wantBreadth {
+				t.Errorf("APIBreadth = %d, want %d", ca.APIBreadth, tt.wantBreadth)
+			}
+
+			sort.Strings(tt.wantSymbols)
+			if len(ca.Symbols) != len(tt.wantSymbols) {
+				t.Errorf("Symbols = %v, want %v", ca.Symbols, tt.wantSymbols)
+			} else {
+				for i, s := range ca.Symbols {
+					if s != tt.wantSymbols[i] {
+						t.Errorf("Symbols[%d] = %q, want %q", i, s, tt.wantSymbols[i])
+					}
+				}
+			}
+		})
+	}
+}

--- a/internal/interfaces/cli/diet_render.go
+++ b/internal/interfaces/cli/diet_render.go
@@ -225,7 +225,7 @@ func renderDietDetailed(w io.Writer, plan *domaindiet.DietPlan) error {
 		if e.Scope == domaindiet.ScopeTool {
 			p.printf("│    Status: TOOL (go.mod tool directive — not imported in source)\n")
 		} else if e.Scope == domaindiet.ScopeRuntime {
-			p.printf("│    Status: RUNTIME (reflection/ServiceLoader — not statically imported)\n")
+			p.printf("│    Status: RUNTIME (reflection/ServiceLoader/classpath resources — not statically imported)\n")
 		} else if e.Coupling.IsUnused {
 			p.printf("│    Status: UNUSED (0 imports found)\n")
 		} else {

--- a/internal/interfaces/cli/diet_render.go
+++ b/internal/interfaces/cli/diet_render.go
@@ -224,6 +224,8 @@ func renderDietDetailed(w io.Writer, plan *domaindiet.DietPlan) error {
 		p.printf("│  Coupling\n")
 		if e.Scope == domaindiet.ScopeTool {
 			p.printf("│    Status: TOOL (go.mod tool directive — not imported in source)\n")
+		} else if e.Scope == domaindiet.ScopeRuntime {
+			p.printf("│    Status: RUNTIME (reflection/ServiceLoader — not statically imported)\n")
 		} else if e.Coupling.IsUnused {
 			p.printf("│    Status: UNUSED (0 imports found)\n")
 		} else {


### PR DESCRIPTION
## Summary
- Add `ScopeRuntime` scope for Java dependencies loaded via reflection (JDBC drivers, logging backends, webjars)
- Follows existing `ScopeTool` pattern: known Maven coordinates are recognized and excluded from unused-dep recommendations
- Prevents false-positive removal recommendations for critical runtime dependencies
- Display `RUNTIME` status in detailed diet output

## Before (reproduction test output)

```
$ GOWORK=off go test -v -run TestRun_RuntimeDepsNotFlaggedAsUnused ./internal/application/diet/
testing: warning: no tests to run
PASS
ok  github.com/future-architect/uzomuzo-oss/internal/application/diet  0.007s [no tests to run]
```

JDBC drivers like `mysql-connector-j` would be flagged with `IsUnused=true`, `Scope=""`, `Difficulty=trivial` — a false-positive removal recommendation for a critical runtime dependency.

## After (verification test output)

```
$ GOWORK=off go test -v -run TestRun_RuntimeDepsNotFlaggedAsUnused ./internal/application/diet/
=== RUN   TestRun_RuntimeDepsNotFlaggedAsUnused
=== RUN   TestRun_RuntimeDepsNotFlaggedAsUnused/MySQL_JDBC_driver_recognized_as_runtime
=== RUN   TestRun_RuntimeDepsNotFlaggedAsUnused/PostgreSQL_JDBC_driver_recognized_as_runtime
=== RUN   TestRun_RuntimeDepsNotFlaggedAsUnused/Logback_logging_backend_recognized_as_runtime
=== RUN   TestRun_RuntimeDepsNotFlaggedAsUnused/WebJars_bootstrap_recognized_as_runtime
=== RUN   TestRun_RuntimeDepsNotFlaggedAsUnused/Non-runtime_Maven_dep_unaffected
=== RUN   TestRun_RuntimeDepsNotFlaggedAsUnused/Non-Maven_PURL_unaffected
--- PASS: TestRun_RuntimeDepsNotFlaggedAsUnused (0.00s)
    --- PASS: TestRun_RuntimeDepsNotFlaggedAsUnused/WebJars_bootstrap_recognized_as_runtime (0.00s)
    --- PASS: TestRun_RuntimeDepsNotFlaggedAsUnused/MySQL_JDBC_driver_recognized_as_runtime (0.00s)
    --- PASS: TestRun_RuntimeDepsNotFlaggedAsUnused/Logback_logging_backend_recognized_as_runtime (0.00s)
    --- PASS: TestRun_RuntimeDepsNotFlaggedAsUnused/Non-Maven_PURL_unaffected (0.00s)
    --- PASS: TestRun_RuntimeDepsNotFlaggedAsUnused/Non-runtime_Maven_dep_unaffected (0.00s)
    --- PASS: TestRun_RuntimeDepsNotFlaggedAsUnused/PostgreSQL_JDBC_driver_recognized_as_runtime (0.00s)
PASS
ok  github.com/future-architect/uzomuzo-oss/internal/application/diet  0.008s
```

Closes #248

## Test plan
- [x] JDBC driver (mysql-connector-j) recognized as ScopeRuntime
- [x] Logging backend (logback-classic) recognized as ScopeRuntime
- [x] WebJars dependency recognized as ScopeRuntime
- [x] Non-runtime Maven dep unaffected
- [x] Non-Maven PURL unaffected
- [x] go vet passes
- [x] golangci-lint passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)