### PR TITLE
docs: replace gated whitepaper link with FIRST VulnCon 2026 reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/future-architect/uzomuzo-oss/actions/workflows/ci.yml/badge.svg)](https://github.com/future-architect/uzomuzo-oss/actions/workflows/ci.yml) [![Dependency Scan](https://github.com/future-architect/uzomuzo-oss/actions/workflows/dependency-scan.yml/badge.svg)](https://github.com/future-architect/uzomuzo-oss/actions/workflows/dependency-scan.yml) [![Go Report Card](https://goreportcard.com/badge/github.com/future-architect/uzomuzo-oss)](https://goreportcard.com/report/github.com/future-architect/uzomuzo-oss) [![Go Reference](https://pkg.go.dev/badge/github.com/future-architect/uzomuzo-oss.svg)](https://pkg.go.dev/github.com/future-architect/uzomuzo-oss) [![Release](https://img.shields.io/github/v/release/future-architect/uzomuzo-oss)](https://github.com/future-architect/uzomuzo-oss/releases/latest) [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 
-📊 **We analyzed 16,000 production packages: [48% have lifecycle risk](https://www.vuls.biz/software-supplychain/eol-risk). SCA tools like Trivy, Syft, and cdxgen detect none of them.**
+📊 **We analyzed 16,000 production packages: 48% have lifecycle risk. SCA tools like Trivy, Syft, and cdxgen detect none of them.** (Presented at [FIRST VulnCon 2026](https://www.first.org/conference/vulncon26/program#pThe-CVE-Blind-Spot-Defeating-Hidden-EOLs-and-Repo-Jacking-with-Engineering-Triage-Code-Diet))
 
 **Find abandoned dependencies before they become vulnerabilities. Then remove them — in the right order.**
 


### PR DESCRIPTION
## Summary
- Replace the Japanese registration-gated marketing page link (`vuls.biz`) with a public FIRST.org VulnCon 2026 program page as verifiable evidence for the 16,000-package lifecycle risk stat

## Test plan
- [x] Verify README renders correctly
- [x] Verify FIRST.org link is publicly accessible without registration

🤖 Generated with [Claude Code](https://claude.com/claude-code)