### PR TITLE
docs: rewrite diet-evaluate-removal skill with data-driven 5-phase framework

### DIFF
--- a/claude-skills/README.md
+++ b/claude-skills/README.md
@@ -22,19 +22,26 @@ Detects EOL packages with uzomuzo, then uses the LLM to trace data flow through 
 /diet-assess-risk top 5
 ```
 
-### `/diet-evaluate-removal` — 6-Axis Dependency Removal Evaluation
+### `/diet-evaluate-removal` — Data-Driven Dependency Removal Evaluation
 
-Evaluates a single dependency for removal feasibility across six axes.
+Evaluates a single dependency for removal using a 5-phase data-driven framework that leverages diet's full JSON output.
 
-**The 6 axes:**
-| Axis | Question |
-|------|----------|
-| Update PR reduction | How many automated PRs does this dep generate? |
-| Clean dependency list | Does removing it clarify the dependency intent? |
-| Code standardization | Can it be replaced with stdlib? |
-| Supply chain risk | Is it abandoned? Does removing reduce attack surface? |
-| Code portability | How coupled is the usage? |
-| Future removal readiness | Does removing this unblock further cleanups? |
+**The 5 phases:**
+1. **Ingest Diet Data** -- Extract all fields from diet JSON (existing file or fresh run)
+2. **Usage Classification** -- Classify `import_files` into production/test/CI/example/generated
+3. **Feasibility Analysis** -- API leakage gate check + symbol-by-symbol migration map
+4. **6-Axis Scoring** -- Data-anchored ratings (no guesswork)
+5. **Verdict** -- Structured REMOVE/DEFER/KEEP recommendation
+
+**The 6 axes** (each anchored to concrete diet data):
+| Axis | Data source |
+|------|-------------|
+| Transitive Cleanup | `exclusive_transitive` |
+| Production Scope | Usage classification from Phase 2 |
+| Coupling Depth | `coupling_effort`, `call_site_count`, `api_breadth` |
+| Replaceability | Symbol migration map from Phase 3 |
+| Security Urgency | `has_vulnerabilities`, `max_cvss_score`, `lifecycle` |
+| Cascade Potential | `exclusive_transitive` + project knowledge |
 
 ```bash
 # In Claude Code
@@ -92,8 +99,8 @@ These skills are the LLM-powered stages of the `scan → diet → LLM → remove
 ```
 uzomuzo diet              Rank all deps by removability        (automated, CLI)
        ↓
-/diet-assess-risk         "How dangerous is it to keep?"       (LLM reads source)
-/diet-evaluate-removal    "Is removal worth the effort?"       (LLM evaluates 6 axes)
+/diet-assess-risk         "How dangerous is it to keep?"       (LLM traces data flow)
+/diet-evaluate-removal    "Is removal worth the effort?"       (LLM classifies usage + scores 6 axes)
        ↓
 /diet-remove              "Remove it safely"                   (LLM implements change)
 ```

--- a/claude-skills/diet-evaluate-removal/SKILL.md
+++ b/claude-skills/diet-evaluate-removal/SKILL.md
@@ -40,7 +40,7 @@ Display ALL of these from the diet JSON. Do NOT re-compute any of them.
 |-------|-------------------|
 | `name` / `version` / `ecosystem` | Dependency identity |
 | `purl` | Canonical package URL identifier |
-| `scope` | Dependency scope (e.g., `"tool"` for build-time-only deps) |
+| `scope` | Dependency scope: `"tool"` (build-time-only), `"runtime"` (reflection/ServiceLoader-loaded) |
 | `rank` / `priority_score` | Where this dep sits in the removal priority list |
 | `difficulty` | trivial / easy / moderate / hard |
 | `exclusive_transitive` / `total_transitive` | Deps removed together / total transitive count |
@@ -63,6 +63,7 @@ Display ALL of these from the diet JSON. Do NOT re-compute any of them.
 Before proceeding, flag any of these patterns -- they indicate diet's coupling data may be unreliable:
 
 - `scope: "tool"` + `import_file_count: 0` -- Expected for build-time-only tool deps. Not an IBNC pattern. These have zero runtime imports by design.
+- `scope: "runtime"` + `import_file_count: 0` -- Expected for runtime-mechanism deps (JDBC drivers, logging backends, Spring auto-config). Loaded via reflection/ServiceLoader/classpath, not static imports.
 - `has_blank_import: true` + `call_site_count: 0` -- The blank import IS the usage (Go DB drivers, JS polyfills). Coupling is underestimated.
 - `has_wildcard_import: true` -- All symbols are in scope. `api_breadth` may undercount.
 - `has_dot_import: true` -- Broadly coupled; symbols lack package qualifier.
@@ -172,7 +173,7 @@ Rate each axis High/Med/Low using the data gathered in Phases 1-3. Each axis is 
 | **Production Scope** | Phase 2 classification | 0 production files (all test/CI/example) | < 50% production files | >= 50% production files |
 | **Coupling Depth** | `coupling_effort`, `import_file_count`, `call_site_count` | `coupling_effort` < 0.25 (trivial/easy) | 0.25 - 0.6 (moderate) | >= 0.6 (hard, deeply wired) |
 | **Replaceability** | Phase 3b symbol map | > 80% symbols have stdlib/existing-dep replacement | 50-80% replaceable | < 50%, or crypto/protocol involved |
-| **Security Urgency** | `has_vulnerabilities`, `max_cvss_score`, `lifecycle` | CVSS >= 7.0, or lifecycle EOL-Confirmed/EOL-Effective/Archived | CVSS 4.0-6.9, or lifecycle Stalled/EOL-Scheduled | No vulns, lifecycle Active/Legacy-Safe |
+| **Security Urgency** | `has_vulnerabilities`, `max_cvss_score`, `lifecycle` | CVSS >= 7.0, or lifecycle EOL-Confirmed/EOL-Effective/Archived | CVSS 4.0-6.9, or lifecycle Stalled/EOL-Scheduled/Review Needed | No vulns, lifecycle Active/Legacy-Safe |
 | **Cascade Potential** | `exclusive_transitive`, project knowledge | Removing unblocks 3+ further removals | Unblocks 1-2 | Standalone, no cascade |
 
 ### Scoring overrides
@@ -245,8 +246,8 @@ Rules are evaluated **top-to-bottom; first match wins.** If multiple rows could 
 | Replaceability = Low (crypto/protocol) | KEEP -- find an alternative maintained library rather than self-implementing. If Security Urgency is also High, escalate to `/diet-assess-risk` for full risk analysis. Never recommend self-implementing crypto/protocol |
 | All 6 axes High or Med | REMOVE |
 | 1-2 axes Low, rest High/Med | REMOVE -- note the Low axes as caveats in rationale |
-| >= 3 axes Low | KEEP |
 | Security Urgency = High, others mixed | REMOVE (prioritize security). Suggest `/diet-assess-risk` for full analysis |
+| >= 3 axes Low | KEEP |
 | `stays_as_indirect: true`, coupling low | REMOVE (still valuable: delegates version management, unblocks future cleanup) |
 
 ### Effort derivation

--- a/claude-skills/diet-evaluate-removal/SKILL.md
+++ b/claude-skills/diet-evaluate-removal/SKILL.md
@@ -1,126 +1,253 @@
 ---
 name: diet-evaluate-removal
-description: "6-axis deep evaluation of whether a dependency is worth removing"
-argument-hint: "<module path, e.g. github.com/pkg/errors>"
+description: "Data-driven deep evaluation of whether a dependency is worth removing"
+argument-hint: "<dependency name, e.g. github.com/pkg/errors>"
 ---
 
 # Diet Removal Evaluation: $ARGUMENTS
 
-Deep-dive evaluation of whether `$ARGUMENTS` is worth removing, using a 6-axis framework. This command picks up where `uzomuzo diet` leaves off — diet gives you the priority ranking, this gives you the removal plan.
+Deep-dive evaluation of whether `$ARGUMENTS` is worth removing, using a 5-phase data-driven framework. This command picks up where `uzomuzo diet` leaves off -- diet gives you the priority ranking, this gives you the removal verdict.
 
-**When to use**: After `uzomuzo diet` ranks a dependency as moderate/easy but you're unsure whether to invest the effort. Also useful for "hard" dependencies where you need a concrete migration plan.
+**When to use**: After `uzomuzo diet` ranks a dependency and you need to decide whether to invest the effort. Works for any difficulty level -- trivial deps get a quick confirmation, hard deps get a concrete migration plan.
 
-**Relationship to diet**:
+**Relationship to other skills**:
 - `uzomuzo diet` tells you **ranking and difficulty** (automated, all dependencies at once)
-- `/diet-evaluate-removal` tells you **exactly how to remove it** and **whether it's worth it** (LLM-powered, one dependency at a time)
+- `/diet-evaluate-removal` tells you **whether it's worth removing** and **how** (LLM-powered, one dependency at a time)
+- `/diet-assess-risk` tells you **how dangerous it is to keep** (LLM-powered, security focus)
+- `/diet-remove` **executes the removal** (LLM-powered, implementation)
 
-## Phase 1: Gather diet context
+---
 
-If a diet plan is available, extract the target dependency's automated scores first:
+## Phase 1: Ingest Diet Data
 
+Extract the target dependency's diet JSON entry. Prefer existing JSON over re-running diet.
+
+**Option A -- existing diet JSON** (preferred):
+```bash
+jq '.dependencies[] | select(.name == "$ARGUMENTS")' diet.json
+```
+
+**Option B -- run diet now**:
 ```bash
 uzomuzo diet --sbom bom.json --source . --format json | jq '.dependencies[] | select(.name == "$ARGUMENTS")'
 ```
 
-Note the following from diet (do NOT re-compute these):
-- **ONLY-VIA-THIS**: transitive deps removed together
-- **FILES / CALLS / API breadth**: coupling metrics
-- **Difficulty**: trivial / easy / moderate / hard
-- **Lifecycle**: maintenance status
+### Required fields to extract
 
-## Phase 2: Analysis beyond diet
+Display ALL of these from the diet JSON. Do NOT re-compute any of them.
 
-Focus on what diet's automated analysis cannot determine:
+| Field | What it tells you |
+|-------|-------------------|
+| `name` / `version` / `ecosystem` | Dependency identity |
+| `purl` | Canonical package URL identifier |
+| `rank` / `priority_score` | Where this dep sits in the removal priority list |
+| `difficulty` | trivial / easy / moderate / hard |
+| `exclusive_transitive` / `total_transitive` | Deps removed together / total transitive count |
+| `stays_as_indirect` | Whether it remains after removing direct usage |
+| `indirect_via` | Which other deps pull it in transitively |
+| `import_file_count` | Number of files importing this dep |
+| `call_site_count` | Total call sites across all files |
+| `api_breadth` | Number of distinct APIs used |
+| `symbols` | Exact API surface used (function/type names) |
+| `import_files` | Exact file paths that import this dep |
+| `has_blank_import` / `has_dot_import` / `has_wildcard_import` | Special import patterns |
+| `is_unused` | Whether diet detected zero imports |
+| `lifecycle` | EOL-Confirmed / Archived / Stalled / Active / etc. |
+| `has_vulnerabilities` / `vulnerability_count` / `max_cvss_score` | Security signals |
+| `graph_impact` / `coupling_effort` / `health_risk` | Score components |
 
-### 1. Full removal feasibility
+### Data quality check
 
-Check whether removing direct usage actually eliminates the module, or if it stays as an indirect dependency.
+Before proceeding, flag any of these patterns -- they indicate diet's coupling data may be unreliable:
 
-For Go projects:
-```bash
-go mod why -m $ARGUMENTS
-# or faster: go mod graph | grep " $ARGUMENTS@"
-```
+- `has_blank_import: true` + `call_site_count: 0` -- The blank import IS the usage (Go DB drivers, JS polyfills). Coupling is underestimated.
+- `has_wildcard_import: true` -- All symbols are in scope. `api_breadth` may undercount.
+- `has_dot_import: true` -- Broadly coupled; symbols lack package qualifier.
+- `import_file_count > 0` + `call_site_count: 0` -- Possible IBNC pattern (type-only usage, annotation processing, framework DI, config-driven plugins). Investigate before trusting "0 calls."
 
-For other ecosystems: check if other direct dependencies pull this in transitively.
+---
 
-### 2. API leakage check
+## Phase 2: Usage Classification
 
-**Critical**: Do any types from this dependency appear in EXPORTED identifiers?
-- If yes → removing it is a **breaking change** for downstream consumers
-- If no → internal swap, no API impact
+Classify each entry in `import_files` by its role in the project. This is the single most important step -- it determines the **effective difficulty** of removal.
 
-This is the single most important factor diet cannot detect.
+### Classification categories
 
-### 3. Generated code check
+| Category | Path patterns | Impact |
+|----------|--------------|--------|
+| **Production** | `src/`, `lib/`, `internal/`, `pkg/`, `cmd/`, `app/` (not under test/) | Full migration required |
+| **Test** | `*_test.go`, `test/`, `tests/`, `__tests__/`, `spec/`, `*.test.ts` | Can delete or swap independently |
+| **CI / Infrastructure** | `.github/`, `scripts/`, `ci/`, `Makefile`, `build/` | Often trivially replaceable |
+| **Example / Demo** | `examples/`, `example/`, `demo/`, `sample/` | Can delete or update separately |
+| **Generated** | Files with `// Code generated` header, `*_gen.go`, `*.pb.go` | Re-run generator with replacement |
 
-For each file importing the dependency, check for:
-- `// Code generated` headers
-- `//go:generate` directives referencing this module's tools
-
-Generated files are trivially migrated by re-running the generator with a replacement tool.
-
-### 4. Replacement options
-
-Evaluate concrete alternatives (check compatibility with the project's language version):
-
-| Option | Estimated effort | Risk | Notes |
-|--------|-----------------|------|-------|
-| Standard library | N lines | Low | Available since version X |
-| Consolidate into existing dep | N lines | Low | Already in go.mod/package.json |
-| Smaller alternative | N lines | Med | New dependency, but smaller |
-| Self-implement | N lines (+ N test lines) | Varies | Only if non-crypto, non-protocol |
-
-**Do NOT self-implement** crypto, protocol, or security-related functionality.
-
-### 5. Maintenance burden history
-
-```bash
-git log --all --oneline --grep="$ARGUMENTS" --since="2023-01-01" | wc -l
-```
-
-How many PRs/commits were caused by this dependency? (Dependabot updates, breaking changes, etc.)
-
-## Phase 3: 6-Axis Evaluation
-
-| Axis | Rating | Notes |
-|------|--------|-------|
-| Update PR reduction | High/Med/Low | N PRs/year eliminated |
-| Clean dependency list | High/Med/Low | Does removing clarify intent? |
-| Code standardization | High/Med/Low | Can it be replaced with stdlib? |
-| Supply chain risk | High/Med/Low | Is it abandoned + handles sensitive data? |
-| Code portability | High/Med/Low | Does removing make code easier to extract? |
-| Future removal readiness | High/Med/Low | Does this unblock further cleanups? |
-
-### Rating anchors
-
-| Axis | High | Medium | Low |
-|------|------|--------|-----|
-| Update PR reduction | >10 PRs/year | 3-10 PRs/year | 0-2 PRs/year |
-| Clean dependency list | Removes confusing dep | One of many similar | Marginal |
-| Code standardization | Full stdlib replacement | Partial stdlib | No alternative |
-| Supply chain risk | Abandoned + credentials/crypto | Abandoned + config/metadata | Maintained or test-only |
-| Code portability | Types in exported API | Internal, moderate coupling | Isolated |
-| Future removal readiness | Blocks 3+ other deps | Blocks 1-2 deps | No blocking |
-
-## Phase 4: Verdict
+### Output format
 
 ```
-### Verdict: $ARGUMENTS
+Usage Classification for {name}:
+  Production:     {N} files  [{file list}]
+  Test:           {N} files  [{file list}]
+  CI/Infra:       {N} files  [{file list}]
+  Example:        {N} files  [{file list}]
+  Generated:      {N} files  [{file list}]
 
-**Diet ranking**: #{rank}, priority {score}, difficulty {level}
-**Full removal possible**: Yes / Stays as indirect (via X)
-**API leakage**: Yes (breaking change) / No
-
-**Recommendation**: Full removal / Self-implement / Keep (wrap) / Test-only (ignore)
-**Effort**: Trivial (<1h) / Small (1-4h) / Medium (1-3d) / Large (1+ week)
-**Priority**: S (immediate) / A (soon) / B (when convenient) / C (keep)
-**Cost-effectiveness**: {effort vs. 6-axis summary}
+  Effective scope: {N} production files (out of {total} total)
 ```
+
+### Effective difficulty adjustment
+
+| diet difficulty | All files are test/CI/example | Adjusted difficulty |
+|----------------|------------------------------|---------------------|
+| hard | Yes | easy (no production impact) |
+| moderate | Yes | trivial |
+| easy/trivial | -- | unchanged |
+
+If ALL import files are non-production, note: **"Zero production code impact."**
+
+---
+
+## Phase 3: Feasibility Analysis
+
+Two checks that diet cannot automate: API leakage (a binary gate) and symbol replaceability (requires domain knowledge).
+
+### 3a. API Leakage Check (GATE)
+
+**Critical question**: Do any types from this dependency appear in EXPORTED identifiers?
+
+- If **yes** -- removing it is a **breaking change** for downstream consumers. Flag this immediately. The verdict must account for the breaking change cost.
+- If **no** -- internal swap, no API impact.
+
+Check approach by ecosystem:
+
+| Ecosystem | Command |
+|-----------|---------|
+| Go | `grep -rn "func.*{pkg}\|type.*{pkg}" --include="*.go" \| grep -v _test.go` -- look for exported (capitalized) identifiers |
+| npm/TS | `grep -rn "export.*from.*'{pkg}'" --include="*.ts" --include="*.tsx"` |
+| Python | `grep -rn "from {pkg} import" --include="*.py"` in `__init__.py` files (re-exports) |
+| Java/Maven | `grep -rn "public.*{pkg}" --include="*.java"` in non-test source sets |
+
+### 3b. Symbol Migration Map
+
+Using the `symbols` list from diet, classify each symbol's replaceability. This is where the LLM adds the most value.
+
+```
+Symbol Migration Map for {name}:
+
+| Symbol | Category | Replacement | Notes |
+|--------|----------|-------------|-------|
+| {sym1} | stdlib   | {specific function} | Available since {version} |
+| {sym2} | existing-dep | {dep already in project} | Already in go.mod/package.json |
+| {sym3} | self-impl | {N}-line implementation | Non-crypto, well-defined |
+| {sym4} | no-replacement | -- | Crypto/protocol, keep or find alternative lib |
+
+Summary: {N}/{total} stdlib, {N} existing-dep, {N} self-impl, {N} no-replacement.
+```
+
+**Rules for symbol classification**:
+- **stdlib**: Prefer this. Name the specific function (e.g., `os.UserHomeDir()`, `slices.SortFunc()`). Note the minimum language version required.
+- **existing-dep**: A dependency already in the project provides this. No new dependency added.
+- **self-impl**: Only for non-crypto, non-protocol, non-security functionality. Estimate lines of code including tests.
+- **no-replacement**: The symbol has no viable alternative. This blocks removal unless the feature can be dropped.
+
+**Special cases**:
+- If `is_unused: true` -- skip this step. The dep can simply be deleted.
+- If `has_blank_import: true` and `call_site_count <= 1` -- the import itself is the usage (driver registration, polyfill). Check what `init()` does; the replacement is typically a different driver package, not a code change.
+
+---
+
+## Phase 4: 6-Axis Quantitative Scoring
+
+Rate each axis High/Med/Low using the data gathered in Phases 1-3. Each axis is anchored to concrete data -- no guesswork.
+
+| Axis | Data Source | High (favors removal) | Medium | Low (discourages removal) |
+|------|-----------|------|--------|------|
+| **Transitive Cleanup** | `exclusive_transitive` | >= 10 exclusive deps | 1-9 exclusive | 0 exclusive |
+| **Production Scope** | Phase 2 classification | 0 production files (all test/CI/example) | < 50% production files | >= 50% production files |
+| **Coupling Depth** | `coupling_effort`, `import_file_count`, `call_site_count` | `coupling_effort` < 0.2 (trivial/easy) | 0.2 - 0.5 (moderate) | > 0.5 (hard, deeply wired) |
+| **Replaceability** | Phase 3b symbol map | > 80% symbols have stdlib/existing-dep replacement | 50-80% replaceable | < 50%, or crypto/protocol involved |
+| **Security Urgency** | `has_vulnerabilities`, `max_cvss_score`, `lifecycle` | CVSS >= 7.0, or lifecycle EOL/Archived | CVSS 4.0-6.9, or lifecycle Stalled | No vulns, lifecycle Active |
+| **Cascade Potential** | `exclusive_transitive`, project knowledge | Removing unblocks 3+ further removals | Unblocks 1-2 | Standalone, no cascade |
+
+### Scoring output
+
+```
+6-Axis Scores:
+  Transitive Cleanup:  {H/M/L} -- {exclusive_transitive} exclusive deps ({reasoning})
+  Production Scope:    {H/M/L} -- {N}/{total} files are production ({reasoning})
+  Coupling Depth:      {H/M/L} -- effort={coupling_effort:.2f}, {call_site_count} calls across {api_breadth} APIs
+  Replaceability:      {H/M/L} -- {N}/{total} symbols replaceable ({reasoning})
+  Security Urgency:    {H/M/L} -- {lifecycle}, {vulnerability_count} vulns, max CVSS {max_cvss_score}
+  Cascade Potential:   {H/M/L} -- {reasoning}
+```
+
+---
+
+## Phase 5: Verdict
+
+Synthesize all phases into a structured recommendation. Use the exact field names from diet JSON.
+
+```
+### Verdict: {name}@{version}
+
+**Diet Data**:
+  rank: #{rank}
+  priority_score: {priority_score:.3f}
+  difficulty: {difficulty}
+  ecosystem: {ecosystem}
+
+**Graph**:
+  exclusive_transitive: {exclusive_transitive}
+  total_transitive: {total_transitive}
+  stays_as_indirect: {stays_as_indirect}
+  indirect_via: {indirect_via or "none"}
+
+**Coupling**:
+  {import_file_count} files ({N} production, {N} test, {N} other)
+  {call_site_count} calls across {api_breadth} APIs
+  symbols: {symbols count} ({N} stdlib-replaceable, {N} self-impl, {N} no-replacement)
+
+**Health**:
+  lifecycle: {lifecycle}
+  vulnerabilities: {vulnerability_count} (max CVSS {max_cvss_score})
+
+**API Leakage**: {Yes (BREAKING CHANGE) / No}
+
+**6-Axis Summary**:
+  {axis}: {H/M/L}  (x6, from Phase 4)
+
+**Recommendation**: REMOVE / DEFER / KEEP
+**Effort**: Trivial (<1h) / Small (1-4h) / Medium (1-3d) / Large (1w+)
+**Priority**: S (do now) / A (this sprint) / B (when convenient) / C (keep for now)
+**Rationale**: {1-2 sentences -- why this recommendation, citing the key axis scores}
+```
+
+### Recommendation logic
+
+| Condition | Recommendation |
+|-----------|---------------|
+| `is_unused: true` | REMOVE, Trivial, Priority S |
+| All 6 axes High or Med, no API leakage | REMOVE |
+| 1-2 axes Low, rest High/Med, no API leakage | REMOVE -- note the Low axes as caveats in rationale |
+| API leakage = Yes | DEFER (needs major version bump or deprecation period) |
+| Replaceability = Low (crypto/protocol) | KEEP unless Security Urgency is High |
+| >= 3 axes Low | KEEP |
+| Security Urgency = High, others mixed | REMOVE (prioritize security). Suggest `/diet-assess-risk` for full analysis |
+| `stays_as_indirect: true`, coupling low | REMOVE (still valuable: delegates version management, unblocks future cleanup) |
+
+### When to recommend further analysis
+
+- Security Urgency = High --> "Consider running `/diet-assess-risk {name}` for full data-flow analysis."
+- Recommendation = REMOVE, Effort >= Medium --> "Use `/diet-remove {name} --pr` for guided implementation."
+- Recommendation = REMOVE, external project --> "Use `/diet-remove {name} --repo {owner/repo}` to file an issue."
+
+---
 
 ## Important rules
 
-- **Start from diet's output.** Don't re-compute FILES, CALLS, ONLY-VIA-THIS, or lifecycle status.
-- **Focus on what diet can't determine**: API leakage, generated code, replacement feasibility, maintenance history, 6-axis evaluation.
-- **Be concrete about replacements.** Don't just say "use stdlib" — name the specific function and show the migration pattern.
-- **This works for any language.** Adapt the Go-specific commands (go mod why, go mod graph) to the project's ecosystem.
+- **Start from diet's output.** Never re-compute fields that diet already provides.
+- **Classify before scoring.** Usage classification (Phase 2) changes everything -- always do it before the 6-axis scoring.
+- **API leakage is a gate, not a spectrum.** If exported types depend on this package, flag it immediately.
+- **Be concrete about replacements.** Don't say "use stdlib" -- name the specific function, note the version requirement, show the migration pattern.
+- **Respect IBNC patterns.** If `has_blank_import` is true and `call_site_count` is 0, the import IS the usage. Don't call it "unused."
+- **This works for any language.** The `ecosystem` field in diet JSON tells you which language. Use the ecosystem-specific commands in Phase 3a.
+- **One dependency at a time.** This skill is for deep single-dep analysis. For batch evaluation, run it in a loop.

--- a/claude-skills/diet-evaluate-removal/SKILL.md
+++ b/claude-skills/diet-evaluate-removal/SKILL.md
@@ -40,6 +40,7 @@ Display ALL of these from the diet JSON. Do NOT re-compute any of them.
 |-------|-------------------|
 | `name` / `version` / `ecosystem` | Dependency identity |
 | `purl` | Canonical package URL identifier |
+| `scope` | Dependency scope (e.g., `"tool"` for build-time-only deps) |
 | `rank` / `priority_score` | Where this dep sits in the removal priority list |
 | `difficulty` | trivial / easy / moderate / hard |
 | `exclusive_transitive` / `total_transitive` | Deps removed together / total transitive count |
@@ -52,18 +53,20 @@ Display ALL of these from the diet JSON. Do NOT re-compute any of them.
 | `import_files` | Exact file paths that import this dep |
 | `has_blank_import` / `has_dot_import` / `has_wildcard_import` | Special import patterns |
 | `is_unused` | Whether diet detected zero imports |
-| `lifecycle` | EOL-Confirmed / Archived / Stalled / Active / etc. |
+| `lifecycle` | Active / Stalled / Legacy-Safe / EOL-Confirmed / EOL-Effective / EOL-Scheduled / Archived / Review Needed |
 | `has_vulnerabilities` / `vulnerability_count` / `max_cvss_score` | Security signals |
+| `overall_score` | Composite health score (OpenSSF Scorecard) |
 | `graph_impact` / `coupling_effort` / `health_risk` | Score components |
 
 ### Data quality check
 
 Before proceeding, flag any of these patterns -- they indicate diet's coupling data may be unreliable:
 
+- `scope: "tool"` + `import_file_count: 0` -- Expected for build-time-only tool deps. Not an IBNC pattern. These have zero runtime imports by design.
 - `has_blank_import: true` + `call_site_count: 0` -- The blank import IS the usage (Go DB drivers, JS polyfills). Coupling is underestimated.
 - `has_wildcard_import: true` -- All symbols are in scope. `api_breadth` may undercount.
 - `has_dot_import: true` -- Broadly coupled; symbols lack package qualifier.
-- `import_file_count > 0` + `call_site_count: 0` -- Possible IBNC pattern (type-only usage, annotation processing, framework DI, config-driven plugins). Investigate before trusting "0 calls."
+- `import_file_count > 0` + `call_site_count: 0` (without blank/dot/wildcard flags) -- Possible IBNC pattern (type-only usage, annotation processing, framework DI, config-driven plugins). Investigate before trusting "0 calls." Note: distinct from the blank-import pattern above -- blank imports typically produce `call_site_count = 1`, not 0.
 
 ---
 
@@ -80,6 +83,7 @@ Classify each entry in `import_files` by its role in the project. This is the si
 | **CI / Infrastructure** | `.github/`, `scripts/`, `ci/`, `Makefile`, `build/` | Often trivially replaceable |
 | **Example / Demo** | `examples/`, `example/`, `demo/`, `sample/` | Can delete or update separately |
 | **Generated** | Files with `// Code generated` header, `*_gen.go`, `*.pb.go` | Re-run generator with replacement |
+| **Vendored** | `vendor/`, `node_modules/`, `third_party/` | Exclude from analysis -- copies of the dep, not usage |
 
 ### Output format
 
@@ -117,14 +121,16 @@ Two checks that diet cannot automate: API leakage (a binary gate) and symbol rep
 - If **yes** -- removing it is a **breaking change** for downstream consumers. Flag this immediately. The verdict must account for the breaking change cost.
 - If **no** -- internal swap, no API impact.
 
+Look for the package's types in **exported function signatures** (parameter types, return types), **exported struct field types**, and **exported interface method signatures**. Internal usage within function bodies is NOT API leakage.
+
 Check approach by ecosystem:
 
-| Ecosystem | Command |
-|-----------|---------|
-| Go | `grep -rn "func.*{pkg}\|type.*{pkg}" --include="*.go" \| grep -v _test.go` -- look for exported (capitalized) identifiers |
-| npm/TS | `grep -rn "export.*from.*'{pkg}'" --include="*.ts" --include="*.tsx"` |
-| Python | `grep -rn "from {pkg} import" --include="*.py"` in `__init__.py` files (re-exports) |
-| Java/Maven | `grep -rn "public.*{pkg}" --include="*.java"` in non-test source sets |
+| Ecosystem | What to check |
+|-----------|---------------|
+| Go | Exported func signatures, struct fields, and interface methods that reference the dep's types. Search non-test files for the dep's package name in type positions. |
+| npm/TS | `export ... from '{pkg}'` re-exports, or exported types/interfaces using the dep's types. |
+| Python | Re-exports in `__init__.py` files: `from {pkg} import ...` that are part of the public API. |
+| Java/Maven | Public class signatures, method parameters, return types, or field types referencing the dep's packages in non-test source sets. |
 
 ### 3b. Symbol Migration Map
 
@@ -151,7 +157,8 @@ Summary: {N}/{total} stdlib, {N} existing-dep, {N} self-impl, {N} no-replacement
 
 **Special cases**:
 - If `is_unused: true` -- skip this step. The dep can simply be deleted.
-- If `has_blank_import: true` and `call_site_count <= 1` -- the import itself is the usage (driver registration, polyfill). Check what `init()` does; the replacement is typically a different driver package, not a code change.
+- If `has_blank_import: true` and `call_site_count <= 1` -- the import itself is the usage (driver registration, polyfill). Check what `init()` does; the replacement is typically a different driver package, not a code change. Score Replaceability as High if a drop-in alternative driver/polyfill exists, Low if not.
+- If `symbols` is empty but `import_file_count > 0` (without blank/dot/wildcard flags) -- diet's coupling analysis may be incomplete. Manually inspect the import files to determine actual API usage before scoring Replaceability. Note the gap in the rationale.
 
 ---
 
@@ -163,10 +170,15 @@ Rate each axis High/Med/Low using the data gathered in Phases 1-3. Each axis is 
 |------|-----------|------|--------|------|
 | **Transitive Cleanup** | `exclusive_transitive` | >= 10 exclusive deps | 1-9 exclusive | 0 exclusive |
 | **Production Scope** | Phase 2 classification | 0 production files (all test/CI/example) | < 50% production files | >= 50% production files |
-| **Coupling Depth** | `coupling_effort`, `import_file_count`, `call_site_count` | `coupling_effort` < 0.2 (trivial/easy) | 0.2 - 0.5 (moderate) | > 0.5 (hard, deeply wired) |
+| **Coupling Depth** | `coupling_effort`, `import_file_count`, `call_site_count` | `coupling_effort` < 0.25 (trivial/easy) | 0.25 - 0.6 (moderate) | >= 0.6 (hard, deeply wired) |
 | **Replaceability** | Phase 3b symbol map | > 80% symbols have stdlib/existing-dep replacement | 50-80% replaceable | < 50%, or crypto/protocol involved |
-| **Security Urgency** | `has_vulnerabilities`, `max_cvss_score`, `lifecycle` | CVSS >= 7.0, or lifecycle EOL/Archived | CVSS 4.0-6.9, or lifecycle Stalled | No vulns, lifecycle Active |
+| **Security Urgency** | `has_vulnerabilities`, `max_cvss_score`, `lifecycle` | CVSS >= 7.0, or lifecycle EOL-Confirmed/EOL-Effective/Archived | CVSS 4.0-6.9, or lifecycle Stalled/EOL-Scheduled | No vulns, lifecycle Active/Legacy-Safe |
 | **Cascade Potential** | `exclusive_transitive`, project knowledge | Removing unblocks 3+ further removals | Unblocks 1-2 | Standalone, no cascade |
+
+### Scoring overrides
+
+- **Coupling Depth override**: When Phase 2 shows ALL import files are non-production (test/CI/example), override Coupling Depth to **High** regardless of `coupling_effort`. Test/CI refactoring is low-risk regardless of call count.
+- **Transitive Cleanup caveat**: When `stays_as_indirect: true`, `exclusive_transitive` may overestimate actual cleanup -- some "exclusive" transitives may remain reachable via the indirect path. Note this uncertainty in the rationale.
 
 ### Scoring output
 
@@ -223,16 +235,28 @@ Synthesize all phases into a structured recommendation. Use the exact field name
 
 ### Recommendation logic
 
+Rules are evaluated **top-to-bottom; first match wins.** If multiple rows could match, the earlier row takes priority.
+
 | Condition | Recommendation |
 |-----------|---------------|
 | `is_unused: true` | REMOVE, Trivial, Priority S |
-| All 6 axes High or Med, no API leakage | REMOVE |
-| 1-2 axes Low, rest High/Med, no API leakage | REMOVE -- note the Low axes as caveats in rationale |
+| API leakage = Yes AND Security Urgency = High | REMOVE with BREAKING CHANGE warning -- security overrides API stability. Rationale must document the breaking change and recommend a major version bump or deprecation timeline. Escalate to `/diet-assess-risk` |
 | API leakage = Yes | DEFER (needs major version bump or deprecation period) |
-| Replaceability = Low (crypto/protocol) | KEEP unless Security Urgency is High |
+| Replaceability = Low (crypto/protocol) | KEEP -- find an alternative maintained library rather than self-implementing. If Security Urgency is also High, escalate to `/diet-assess-risk` for full risk analysis. Never recommend self-implementing crypto/protocol |
+| All 6 axes High or Med | REMOVE |
+| 1-2 axes Low, rest High/Med | REMOVE -- note the Low axes as caveats in rationale |
 | >= 3 axes Low | KEEP |
 | Security Urgency = High, others mixed | REMOVE (prioritize security). Suggest `/diet-assess-risk` for full analysis |
 | `stays_as_indirect: true`, coupling low | REMOVE (still valuable: delegates version management, unblocks future cleanup) |
+
+### Effort derivation
+
+| Effort | Criteria |
+|--------|----------|
+| Trivial (<1h) | `is_unused: true`, OR 0 production files, OR all symbols stdlib-replaceable with <= 3 files |
+| Small (1-4h) | <= 5 production files AND > 80% symbols replaceable |
+| Medium (1-3d) | 6-15 production files, OR 50-80% symbols replaceable, OR API leakage requiring deprecation |
+| Large (1w+) | > 15 production files, OR < 50% symbols replaceable, OR crypto/protocol replacement needed |
 
 ### When to recommend further analysis
 


### PR DESCRIPTION
## Summary

- Rewrite `/diet-evaluate-removal` skill from subjective 4-phase/6-axis framework to data-driven 5-phase framework
- New Phase 2 (Usage Classification) classifies `import_files` into production/test/CI/example/generated — the #1 insight from the `@vercel/kv` case study
- New Phase 3b (Symbol Migration Map) maps each symbol to stdlib/existing-dep/self-impl/no-replacement
- 6 axes redesigned: replace subjective axes (Update PR reduction, Clean dependency list, Code portability) with data-driven ones anchored to diet JSON fields (Production Scope, Replaceability, Security Urgency)
- API leakage treated as binary gate in Phase 3, not a scoring axis
- Terminology aligned to diet JSON field names (`exclusive_transitive` not `ONLY-VIA-THIS`)
- Recommendation logic with first-match-wins evaluation order and effort derivation table
- Multi-language support via ecosystem-specific guidance tables

## Improvement verification with real diet-fuzz data

Validated against 3 representative dependencies from the 2026-04-12 diet-fuzz run (278 analysis files, 5 languages, 21 projects).

### Case 1: svelte → magic-string — Usage Classification changes the verdict

Diet data: `difficulty: hard`, 15 files, 24 calls, 2 APIs, `coupling_effort: 0.68`, lifecycle Active

| Aspect | Old (v1) | New (v2) |
|--------|----------|----------|
| File classification | 15 files = hard | **2 production** (`src/compiler/`) + **13 test** (`tests/sourcemaps/`) |
| Effort estimate | Large (1w+) — based on raw file count | **Medium (1-3d)** — only 2 production files need migration |
| Verdict reasoning | 6 subjective axes all Low, "keep" | Data-driven: Replaceability=Low (no stdlib for source map manipulation), **KEEP with concrete reason** |
| Symbol analysis | None | 2/2 symbols (`Bundle`, `MagicString`) = no-replacement → **KEEP because no alternative exists** |

**Key improvement**: Old skill saw "15 files, hard" and stopped. New skill reveals 87% of imports are test fixtures — the actual production scope is 2 files. Effort drops from Large to Medium. The KEEP recommendation is the same, but now backed by a concrete reason (no stdlib replacement for source map manipulation) instead of vague subjective ratings.

### Case 2: backbone → underscore — Symbol Migration Map reveals hidden replaceability

Diet data: `difficulty: hard`, 3 files, 163 calls, 57 APIs, `coupling_effort: 0.67`, lifecycle Active

| Aspect | Old (v1) | New (v2) |
|--------|----------|----------|
| Replacement analysis | "57 APIs, use stdlib" (no detail) | **17 stdlib** (`each`→`forEach`, `keys`→`Object.keys`, `clone`→`structuredClone`), **10 self-impl** (`isEmpty`, `isEqual`, `pick`...), **30 backbone internals** (not underscore API) |
| File classification | None | 2 production (`backbone.js`) + 1 CI (`karma.conf-sauce.js`) |
| Replaceability | No axis existed | **High** — 27/27 actual underscore symbols replaceable via ES5+ stdlib or trivial helpers |
| Actionability | "hard, keep, end" | **KEEP, but Replaceability=High** — viable long-term removal when backbone itself is replaced |

**Key improvement**: Old skill's "57 APIs" was misleading — 30 of those are backbone's own internal symbols (`Backbone`, `_isModel`, `cid`...), not underscore API calls. New skill's Symbol Migration Map separates them, revealing that all 27 actual underscore APIs have stdlib or trivial self-impl replacements. The verdict is still KEEP (4/6 axes Low), but now the user knows **removal is feasible when the time comes**.

### Case 3: browserify → coffee-script — stays_as_indirect accuracy

Diet data: `difficulty: trivial`, `is_unused: true`, `stays_as_indirect: true` (via coffeeify), lifecycle EOL-Confirmed

| Aspect | Old (v1) | New (v2) |
|--------|----------|----------|
| Recommendation | "Full removal" — **contradicts** `stays_as_indirect: true` | **REMOVE** with explicit note: "stays in lockfile via coffeeify. To fully eliminate, also remove coffeeify" |
| Fast-path | Evaluates all 6 axes even though unused | `is_unused: true` → **Phase 2/3b skipped**, immediate Priority S |
| indirect_via | Not shown | **`coffeeify`** explicitly named → next action is clear |
| Effort derivation | Subjective "Trivial" | **Trivial** via effort derivation table: `is_unused: true` → Trivial |

**Key improvement**: Old skill said "Full removal" but the dep stays as indirect — the user would be confused when `coffee-script` remains in the lockfile after removing it from `package.json`. New skill is honest: REMOVE the direct dep (trivial), but it stays via coffeeify, and names the upstream dep to target next.

### Summary of improvements across cases

| Improvement | Case 1 (magic-string) | Case 2 (underscore) | Case 3 (coffee-script) |
|-------------|----------------------|---------------------|----------------------|
| Usage Classification | 13/15 = test → Effort Large→Medium | karma.conf = CI | is_unused → skip |
| Symbol Migration Map | 2/2 no-replacement → KEEP reason clear | 27/27 replaceable → future removal viable | N/A (unused) |
| Data-driven 6-Axis | Production Scope=Med is only non-Low | Replaceability=High is the key finding | is_unused fast-path |
| stays_as_indirect | N/A | N/A | No contradiction, indirect_via shown |
| Effort derivation | 2 prod files → Medium (was Large) | 57 APIs → Large (unchanged) | is_unused → Trivial (was subjective) |

## Test plan

- [ ] Run `/diet-evaluate-removal` on a Go dependency and verify 5-phase output
- [ ] Run on a JS/TS dependency to verify multi-language guidance
- [ ] Verify blank-import special case produces correct Replaceability scoring
- [ ] Verify all lifecycle values map to a Security Urgency bucket
- [ ] Verify recommendation logic handles API leakage + Security Urgency conflict

🤖 Generated with [Claude Code](https://claude.com/claude-code)