### PR TITLE
docs: brush up diet-remove skill with IBNC safety checks

### DIFF
--- a/claude-skills/diet-remove/SKILL.md
+++ b/claude-skills/diet-remove/SKILL.md
@@ -22,9 +22,20 @@ Parse `$ARGUMENTS` for flags:
 
 **Safety principle**: Every removal must pass build + vet + test before committing. If any step fails, stop and diagnose — don't force it.
 
+### GitHub Actions detection
+
+If the target PURL starts with `pkg:githubactions/` or is a GitHub Action name (`owner/action`):
+
+1. **Find usage**: `grep -rn "{action-name}" .github/workflows/ --include="*.yml" --include="*.yaml"`
+2. **Assess impact**: Count workflow files and jobs affected. Note whether release-critical pipelines are involved.
+3. **Find replacement**: Check if an official replacement, maintained fork, or first-party alternative exists (e.g., `tibdex/github-app-token` → `actions/create-github-app-token`).
+4. **Pin strategy**: Replacement should use SHA pins with version comments (e.g., `uses: actions/checkout@<sha> # v4.2.0`).
+
+The rest of the flow (duplicate check, issue template, etc.) proceeds identically. In the Usage breakdown table, list workflow files instead of source files.
+
 ## Phase 1: Pre-flight checks
 
-Before writing any code, answer these three questions:
+Before writing any code, run through these checks:
 
 ### 1. Will it actually disappear?
 
@@ -77,8 +88,25 @@ Check these before starting:
 - **Generated code**: Files with `// Code generated` headers are trivially migrated
   by re-running the generator with the replacement tool.
 
-- **Blank imports**: `import _ "pkg"` only runs `init()`. Check what `init()` does
-  (usually driver/codec registration) before removing.
+- **Blank / side-effect imports**: See the IBNC checklist in step 4 below.
+
+### 4. IBNC safety check (imports-but-no-calls patterns)
+
+If the dependency shows 0 call sites but >0 import files, it may still be required. Verify it is not:
+
+- [ ] Side-effect import (`import _ "pkg"`, `import 'pkg'`, `require('pkg')` without assignment)
+- [ ] Database / driver registration (blank import or conditional `require()`)
+- [ ] Config-driven plugin (eslint, tailwind, babel, postcss — referenced in config files, not imports)
+- [ ] Framework DI / decorator (`@Entity`, `@Autowired`, `extends Framework`, Ember DI)
+- [ ] Annotation-only usage (Java: `@NotNull`, `@JsonProperty` — the annotation *is* the usage)
+- [ ] Type-only / constant-only package (imported for types or constants, zero function calls)
+- [ ] Delegated composition (called indirectly through SDK wrappers or framework context objects)
+
+If any apply, the dependency is **not safe to remove** even if call-site analysis shows 0 calls. See `docs/ibnc-patterns.md` for the full pattern taxonomy with evidence from 79+ OSS projects.
+
+### 5. SBOM tool awareness
+
+Note which SBOM tool (trivy/syft/cdxgen) and version generated the dependency data. Tool choice can produce 10-20x variance in dependency counts for the same project, affecting which dependencies appear and their coupling scores. If the dep count seems unexpectedly low, cross-check with a different tool.
 
 ## Issue mode (default): File a GitHub Issue
 
@@ -125,11 +153,12 @@ Title: dep: replace EOL {dependency} with {replacement}
 Body:
 ## Problem
 
-`{dependency}` is {lifecycle status} (detected by [uzomuzo diet](https://github.com/future-architect/uzomuzo-oss)).
+`{dependency}` is {lifecycle status}.
 {1-2 sentences on why this matters — security risk, no more patches, etc.}
 
 ## Impact analysis
 
+- **Detected by**: [uzomuzo diet](https://github.com/future-architect/uzomuzo-oss) with {sbom-tool} {version}
 - **Files**: {N} files import this dependency
 - **Call sites**: {N} calls across {N} APIs
 - **Exclusive transitive deps**: {N} (removed together)
@@ -156,6 +185,14 @@ Body:
 
 {any env var renames needed, or "None"}
 
+## False-positive risk
+
+{If the dependency matches an IBNC pattern (side-effect import, config-driven plugin, framework DI, etc.), note it here. If none apply, write "None — all usage is via direct function calls."}
+
+## Cross-project context
+
+{If the same dependency is known to be EOL/archived in other major OSS projects, note it here. E.g., "mitchellh/go-homedir is archived and also affects Trivy, Terraform, Vault, and MinIO." If no cross-project data is available, write "No cross-project data available."}
+
 ## Notes
 
 - {any hidden complications from Phase 1 step 3}
@@ -174,7 +211,15 @@ Before filing, check the target repository's issue templates:
    ```
 3. If blank issues are enabled or a "feature request" template exists, use `gh issue create`
 
-**After filing, stop.** Do not proceed to implementation.
+### After filing
+
+Do not proceed to implementation. The issue/discussion is the deliverable.
+
+**Follow-up guidance:**
+- If no maintainer response after **2 weeks**, add a polite ping comment.
+- If the maintainer responds with **"PR welcome"**, you may re-run with `--pr` to implement (but check if you can reproduce CI locally first).
+- If the same dependency is EOL across **multiple projects** (e.g., mitchellh/* packages), cross-reference the issues in each body so maintainers see the ecosystem-wide pattern.
+- If the dependency would benefit from **structural reform** rather than individual removal (e.g., a framework that pulls in many EOL deps), mention this in the Notes section — the insight is valuable even if you can't implement it yourself.
 
 If `--pr` was specified, skip this section and continue to Phase 1.5 below.
 
@@ -290,6 +335,8 @@ go mod tidy
 For npm: Remove from `package.json`, run `npm install` or equivalent.
 For Python: Remove from `requirements.txt` / `pyproject.toml`, run `pip install`.
 For Maven: Remove from `pom.xml`.
+
+**Monorepo warning**: In monorepos with workspace-managed lockfiles (pnpm, yarn workspaces, Gradle multi-module), the lockfile must be regenerated in the monorepo environment. If you cannot run the package manager locally, use Issue mode instead of PR mode — the next.js @vercel/kv removal failed CI entirely because `pnpm-lock.yaml` was not regenerated.
 
 ## Phase 3: Verification
 

--- a/claude-skills/diet-remove/SKILL.md
+++ b/claude-skills/diet-remove/SKILL.md
@@ -468,6 +468,8 @@ Structural reform approaches:
 | `c-robinson/iplib` | `net/netip` CIDR enumeration | 1 hr | IPv4 network/broadcast edge cases |
 | Trivy fanal framework | Direct parser calls | 2 days | -68% binary size, found pnpm bug |
 
+**Language coverage**: PR mode commands and common patterns are currently Go-centric, built from real removal experience. Issue mode and IBNC checks are language-agnostic. PRs adding equivalent PR-mode guidance for npm, pip, Maven, or other ecosystems (backed by actual removal data) are welcome.
+
 ## Primary Source Links
 
 All generated content (commit messages, issues, PRs, discussions) MUST include primary source links so reviewers can verify claims independently.

--- a/claude-skills/diet-remove/SKILL.md
+++ b/claude-skills/diet-remove/SKILL.md
@@ -22,6 +22,16 @@ Parse `$ARGUMENTS` for flags:
 
 **Safety principle**: Every removal must pass build + vet + test before committing. If any step fails, stop and diagnose — don't force it.
 
+### Ecosystem detection
+
+Detect the ecosystem from the PURL scheme or module path (`pkg:golang/` → Go, `pkg:npm/` → npm, `pkg:pypi/` → Python, `pkg:maven/` → Maven, `pkg:githubactions/` → GitHub Actions).
+
+If the ecosystem is **not Go**, display this notice to the user before proceeding:
+
+> **Note**: This skill's PR-mode commands and common patterns are optimized for Go. Issue mode and IBNC safety checks work for any language, but ecosystem-specific PR-mode guidance (verification commands, edge cases, lockfile handling) is still being developed for {ecosystem}. If you discover surprises or improvements during this removal, please contribute them via an issue or PR to [future-architect/uzomuzo-oss](https://github.com/future-architect/uzomuzo-oss).
+
+Then continue with the rest of the flow — the analysis, IBNC checks, and issue template are language-agnostic.
+
 ### GitHub Actions detection
 
 If the target PURL starts with `pkg:githubactions/` or is a GitHub Action name (`owner/action`):

--- a/docs/ibnc-patterns.md
+++ b/docs/ibnc-patterns.md
@@ -1,0 +1,166 @@
+# IBNC Pattern Taxonomy
+
+[← Back to README.md](../README.md)
+
+**IBNC** (Imports-But-No-Calls) describes dependencies that appear unused by static call-site analysis but are actually required at runtime. Removing them breaks the build or causes runtime failures.
+
+This document is referenced by `/diet-remove` (Phase 1 step 4). It is maintained from empirical findings across 79+ OSS projects in 5 languages (Go, Java, TypeScript, JavaScript, Python) from diet-fuzz campaigns (April 2026).
+
+## Quick Reference Checklist
+
+Before classifying a dependency as "unused" or "trivial to remove," verify it is not one of these patterns:
+
+- [ ] **Side-effect import** -- `import _ "pkg"` (Go), `import 'pkg'` (JS/TS), `require('pkg')` without assignment
+- [ ] **Database / driver registration** -- blank import or conditional `require()` for DB drivers
+- [ ] **Config-driven plugin** -- referenced in config files (eslint, tailwind, babel, postcss), not source imports
+- [ ] **Framework DI / decorator** -- `@Entity`, `@Autowired`, `extends Framework`, Ember DI
+- [ ] **Annotation-only usage** -- Java annotations (`@NotNull`, `@JsonProperty`) where the annotation *is* the usage
+- [ ] **Type-only / constant-only package** -- imported for types or constants, zero function calls
+- [ ] **Delegated composition** -- called indirectly through SDK wrappers or framework context objects
+
+## Patterns in Detail
+
+### 1. Side-Effect Import
+
+**Languages**: Go, TypeScript, JavaScript
+
+The import statement itself *is* the usage. The module's `init()` function (Go) or top-level code (JS/TS) registers drivers, patches globals, or augments prototypes.
+
+| Language | Syntax | Example |
+|----------|--------|---------|
+| Go | `import _ "github.com/lib/pq"` | Registers PostgreSQL driver with `database/sql` |
+| TypeScript | `import 'reflect-metadata'` | Patches global `Reflect` API for decorator support (794 import files in typeorm) |
+| JavaScript | `require('isomorphic-fetch')` | Patches global `fetch` |
+| CSS-only | `import 'normalize.css'` | Pure CSS package with zero JS API surface |
+
+**Detection**: Look for `import _ "..."` (Go), `import 'pkg'` without destructuring (JS/TS), or packages with no exported API.
+
+**Related issues**: [#258](https://github.com/future-architect/uzomuzo-oss/issues/258) (Go cgo/driver blank imports), [#261](https://github.com/future-architect/uzomuzo-oss/issues/261) (CSS-only imports)
+
+### 2. Database / Driver Registration
+
+**Languages**: Go, TypeScript, Java
+
+A specialization of Pattern 1: database drivers are loaded at runtime via registration mechanisms, not direct function calls from user code. Listed separately because the consequences of removal (broken DB connections) are more severe and harder to diagnose than general side-effect imports.
+
+| Language | Pattern | Example |
+|----------|---------|---------|
+| Go | `import _ "github.com/mattn/go-sqlite3"` | Registers via `sql.Register()` in `init()` |
+| TypeScript | `require('pg')` inside try-catch | typeorm loads drivers conditionally based on user config |
+| Java | `Class.forName("com.mysql.cj.jdbc.Driver")` | JDBC driver registration via reflection |
+
+**Evidence**: hashicorp/vault (go-mssqldb, go-hdb), typeorm (@google-cloud/spanner, mssql, mysql2, better-sqlite3).
+
+**Related issues**: [#258](https://github.com/future-architect/uzomuzo-oss/issues/258)
+
+### 3. Config-Driven Plugin
+
+**Languages**: TypeScript, JavaScript
+
+The dependency is referenced in a configuration file (JSON, JS, YAML), not in source code imports. Static import analysis will never find it.
+
+| Config file | Plugin type | Example |
+|-------------|------------|---------|
+| `.eslintrc` / `eslint.config.js` | ESLint plugin | `eslint-plugin-unicorn`, `eslint-plugin-markdown` |
+| `tailwind.config.js` | Tailwind plugin | `@tailwindcss/typography` |
+| `babel.config.js` | Babel plugin | `@babel/plugin-transform-runtime` |
+| `postcss.config.js` | PostCSS plugin | `autoprefixer` |
+| `jest.config.js` | Jest preset/transform | `ts-jest`, `esbuild-register` |
+
+**Detection**: Search config files (`*.config.js`, `.*rc`, `*.config.ts`) in addition to source imports.
+
+**Note**: CLI-only tools (`wrangler`, `jest`, `ava`, `zx`) also fall in this category -- invoked as binaries, not imported.
+
+### 4. Framework DI / Decorator
+
+**Languages**: TypeScript, JavaScript, Java
+
+Frameworks use inversion-of-control patterns (dependency injection, decorators, class inheritance) to wire components. The framework invokes user code, not the other way around.
+
+| Framework | Pattern | Example |
+|-----------|---------|---------|
+| Ember | `extends GlimmerComponent`, `@classic` decorator | Ghost produced 80+ IBNC from Ember DI alone |
+| NestJS | `@Injectable()`, `@Module()` | Adapter/transport packages loaded conditionally |
+| Angular | `<app-component>` in templates | Template component usage invisible to import analysis |
+| Vue | `<PrimeButton>` in `<template>` blocks | Component registered in `<script>`, used in `<template>` |
+| Spring | `@Autowired`, `@Service`, classpath scanning | Auto-configuration loads beans via reflection |
+| Netty | `extends ChannelInboundHandlerAdapter` | Handlers invoked by event loop, not user code |
+
+**Evidence**: TryGhost/Ghost (Ember, 80+ IBNC), NestJS (16 IBNC via cdxgen), OpenFeign/feign (Netty, 3 modules), spring-petclinic (caffeine, mysql-connector-j via auto-config).
+
+**Related issues**: [#262](https://github.com/future-architect/uzomuzo-oss/issues/262) (Angular/Vue template detection), [#288](https://github.com/future-architect/uzomuzo-oss/issues/288) (Framework interface dispatch), [#295](https://github.com/future-architect/uzomuzo-oss/issues/295) (Spring Boot starter false-sharing)
+
+### 5. Annotation-Only Usage
+
+**Languages**: Java
+
+Java annotations are applied to classes, fields, and methods as metadata. The annotation processor or framework reads them at compile time or runtime. There is no function call to detect.
+
+| Annotation source | Examples | Used by |
+|-------------------|----------|---------|
+| Bean Validation (Hibernate Validator) | `@NotNull`, `@Size`, `@Min`, `@Max` | Entity field validation |
+| JPA (Jakarta Persistence) | `@Entity`, `@Column`, `@Table` | ORM mapping |
+| Lombok | `@Data`, `@Getter`, `@Builder` | Compile-time code generation |
+| Jackson | `@JsonProperty`, `@JsonIgnore` | JSON serialization |
+
+**Evidence**: linlinjava/litemall (hibernate-validator: 2 import files, 0 call sites).
+
+**Related issues**: [#287](https://github.com/future-architect/uzomuzo-oss/issues/287)
+
+### 6. Type-Only / Constant-Only Package
+
+**Languages**: Go, Java, TypeScript
+
+The package is imported solely for type definitions or constants. No functions or methods are called.
+
+| Language | Pattern | Example |
+|----------|---------|---------|
+| Go | `proton.Link`, `proton.Auth` (types), `proton.LinkStateActive` (constant) | rclone go-proton-api: 1 import file, 0 call sites |
+| Java | `extends Foo<Bar>` where `Bar` is from external package | netty protobuf-java: `MessageLiteOrBuilder` used as type argument |
+| TypeScript | `import type { Foo } from 'pkg'` | Type-only imports (often stripped at compile time) |
+
+**Evidence**: rclone (go-proton-api), netty (protobuf-java via generic type arguments).
+
+**Related issues**: [#278](https://github.com/future-architect/uzomuzo-oss/issues/278) (Type-only / constant-only packages), [#286](https://github.com/future-architect/uzomuzo-oss/issues/286) (Java generic type arguments)
+
+### 7. Delegated Composition
+
+**Languages**: JavaScript, Go
+
+The dependency is called indirectly through a higher-level wrapper, framework context, or SDK layer. The call site exists in the wrapper's source, not in user code.
+
+| Pattern | Example |
+|---------|---------|
+| Koa context delegation | `http-assert` called via `this.assert()` inside koa |
+| SDK wrapper | `1password/onepassword-sdk-go` called through higher-level SDK |
+| Plugin array registration | `metascraper([author(), description(), ...])` -- 7 plugins in Ghost |
+| Class inheritance | `@socket.io/component-emitter` via `extends Emitter` |
+
+**Evidence**: koajs/koa (http-assert via context delegation), TryGhost/Ghost (7 metascraper plugins via array registration), socket.io (component-emitter via class inheritance).
+
+**Detection**: Check if the dependency is a transitive dependency of another direct dependency that wraps it.
+
+## Cross-Cutting Concerns
+
+### SBOM Tool Variance
+
+The same project analyzed with different SBOM tools (trivy, syft, cdxgen) can produce **10-20x variance** in dependency counts. This directly affects which dependencies appear in the analysis and how many IBNC patterns surface.
+
+| Tool | Strength | Weakness |
+|------|----------|----------|
+| trivy | Reliable Go/npm resolution | Misparses some Python projects, excludes devDependencies |
+| syft | Includes devDependencies, finds GitHub Actions | No Python dependency graph, low Java multi-module counts |
+| cdxgen | Richest JS SBOMs (4,585 vs 226 for Ghost) | Monorepo root detection issues (Gradle) |
+
+### Cross-Language SBOM Contamination
+
+Mixed-language repositories (Go + Ember UI, Python + React frontend) produce SBOMs that include dependencies from the other language. These cross-language deps appear as IBNC because the coupling analyzer for one language cannot trace imports in another.
+
+**Evidence**: hashicorp/vault (Ember UI deps in Go SBOM), dagster (JS frontend deps in Python SBOM), spring-boot-admin (Vue frontend deps in Java SBOM).
+
+## Maintenance
+
+This document is updated when diet-fuzz campaigns discover new IBNC categories. Each pattern entry must include:
+- At least one real-world evidence project
+- A link to the tracking issue (if one exists)
+- The affected languages


### PR DESCRIPTION
## Summary

- Add **IBNC (Imports-But-No-Calls) safety checklist** to Phase 1 pre-flight checks — prevents false "unused" removals of side-effect imports, database drivers, config-driven plugins, framework DI targets, annotation-only deps, type-only packages, and delegated composition
- Add **`docs/ibnc-patterns.md`** — shared reference with full pattern taxonomy, evidence from 79+ OSS projects across 5 languages (Go, Java, TypeScript, JavaScript, Python)
- Add **GitHub Actions removal flow** — auto-detects `pkg:githubactions/` PURLs, guides workflow file analysis and SHA-pinned replacements (based on grafana#121911 success)
- Add **SBOM tool awareness** note — flags 10-20x dep count variance between trivy/syft/cdxgen
- Enrich **Issue template** with Detected-by (tool+version), False-positive risk, Cross-project context fields
- Add **post-filing guidance** — follow-up timing (2 weeks), "PR welcome" pivot, cross-project cross-referencing
- Add **monorepo lockfile warning** in PR mode (from next.js @vercel/kv CI failure)

## Motivation

Analysis of 4 real diet-remove operations (next.js, grafana, vault, trivy) and 559 diet-fuzz JSON results across 79+ projects revealed gaps:
1. No guard against removing IBNC-pattern deps that appear unused but are runtime-required
2. GitHub Actions removal had no guidance despite a proven success case
3. Issue template lacked reproducibility info (SBOM tool) and safety signals (false-positive risk)

## Test plan

- [ ] Verify SKILL.md renders correctly in GitHub markdown preview
- [ ] Verify `docs/ibnc-patterns.md` nav link `[← Back to README.md](../README.md)` resolves
- [ ] Verify IBNC checklist in SKILL.md matches Quick Reference in ibnc-patterns.md
- [ ] Run `/diet-remove` against a test dependency to confirm the new Phase 1 steps appear in the workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)