### PR TITLE
fix: disambiguate DirectDepsCount/TransitiveDepsCount zero + extend version fallback (#313)

### DIFF
--- a/.claude/rules/copilot-learned-coding.md
+++ b/.claude/rules/copilot-learned-coding.md
@@ -104,6 +104,11 @@ pending_patterns:
     pr: 299
     file: "internal/application/diet/service_test.go"
     date: "2026-04-12"
+  - category: "performance"
+    summary: "Cache results of expensive parsing functions (e.g., PURL parser) when the same value is checked multiple times in a loop iteration — avoids redundant allocations in batch processing paths"
+    pr: 315
+    file: "internal/infrastructure/integration/purl_batch.go"
+    date: "2026-04-19"
   - category: "comment-doc-drift"
     summary: "Constant doc comment named only Python but the sentinel was reused for Java wildcard imports — doc comments on shared constants must enumerate all languages/contexts that use them"
     pr: 298
@@ -248,4 +253,5 @@ pending_patterns:
   # testing (PR #283): already covered by "Cover New Control Flow Branches with Tests" and "Verify Tree-Sitter Query Patterns Do Not Overlap" — each tree-sitter query pattern variant (generic vs non-generic scoped constructor) needs its own test case
   # comment-doc-drift (PR #283 round 4): already covered by "Comment-Code Consistency" rule — scoped constructor comment described 2-capture positional behavior but queries only have a single @func capture
   # comment-doc-drift (PR #285): already covered by "Comment-Code Consistency" rule — HasBlankImport comments/docs said "no callable API" but flag covers broader patterns (Python feature-detection) that may have callable APIs; aliasMap comment claimed safety without noting lack of scope resolution
+  # comment-doc-drift (PR #315): already covered by "Comment-Code Consistency" rule — enrichDependentCounts comment said "stable release version" but code uses resolvedVersion() with Package.Version > StableVersion > MaxSemverVersion preference chain
 -->

--- a/.claude/rules/copilot-learned-coding.md
+++ b/.claude/rules/copilot-learned-coding.md
@@ -32,6 +32,7 @@ Rules extracted from recurring Copilot review patterns on coding-standards topic
 - **Consistent Conditional Columns Across Output Formats**: When a column or field is conditionally shown in one output format (e.g., table omits RELATION when all entries are Unknown), apply the same conditional logic to all other formats (CSV, JSON). Unconditionally including a column in one format while conditionally hiding it in another creates inconsistent API surfaces and confuses downstream consumers.
 - **Nil vs Empty Map Semantics for Sentinel-Checked Maps**: When a function returns a map that callers check for `nil` as a sentinel (e.g., "no data available" vs "data resolved but empty"), return `nil` when the resolved set is empty rather than an empty non-nil map. An empty non-nil map can cause callers to misinterpret "no results found" as "all items excluded", leading to incorrect classification or silent data loss.
 - **Normalize Repo-Scoped Paths with `path.Clean`**: When accepting user- or YAML-supplied paths that are scoped within a repository (e.g., local action `./` references), normalize with `path.Clean` (not `filepath.Clean`) and reject results that equal `"."` or start with `".."`. Also reject backslashes. This prevents traversal beyond the repository root via the Contents API without blocking valid intra-repo `..` segments (e.g., `./foo/../bar` → `bar`).
+- **Preserve Original Input Through Heuristic Fallback Chains**: In chained heuristic pipelines where each step transforms an intermediate result, fallback on empty must return the original input — not the intermediate value from a prior step. Returning an intermediate value violates the documented contract and can produce silently incorrect results when later steps depend on the untransformed original.
 - **Accurate Error Map Keys**: When recording errors in a `map[string]error` keyed by file path, use the actual resolved path — not a hardcoded filename. If a fetch tries `action.yml` then falls back to `action.yaml`, the error key must reflect which file was attempted, or use the parent path without a filename assumption.
 - **Handle All Valid Input Forms in Format Parsers**: When parsing a structured format (ZIP entries, RECORD files, manifests), handle all valid representations defined by the spec — not just the common case. For example, Python wheel RECORD files contain both package directories (`pkg/__init__.py`) and root-level modules (`six.py`); skipping root-level entries silently drops valid import names for single-module packages.
 - **Explicit Fallback for Unknown Enum Values**: When mapping external values (API responses, YAML fields) to internal enums or display strings, map unrecognized values to an explicit fallback (e.g., `"unknown(X)"`) rather than silently defaulting to a valid enum member. Silent defaults hide data quality issues and make debugging harder.
@@ -42,6 +43,7 @@ Rules extracted from recurring Copilot review patterns on coding-standards topic
 - **Filter and Normalize IDs Before Batch API Calls**: When building batch API requests from collected IDs, filter empty/whitespace values and deduplicate before processing to prevent invalid HTTP requests and cache pollution. Use `select` on `ctx.Done()` alongside channel operations in batch goroutines to avoid blocking after context cancellation.
 - **Guard Nil Structs Consistently Across Output Formats**: When a struct field may be nil (e.g., `ReleaseInfo`), apply the nil guard in every output renderer that accesses it (text, CSV, JSON). If one renderer has the guard and another does not, the unguarded path will panic on nil input.
 - **Gate Fallback Logic on Error, Not Result Nilness**: When deciding whether to trigger fallback or retry logic, check the error value — not whether the result is nil. A nil result with nil error is a valid success case (e.g., zero matches found), and treating it as a failure triggers unnecessary retries or incorrect fallback paths.
+- **Use Structured Parsers for Structured Identifier Properties**: When checking properties of structured identifiers (PURLs, URIs, import paths), use the appropriate parser rather than naive string operations (`strings.Contains`, `strings.Split`). For example, `strings.Contains(purl, "@")` misclassifies npm scoped packages like `pkg:npm/@scope/name` as versioned because `@` appears in the namespace. Use `packageurl.FromString(p).Version != ""` or an equivalent parser-based check.
 - **Use Case-Insensitive Comparison for URL Components**: When comparing URL components (scheme, host), use case-insensitive comparison per RFC 3986 — schemes (`HTTP://`) and hosts (`GitHub.COM`) are case-insensitive. Normalize with `strings.ToLower` or `strings.EqualFold` before prefix checks or host matching to avoid double-prefixing or missed matches.
 - **Structured Logging Conventions**: When adding `slog` calls: use DEBUG level for routine per-item telemetry (reserve INFO for exceptional events); use `snake_case` for event names (not spaces) for consistency and filterability; choose field key names that accurately describe the data across all call sites (e.g., `"ref"` not `"purl"` when the function handles both PURLs and URLs).
 - **Match Validation Format Strings to Production Format Strings**: When a validation or check function mirrors a production function's output (e.g., marker validation vs. marker replacement), use the exact same format strings and delimiters. Mismatched formats allow invalid input to pass validation silently.
@@ -97,11 +99,6 @@ pending_patterns:
     pr: 276
     file: "internal/infrastructure/pypi/client.go"
     date: "2026-04-11"
-  - category: "defensive-coding"
-    summary: "In chained heuristic pipelines where each step transforms an intermediate result, fallback on empty must return the original input — not the intermediate value from a prior step — to match the documented contract"
-    pr: 281
-    file: "internal/infrastructure/treesitter/lang_go.go"
-    date: "2026-04-11"
   - category: "comment-doc-drift"
     summary: "Test case name claimed 'web vs data-jpa' but input PURL was spring-boot-starter-security — test names must match the actual input under test"
     pr: 299
@@ -130,6 +127,7 @@ pending_patterns:
 ```
 
 <!-- Promotion history (kept for audit trail):
+  # defensive-coding: promoted to copilot-learned-coding.instructions.md (PRs #281, #315 — preserve original input through heuristic fallback chains, use structured parsers for structured identifier properties)
   # defensive-coding: promoted to copilot-learned-coding.instructions.md (PRs #276, #280 — rerun analyzers with combined input, gate fallback on error, spec-compliant parsers, AST ancestor walk continuation)
   # comment-doc-drift: promoted to copilot-learned-coding.instructions.md (PRs #253, #276 — interface contract doc must match signature semantics)
   # testing: promoted to testing-performance.instructions.md (PRs #276, #282, #298 — nil map merge tests, sibling assertions, test name/code consistency, unconditional test assertions)

--- a/.github/instructions/copilot-learned-coding.instructions.md
+++ b/.github/instructions/copilot-learned-coding.instructions.md
@@ -102,6 +102,11 @@ pending_patterns:
     pr: 299
     file: "internal/application/diet/service_test.go"
     date: "2026-04-12"
+  - category: "performance"
+    summary: "Cache results of expensive parsing functions (e.g., PURL parser) when the same value is checked multiple times in a loop iteration — avoids redundant allocations in batch processing paths"
+    pr: 315
+    file: "internal/infrastructure/integration/purl_batch.go"
+    date: "2026-04-19"
   - category: "comment-doc-drift"
     summary: "Constant doc comment named only Python but the sentinel was reused for Java wildcard imports — doc comments on shared constants must enumerate all languages/contexts that use them"
     pr: 298
@@ -246,4 +251,5 @@ pending_patterns:
   # testing (PR #283): already covered by "Cover New Control Flow Branches with Tests" and "Verify Tree-Sitter Query Patterns Do Not Overlap" — each tree-sitter query pattern variant (generic vs non-generic scoped constructor) needs its own test case
   # comment-doc-drift (PR #283 round 4): already covered by "Comment-Code Consistency" rule — scoped constructor comment described 2-capture positional behavior but queries only have a single @func capture
   # comment-doc-drift (PR #285): already covered by "Comment-Code Consistency" rule — HasBlankImport comments/docs said "no callable API" but flag covers broader patterns (Python feature-detection) that may have callable APIs; aliasMap comment claimed safety without noting lack of scope resolution
+  # comment-doc-drift (PR #315): already covered by "Comment-Code Consistency" rule — enrichDependentCounts comment said "stable release version" but code uses resolvedVersion() with Package.Version > StableVersion > MaxSemverVersion preference chain
 -->

--- a/.github/instructions/copilot-learned-coding.instructions.md
+++ b/.github/instructions/copilot-learned-coding.instructions.md
@@ -30,6 +30,7 @@ Rules extracted from recurring Copilot review patterns on coding-standards topic
 - **Consistent Conditional Columns Across Output Formats**: When a column or field is conditionally shown in one output format (e.g., table omits RELATION when all entries are Unknown), apply the same conditional logic to all other formats (CSV, JSON). Unconditionally including a column in one format while conditionally hiding it in another creates inconsistent API surfaces and confuses downstream consumers.
 - **Nil vs Empty Map Semantics for Sentinel-Checked Maps**: When a function returns a map that callers check for `nil` as a sentinel (e.g., "no data available" vs "data resolved but empty"), return `nil` when the resolved set is empty rather than an empty non-nil map. An empty non-nil map can cause callers to misinterpret "no results found" as "all items excluded", leading to incorrect classification or silent data loss.
 - **Normalize Repo-Scoped Paths with `path.Clean`**: When accepting user- or YAML-supplied paths that are scoped within a repository (e.g., local action `./` references), normalize with `path.Clean` (not `filepath.Clean`) and reject results that equal `"."` or start with `".."`. Also reject backslashes. This prevents traversal beyond the repository root via the Contents API without blocking valid intra-repo `..` segments (e.g., `./foo/../bar` → `bar`).
+- **Preserve Original Input Through Heuristic Fallback Chains**: In chained heuristic pipelines where each step transforms an intermediate result, fallback on empty must return the original input — not the intermediate value from a prior step. Returning an intermediate value violates the documented contract and can produce silently incorrect results when later steps depend on the untransformed original.
 - **Accurate Error Map Keys**: When recording errors in a `map[string]error` keyed by file path, use the actual resolved path — not a hardcoded filename. If a fetch tries `action.yml` then falls back to `action.yaml`, the error key must reflect which file was attempted, or use the parent path without a filename assumption.
 - **Handle All Valid Input Forms in Format Parsers**: When parsing a structured format (ZIP entries, RECORD files, manifests), handle all valid representations defined by the spec — not just the common case. For example, Python wheel RECORD files contain both package directories (`pkg/__init__.py`) and root-level modules (`six.py`); skipping root-level entries silently drops valid import names for single-module packages.
 - **Explicit Fallback for Unknown Enum Values**: When mapping external values (API responses, YAML fields) to internal enums or display strings, map unrecognized values to an explicit fallback (e.g., `"unknown(X)"`) rather than silently defaulting to a valid enum member. Silent defaults hide data quality issues and make debugging harder.
@@ -40,6 +41,7 @@ Rules extracted from recurring Copilot review patterns on coding-standards topic
 - **Filter and Normalize IDs Before Batch API Calls**: When building batch API requests from collected IDs, filter empty/whitespace values and deduplicate before processing to prevent invalid HTTP requests and cache pollution. Use `select` on `ctx.Done()` alongside channel operations in batch goroutines to avoid blocking after context cancellation.
 - **Guard Nil Structs Consistently Across Output Formats**: When a struct field may be nil (e.g., `ReleaseInfo`), apply the nil guard in every output renderer that accesses it (text, CSV, JSON). If one renderer has the guard and another does not, the unguarded path will panic on nil input.
 - **Gate Fallback Logic on Error, Not Result Nilness**: When deciding whether to trigger fallback or retry logic, check the error value — not whether the result is nil. A nil result with nil error is a valid success case (e.g., zero matches found), and treating it as a failure triggers unnecessary retries or incorrect fallback paths.
+- **Use Structured Parsers for Structured Identifier Properties**: When checking properties of structured identifiers (PURLs, URIs, import paths), use the appropriate parser rather than naive string operations (`strings.Contains`, `strings.Split`). For example, `strings.Contains(purl, "@")` misclassifies npm scoped packages like `pkg:npm/@scope/name` as versioned because `@` appears in the namespace. Use `packageurl.FromString(p).Version != ""` or an equivalent parser-based check.
 - **Use Case-Insensitive Comparison for URL Components**: When comparing URL components (scheme, host), use case-insensitive comparison per RFC 3986 — schemes (`HTTP://`) and hosts (`GitHub.COM`) are case-insensitive. Normalize with `strings.ToLower` or `strings.EqualFold` before prefix checks or host matching to avoid double-prefixing or missed matches.
 - **Structured Logging Conventions**: When adding `slog` calls: use DEBUG level for routine per-item telemetry (reserve INFO for exceptional events); use `snake_case` for event names (not spaces) for consistency and filterability; choose field key names that accurately describe the data across all call sites (e.g., `"ref"` not `"purl"` when the function handles both PURLs and URLs).
 - **Match Validation Format Strings to Production Format Strings**: When a validation or check function mirrors a production function's output (e.g., marker validation vs. marker replacement), use the exact same format strings and delimiters. Mismatched formats allow invalid input to pass validation silently.
@@ -95,11 +97,6 @@ pending_patterns:
     pr: 276
     file: "internal/infrastructure/pypi/client.go"
     date: "2026-04-11"
-  - category: "defensive-coding"
-    summary: "In chained heuristic pipelines where each step transforms an intermediate result, fallback on empty must return the original input — not the intermediate value from a prior step — to match the documented contract"
-    pr: 281
-    file: "internal/infrastructure/treesitter/lang_go.go"
-    date: "2026-04-11"
   - category: "comment-doc-drift"
     summary: "Test case name claimed 'web vs data-jpa' but input PURL was spring-boot-starter-security — test names must match the actual input under test"
     pr: 299
@@ -128,6 +125,7 @@ pending_patterns:
 ```
 
 <!-- Promotion history (kept for audit trail):
+  # defensive-coding: promoted to copilot-learned-coding.instructions.md (PRs #281, #315 — preserve original input through heuristic fallback chains, use structured parsers for structured identifier properties)
   # defensive-coding: promoted to copilot-learned-coding.instructions.md (PRs #276, #280 — rerun analyzers with combined input, gate fallback on error, spec-compliant parsers, AST ancestor walk continuation)
   # comment-doc-drift: promoted to copilot-learned-coding.instructions.md (PRs #253, #276 — interface contract doc must match signature semantics)
   # testing: promoted to testing-performance.instructions.md (PRs #276, #282, #298 — nil map merge tests, sibling assertions, test name/code consistency, unconditional test assertions)

--- a/internal/common/purl/has_version.go
+++ b/internal/common/purl/has_version.go
@@ -1,0 +1,15 @@
+package purl
+
+import "github.com/package-url/packageurl-go"
+
+// HasVersion reports whether the PURL string contains a non-empty version component.
+// Unlike strings.Contains(p, "@"), this correctly handles namespaced PURLs
+// such as pkg:npm/@scope/name where "@" appears in the namespace, not as a
+// version delimiter.
+func HasVersion(p string) bool {
+	parsed, err := packageurl.FromString(p)
+	if err != nil {
+		return false
+	}
+	return parsed.Version != ""
+}

--- a/internal/domain/analysis/aggregates.go
+++ b/internal/domain/analysis/aggregates.go
@@ -76,21 +76,24 @@ type Analysis struct {
 	// DirectDepsCount is the number of direct dependencies for the package version
 	// used in the deps.dev query:
 	//   - If EffectivePURL includes a version, that exact version is used.
-	//   - Otherwise, the latest release is used (stable > prerelease).
+	//   - Otherwise, the latest release is used (stable > maxSemver > prerelease).
 	// Supported ecosystems: npm, cargo, maven, pypi (deps.dev limitation).
-	// Zero is ambiguous without HasDependencyGraph: it can mean "genuinely a leaf
-	// package" (e.g., react@19 has no runtime deps), "unsupported ecosystem", or
-	// "no version resolved". Consult HasDependencyGraph to distinguish.
+	// When HasDependencyGraph is true, zero means the resolved version genuinely
+	// has no direct dependencies (e.g., react@19 declares none). When
+	// HasDependencyGraph is false, zero is uninformative — the graph was not
+	// reached (unsupported ecosystem, no resolvable release, 404, or transport
+	// error). Always consult HasDependencyGraph before interpreting zero.
 	DirectDepsCount int
 
 	// TransitiveDepsCount is the number of transitive (indirect) dependencies for the
 	// package version used in the deps.dev query:
 	//   - If EffectivePURL includes a version, that exact version is used.
-	//   - Otherwise, the latest release is used (stable > prerelease).
+	//   - Otherwise, the latest release is used (stable > maxSemver > prerelease).
 	// Supported ecosystems: npm, cargo, maven, pypi (deps.dev limitation).
-	// Zero is ambiguous without HasDependencyGraph: it can mean "no transitive
-	// deps" (e.g., pypi's graph only covers direct deps), "unsupported ecosystem",
-	// or "no version resolved". Consult HasDependencyGraph to distinguish.
+	// When HasDependencyGraph is true, zero means the resolved version genuinely
+	// has no transitive dependencies in the graph (e.g., pypi responses typically
+	// include only direct deps). When HasDependencyGraph is false, zero is
+	// uninformative. Always consult HasDependencyGraph before interpreting zero.
 	TransitiveDepsCount int
 
 	// HasDependencyGraph reports whether a deps.dev dependency-graph response was

--- a/internal/domain/analysis/aggregates.go
+++ b/internal/domain/analysis/aggregates.go
@@ -77,17 +77,30 @@ type Analysis struct {
 	// used in the deps.dev query:
 	//   - If EffectivePURL includes a version, that exact version is used.
 	//   - Otherwise, the latest release is used (stable > prerelease).
-	// Zero means unknown, unsupported ecosystem, or no version resolved.
 	// Supported ecosystems: npm, cargo, maven, pypi (deps.dev limitation).
+	// Zero is ambiguous without HasDependencyGraph: it can mean "genuinely a leaf
+	// package" (e.g., react@19 has no runtime deps), "unsupported ecosystem", or
+	// "no version resolved". Consult HasDependencyGraph to distinguish.
 	DirectDepsCount int
 
 	// TransitiveDepsCount is the number of transitive (indirect) dependencies for the
 	// package version used in the deps.dev query:
 	//   - If EffectivePURL includes a version, that exact version is used.
 	//   - Otherwise, the latest release is used (stable > prerelease).
-	// Zero means unknown, unsupported ecosystem, or no version resolved.
 	// Supported ecosystems: npm, cargo, maven, pypi (deps.dev limitation).
+	// Zero is ambiguous without HasDependencyGraph: it can mean "no transitive
+	// deps" (e.g., pypi's graph only covers direct deps), "unsupported ecosystem",
+	// or "no version resolved". Consult HasDependencyGraph to distinguish.
 	TransitiveDepsCount int
+
+	// HasDependencyGraph reports whether a deps.dev dependency-graph response was
+	// successfully retrieved for this analysis. When true, DirectDepsCount and
+	// TransitiveDepsCount reflect the graph contents (zero means the resolved
+	// version genuinely has no dependencies in that relation class). When false,
+	// the graph was unavailable — typical reasons are an unsupported ecosystem,
+	// a versionless analysis with no resolvable release, a 404 from deps.dev, or
+	// a transport error — so the counts carry no positive information.
+	HasDependencyGraph bool
 
 	// Canonical package links (homepage, registry, docs, changelog)
 	PackageLinks *PackageLinks

--- a/internal/infrastructure/depsdev/issue313_verify_test.go
+++ b/internal/infrastructure/depsdev/issue313_verify_test.go
@@ -1,0 +1,91 @@
+package depsdev
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/future-architect/uzomuzo-oss/internal/domain/config"
+)
+
+// TestIssue313Reproduction mocks deps.dev at the HTTP layer and runs the exact
+// five PURLs from issue #313 through FetchDependenciesBatch + CountByRelation,
+// then renders the same table the bug reporter produced. This is a temporary
+// verification test for the PR; response shapes mirror what deps.dev returns
+// for each PURL (derived from the upstream package manifests at the time of
+// writing).
+func TestIssue313Reproduction(t *testing.T) {
+	fixtures := map[string]string{
+		"/v3alpha/systems/npm/packages/express/versions/4.21.2:dependencies": relations(1, 28, 39),
+		"/v3alpha/systems/npm/packages/react/versions/19.1.0:dependencies":   relations(1, 0, 0),
+		"/v3alpha/systems/pypi/packages/requests/versions/2.32.3:dependencies": relations(1, 4, 0),
+		"/v3alpha/systems/pypi/packages/django/versions/5.1.0:dependencies":    relations(1, 2, 0),
+		"/v3alpha/systems/cargo/packages/serde/versions/1.0.210:dependencies":  relations(1, 0, 0),
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, ok := fixtures[r.URL.Path]
+		if !ok {
+			t.Logf("unexpected request: %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	client := NewDepsDevClient(&config.DepsDevConfig{
+		BaseURL:    srv.URL,
+		Timeout:    5 * time.Second,
+		MaxRetries: 0,
+		BatchSize:  10,
+	})
+
+	inputs := []string{
+		"pkg:npm/express@4.21.2",
+		"pkg:npm/react@19.1.0",
+		"pkg:pypi/requests@2.32.3",
+		"pkg:pypi/django@5.1.0",
+		"pkg:cargo/serde@1.0.210",
+	}
+
+	results := client.FetchDependenciesBatch(context.Background(), inputs)
+
+	var b strings.Builder
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "| PURL | direct | transitive | HasDependencyGraph |")
+	fmt.Fprintln(&b, "|---|---|---|---|")
+	for _, in := range inputs {
+		key := strings.ToLower(strings.SplitN(in, "@", 2)[0])
+		resp, ok := results[key]
+		if !ok || resp == nil {
+			fmt.Fprintf(&b, "| `%s` | - | - | false (not collected) |\n", in)
+			continue
+		}
+		d, tr := resp.CountByRelation()
+		fmt.Fprintf(&b, "| `%s` | %d | %d | true |\n", in, d, tr)
+	}
+	t.Log(b.String())
+}
+
+// relations renders a deps.dev :dependencies payload with the given counts
+// of SELF / DIRECT / INDIRECT nodes. Edges are omitted because CountByRelation
+// does not use them.
+func relations(self, direct, indirect int) string {
+	var nodes []string
+	for i := 0; i < self; i++ {
+		nodes = append(nodes, `{"relation":"SELF"}`)
+	}
+	for i := 0; i < direct; i++ {
+		nodes = append(nodes, `{"relation":"DIRECT"}`)
+	}
+	for i := 0; i < indirect; i++ {
+		nodes = append(nodes, `{"relation":"INDIRECT"}`)
+	}
+	return `{"nodes":[` + strings.Join(nodes, ",") + `],"edges":[]}`
+}

--- a/internal/infrastructure/depsdev/issue313_verify_test.go
+++ b/internal/infrastructure/depsdev/issue313_verify_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	commonpurl "github.com/future-architect/uzomuzo-oss/internal/common/purl"
 	"github.com/future-architect/uzomuzo-oss/internal/domain/config"
 )
 
@@ -20,8 +21,8 @@ import (
 // writing).
 func TestIssue313Reproduction(t *testing.T) {
 	fixtures := map[string]string{
-		"/v3alpha/systems/npm/packages/express/versions/4.21.2:dependencies": relations(1, 28, 39),
-		"/v3alpha/systems/npm/packages/react/versions/19.1.0:dependencies":   relations(1, 0, 0),
+		"/v3alpha/systems/npm/packages/express/versions/4.21.2:dependencies":   relations(1, 28, 39),
+		"/v3alpha/systems/npm/packages/react/versions/19.1.0:dependencies":     relations(1, 0, 0),
 		"/v3alpha/systems/pypi/packages/requests/versions/2.32.3:dependencies": relations(1, 4, 0),
 		"/v3alpha/systems/pypi/packages/django/versions/5.1.0:dependencies":    relations(1, 2, 0),
 		"/v3alpha/systems/cargo/packages/serde/versions/1.0.210:dependencies":  relations(1, 0, 0),
@@ -30,7 +31,8 @@ func TestIssue313Reproduction(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, ok := fixtures[r.URL.Path]
 		if !ok {
-			t.Logf("unexpected request: %s", r.URL.Path)
+			// t.Errorf is goroutine-safe; t.Fatalf is not (handler runs outside the test goroutine).
+			t.Errorf("unexpected request path: %s", r.URL.Path)
 			w.WriteHeader(http.StatusNotFound)
 			return
 		}
@@ -46,12 +48,21 @@ func TestIssue313Reproduction(t *testing.T) {
 		BatchSize:  10,
 	})
 
-	inputs := []string{
-		"pkg:npm/express@4.21.2",
-		"pkg:npm/react@19.1.0",
-		"pkg:pypi/requests@2.32.3",
-		"pkg:pypi/django@5.1.0",
-		"pkg:cargo/serde@1.0.210",
+	testCases := []struct {
+		purl           string
+		wantDirect     int
+		wantTransitive int
+	}{
+		{purl: "pkg:npm/express@4.21.2", wantDirect: 28, wantTransitive: 39},
+		{purl: "pkg:npm/react@19.1.0", wantDirect: 0, wantTransitive: 0},
+		{purl: "pkg:pypi/requests@2.32.3", wantDirect: 4, wantTransitive: 0},
+		{purl: "pkg:pypi/django@5.1.0", wantDirect: 2, wantTransitive: 0},
+		{purl: "pkg:cargo/serde@1.0.210", wantDirect: 0, wantTransitive: 0},
+	}
+
+	inputs := make([]string, 0, len(testCases))
+	for _, tc := range testCases {
+		inputs = append(inputs, tc.purl)
 	}
 
 	results := client.FetchDependenciesBatch(context.Background(), inputs)
@@ -60,15 +71,29 @@ func TestIssue313Reproduction(t *testing.T) {
 	fmt.Fprintln(&b)
 	fmt.Fprintln(&b, "| PURL | direct | transitive | HasDependencyGraph |")
 	fmt.Fprintln(&b, "|---|---|---|---|")
-	for _, in := range inputs {
-		key := strings.ToLower(strings.SplitN(in, "@", 2)[0])
+	for _, tc := range testCases {
+		key := commonpurl.CanonicalKey(tc.purl)
 		resp, ok := results[key]
-		if !ok || resp == nil {
-			fmt.Fprintf(&b, "| `%s` | - | - | false (not collected) |\n", in)
+		if !ok {
+			fmt.Fprintf(&b, "| `%s` | - | - | false (missing response entry) |\n", tc.purl)
+			t.Errorf("missing response for input %q (lookup key %q)", tc.purl, key)
 			continue
 		}
+		if resp == nil {
+			fmt.Fprintf(&b, "| `%s` | - | - | false (nil response) |\n", tc.purl)
+			t.Errorf("nil response for input %q (lookup key %q)", tc.purl, key)
+			continue
+		}
+
 		d, tr := resp.CountByRelation()
-		fmt.Fprintf(&b, "| `%s` | %d | %d | true |\n", in, d, tr)
+		fmt.Fprintf(&b, "| `%s` | %d | %d | true |\n", tc.purl, d, tr)
+
+		if d != tc.wantDirect || tr != tc.wantTransitive {
+			t.Errorf(
+				"unexpected dependency counts for %q: got direct=%d transitive=%d, want direct=%d transitive=%d",
+				tc.purl, d, tr, tc.wantDirect, tc.wantTransitive,
+			)
+		}
 	}
 	t.Log(b.String())
 }

--- a/internal/infrastructure/depsdev/issue313_verify_test.go
+++ b/internal/infrastructure/depsdev/issue313_verify_test.go
@@ -15,17 +15,16 @@ import (
 
 // TestIssue313Reproduction mocks deps.dev at the HTTP layer and runs the exact
 // five PURLs from issue #313 through FetchDependenciesBatch + CountByRelation,
-// then renders the same table the bug reporter produced. This is a temporary
-// verification test for the PR; response shapes mirror what deps.dev returns
-// for each PURL (derived from the upstream package manifests at the time of
-// writing).
+// then renders the same table the bug reporter produced. Node counts mirror the
+// real deps.dev responses captured against api.deps.dev on 2026-04-19 — update
+// both the fixtures and the assertions together if deps.dev data changes.
 func TestIssue313Reproduction(t *testing.T) {
 	fixtures := map[string]string{
-		"/v3alpha/systems/npm/packages/express/versions/4.21.2:dependencies":   relations(1, 28, 39),
+		"/v3alpha/systems/npm/packages/express/versions/4.21.2:dependencies":   relations(1, 31, 40),
 		"/v3alpha/systems/npm/packages/react/versions/19.1.0:dependencies":     relations(1, 0, 0),
 		"/v3alpha/systems/pypi/packages/requests/versions/2.32.3:dependencies": relations(1, 4, 0),
-		"/v3alpha/systems/pypi/packages/django/versions/5.1.0:dependencies":    relations(1, 2, 0),
-		"/v3alpha/systems/cargo/packages/serde/versions/1.0.210:dependencies":  relations(1, 0, 0),
+		"/v3alpha/systems/pypi/packages/django/versions/5.1.0:dependencies":    relations(1, 2, 1),
+		"/v3alpha/systems/cargo/packages/serde/versions/1.0.210:dependencies":  relations(1, 1, 4),
 	}
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -53,11 +52,11 @@ func TestIssue313Reproduction(t *testing.T) {
 		wantDirect     int
 		wantTransitive int
 	}{
-		{purl: "pkg:npm/express@4.21.2", wantDirect: 28, wantTransitive: 39},
+		{purl: "pkg:npm/express@4.21.2", wantDirect: 31, wantTransitive: 40},
 		{purl: "pkg:npm/react@19.1.0", wantDirect: 0, wantTransitive: 0},
 		{purl: "pkg:pypi/requests@2.32.3", wantDirect: 4, wantTransitive: 0},
-		{purl: "pkg:pypi/django@5.1.0", wantDirect: 2, wantTransitive: 0},
-		{purl: "pkg:cargo/serde@1.0.210", wantDirect: 0, wantTransitive: 0},
+		{purl: "pkg:pypi/django@5.1.0", wantDirect: 2, wantTransitive: 1},
+		{purl: "pkg:cargo/serde@1.0.210", wantDirect: 1, wantTransitive: 4},
 	}
 
 	inputs := make([]string, 0, len(testCases))

--- a/internal/infrastructure/integration/purl_batch.go
+++ b/internal/infrastructure/integration/purl_batch.go
@@ -289,6 +289,14 @@ func (s *IntegrationService) enrichDependencyCounts(ctx context.Context, purls [
 				}
 			}
 		}
+		// Skip entries where version could not be resolved: the deps.dev :dependencies
+		// endpoint requires a versioned PURL, and an unresolved version would round-trip
+		// through the batch layer only to be silently dropped. Logging here makes the
+		// condition diagnosable (distinguishes "no version" from "API returned empty").
+		if !strings.Contains(ep, "@") {
+			slog.Debug("dependency_count_skipped_versionless", "purl", p, "ecosystem", a.Package.Ecosystem)
+			continue
+		}
 		// Deduplicate effective PURLs to avoid redundant API calls.
 		if !seen[ep] {
 			effectivePURLs = append(effectivePURLs, ep)
@@ -303,6 +311,9 @@ func (s *IntegrationService) enrichDependencyCounts(ctx context.Context, purls [
 
 	// Map results back to original PURLs and populate counts.
 	// Also build a per-original-PURL map for downstream transitive advisory enrichment.
+	// HasDependencyGraph is set whenever deps.dev returned a response, even when the
+	// counts are zero — this lets callers distinguish "genuine leaf package" (e.g.,
+	// react@19) from "graph not collected" (unsupported ecosystem, 404, etc.).
 	perPURL := make(map[string]*depsdev.DependenciesResponse, len(purls))
 	for ep, originalKeys := range effectiveToOriginals {
 		key := purl.CanonicalKey(ep)
@@ -320,6 +331,7 @@ func (s *IntegrationService) enrichDependencyCounts(ctx context.Context, purls [
 				continue
 			}
 			a.DirectDepsCount, a.TransitiveDepsCount = direct, transitive
+			a.HasDependencyGraph = true
 			perPURL[originalKey] = resp
 		}
 	}

--- a/internal/infrastructure/integration/purl_batch.go
+++ b/internal/infrastructure/integration/purl_batch.go
@@ -147,8 +147,9 @@ func (s *IntegrationService) enrichDependentCounts(ctx context.Context, purls []
 			ep = p
 		}
 		// FetchDependentCount requires a versioned PURL. If the effective PURL
-		// is versionless, inject the stable release version (resolved earlier by
-		// populateReleaseInfo) using purl.WithVersion to handle qualifiers/subpaths safely.
+		// is versionless, inject the resolved version selected earlier by
+		// populateReleaseInfo (Package.Version > StableVersion > MaxSemverVersion)
+		// using purl.WithVersion to handle qualifiers/subpaths safely.
 		if !purl.HasVersion(ep) {
 			if v := resolvedVersion(a); v != "" {
 				if versioned, err := purl.WithVersion(ep, v); err == nil {
@@ -289,10 +290,12 @@ func (s *IntegrationService) enrichDependencyCounts(ctx context.Context, purls [
 		}
 		// The :dependencies endpoint requires a versioned PURL.
 		// Use the latest release version (stable > maxSemver > prerelease) for catalog consistency.
-		if !purl.HasVersion(ep) {
+		hasVer := purl.HasVersion(ep)
+		if !hasVer {
 			if v := latestReleaseVersion(a); v != "" {
 				if versioned, err := purl.WithVersion(ep, v); err == nil {
 					ep = versioned
+					hasVer = true
 				}
 			}
 		}
@@ -300,7 +303,7 @@ func (s *IntegrationService) enrichDependencyCounts(ctx context.Context, purls [
 		// endpoint requires a versioned PURL, and an unresolved version would round-trip
 		// through the batch layer only to be silently dropped. Logging here makes the
 		// condition diagnosable (distinguishes "no version" from "API returned empty").
-		if !purl.HasVersion(ep) {
+		if !hasVer {
 			slog.Debug("dependency_count_skipped_versionless", "purl", p, "ecosystem", a.Package.Ecosystem)
 			continue
 		}

--- a/internal/infrastructure/integration/purl_batch.go
+++ b/internal/infrastructure/integration/purl_batch.go
@@ -149,7 +149,7 @@ func (s *IntegrationService) enrichDependentCounts(ctx context.Context, purls []
 		// FetchDependentCount requires a versioned PURL. If the effective PURL
 		// is versionless, inject the stable release version (resolved earlier by
 		// populateReleaseInfo) using purl.WithVersion to handle qualifiers/subpaths safely.
-		if !strings.Contains(ep, "@") {
+		if !purl.HasVersion(ep) {
 			if v := resolvedVersion(a); v != "" {
 				if versioned, err := purl.WithVersion(ep, v); err == nil {
 					ep = versioned
@@ -289,7 +289,7 @@ func (s *IntegrationService) enrichDependencyCounts(ctx context.Context, purls [
 		}
 		// The :dependencies endpoint requires a versioned PURL.
 		// Use the latest release version (stable > maxSemver > prerelease) for catalog consistency.
-		if !strings.Contains(ep, "@") {
+		if !purl.HasVersion(ep) {
 			if v := latestReleaseVersion(a); v != "" {
 				if versioned, err := purl.WithVersion(ep, v); err == nil {
 					ep = versioned
@@ -300,7 +300,7 @@ func (s *IntegrationService) enrichDependencyCounts(ctx context.Context, purls [
 		// endpoint requires a versioned PURL, and an unresolved version would round-trip
 		// through the batch layer only to be silently dropped. Logging here makes the
 		// condition diagnosable (distinguishes "no version" from "API returned empty").
-		if !strings.Contains(ep, "@") {
+		if !purl.HasVersion(ep) {
 			slog.Debug("dependency_count_skipped_versionless", "purl", p, "ecosystem", a.Package.Ecosystem)
 			continue
 		}

--- a/internal/infrastructure/integration/purl_batch.go
+++ b/internal/infrastructure/integration/purl_batch.go
@@ -93,9 +93,10 @@ func (s *IntegrationService) AnalyzeFromPURLs(ctx context.Context, purls []strin
 	}()
 	go func() {
 		defer enrichWg.Done()
-		// Uses latestReleaseVersion (stable > prerelease) instead of resolvedVersion
-		// because catalog DB stores version-agnostic package data; the latest release
-		// best represents the current dependency surface for OSS selection.
+		// Uses latestReleaseVersion (stable > maxSemver > prerelease) instead of
+		// resolvedVersion because catalog DB stores version-agnostic package data;
+		// the latest release best represents the current dependency surface for
+		// OSS selection.
 		depsGraphResults = s.enrichDependencyCounts(ctx, purls, analyses)
 	}()
 	enrichWg.Wait()
@@ -281,7 +282,7 @@ func (s *IntegrationService) enrichDependencyCounts(ctx context.Context, purls [
 			ep = p
 		}
 		// The :dependencies endpoint requires a versioned PURL.
-		// Use the latest release version (stable > prerelease) for catalog consistency.
+		// Use the latest release version (stable > maxSemver > prerelease) for catalog consistency.
 		if !strings.Contains(ep, "@") {
 			if v := latestReleaseVersion(a); v != "" {
 				if versioned, err := purl.WithVersion(ep, v); err == nil {
@@ -340,34 +341,28 @@ func (s *IntegrationService) enrichDependencyCounts(ctx context.Context, purls [
 
 // latestReleaseVersion returns the best version string for dependency count queries.
 // Preference order:
-//  1. StableVersion       — latest stable release (best representation of the current dependency surface)
-//  2. MaxSemverVersion    — highest semver across published versions (often matches stable; useful when deps.dev data lacks IsDefault/stable flags)
-//  3. PreReleaseVersion   — latest non-stable release, for ecosystems/packages where no stable exists yet
-//  4. RequestedVersion    — user-pinned version from the request, if present
-//  5. Package.Version     — version embedded in the original PURL
+//  1. StableVersion     — latest stable release (best representation of the current dependency surface)
+//  2. MaxSemverVersion  — highest semver across published versions (often matches stable; useful when deps.dev data lacks IsDefault/stable flags)
+//  3. PreReleaseVersion — latest non-stable release, for ecosystems/packages where no stable exists yet
 //
-// The first three probe "what does this package currently depend on". The
-// last two ensure we still issue a deps.dev query when upstream release
-// metadata is sparse but a concrete version is known from the input.
+// Intentionally does NOT fall back to RequestedVersion or Package.Version:
+// the contract is "current dependency surface", not "whatever version happens
+// to be pinned". Callers that want version-specific semantics (as in
+// DependentCount) use resolvedVersion instead, which has the opposite
+// ordering (Package.Version first). Keeping the two helpers distinct prevents
+// silent drift between "latest release" and "pinned version" queries.
 func latestReleaseVersion(a *domain.Analysis) string {
-	if a.ReleaseInfo != nil {
-		if v := a.ReleaseInfo.StableVersion; v != nil && v.Version != "" {
-			return v.Version
-		}
-		if v := a.ReleaseInfo.MaxSemverVersion; v != nil && v.Version != "" {
-			return v.Version
-		}
-		if v := a.ReleaseInfo.PreReleaseVersion; v != nil && v.Version != "" {
-			return v.Version
-		}
-		if v := a.ReleaseInfo.RequestedVersion; v != nil && v.Version != "" {
-			return v.Version
-		}
+	if a == nil || a.ReleaseInfo == nil {
+		return ""
 	}
-	if a.Package != nil {
-		if v := strings.TrimSpace(a.Package.Version); v != "" {
-			return v
-		}
+	if v := a.ReleaseInfo.StableVersion; v != nil && v.Version != "" {
+		return v.Version
+	}
+	if v := a.ReleaseInfo.MaxSemverVersion; v != nil && v.Version != "" {
+		return v.Version
+	}
+	if v := a.ReleaseInfo.PreReleaseVersion; v != nil && v.Version != "" {
+		return v.Version
 	}
 	return ""
 }

--- a/internal/infrastructure/integration/purl_batch.go
+++ b/internal/infrastructure/integration/purl_batch.go
@@ -338,17 +338,36 @@ func (s *IntegrationService) enrichDependencyCounts(ctx context.Context, purls [
 	return perPURL
 }
 
-// latestReleaseVersion returns the latest release version for dependency count queries.
-// Preference: StableVersion > PrereleaseVersion.
+// latestReleaseVersion returns the best version string for dependency count queries.
+// Preference order:
+//  1. StableVersion       — latest stable release (best representation of the current dependency surface)
+//  2. MaxSemverVersion    — highest semver across published versions (often matches stable; useful when deps.dev data lacks IsDefault/stable flags)
+//  3. PreReleaseVersion   — latest non-stable release, for ecosystems/packages where no stable exists yet
+//  4. RequestedVersion    — user-pinned version from the request, if present
+//  5. Package.Version     — version embedded in the original PURL
+//
+// The first three probe "what does this package currently depend on". The
+// last two ensure we still issue a deps.dev query when upstream release
+// metadata is sparse but a concrete version is known from the input.
 func latestReleaseVersion(a *domain.Analysis) string {
-	if a.ReleaseInfo == nil {
-		return ""
+	if a.ReleaseInfo != nil {
+		if v := a.ReleaseInfo.StableVersion; v != nil && v.Version != "" {
+			return v.Version
+		}
+		if v := a.ReleaseInfo.MaxSemverVersion; v != nil && v.Version != "" {
+			return v.Version
+		}
+		if v := a.ReleaseInfo.PreReleaseVersion; v != nil && v.Version != "" {
+			return v.Version
+		}
+		if v := a.ReleaseInfo.RequestedVersion; v != nil && v.Version != "" {
+			return v.Version
+		}
 	}
-	if a.ReleaseInfo.StableVersion != nil && a.ReleaseInfo.StableVersion.Version != "" {
-		return a.ReleaseInfo.StableVersion.Version
-	}
-	if a.ReleaseInfo.PreReleaseVersion != nil && a.ReleaseInfo.PreReleaseVersion.Version != "" {
-		return a.ReleaseInfo.PreReleaseVersion.Version
+	if a.Package != nil {
+		if v := strings.TrimSpace(a.Package.Version); v != "" {
+			return v
+		}
 	}
 	return ""
 }

--- a/internal/infrastructure/integration/purl_batch.go
+++ b/internal/infrastructure/integration/purl_batch.go
@@ -252,10 +252,16 @@ func dependenciesSupportedEcosystem(eco string) bool {
 }
 
 // enrichDependencyCounts fetches dependency counts (direct + transitive) from deps.dev
-// and populates Analysis.DirectDepsCount and Analysis.TransitiveDepsCount.
+// and populates Analysis.DirectDepsCount, Analysis.TransitiveDepsCount, and
+// Analysis.HasDependencyGraph.
 // Returns the raw DependenciesResponse map for downstream use (e.g., transitive advisory enrichment).
 //
-// Version selection: StableVersion > PrereleaseVersion (latest release for catalog DB).
+// Version selection: delegated to latestReleaseVersion (StableVersion >
+// MaxSemverVersion > PreReleaseVersion). This intentionally differs from
+// enrichDependentCounts / resolvedVersion (which prefers Package.Version) —
+// DependentCount asks "who depends on this exact version" while DirectDepsCount
+// asks "what does the current release of this package depend on". Keep the two
+// helpers distinct; do not unify them.
 // Supported ecosystems: npm, cargo, maven, pypi (deps.dev limitation).
 // Unsupported ecosystems are filtered out before making API requests to avoid
 // wasting HTTP round-trips on guaranteed 404 responses (important for large batches).

--- a/internal/infrastructure/integration/purl_batch_test.go
+++ b/internal/infrastructure/integration/purl_batch_test.go
@@ -311,7 +311,7 @@ func TestLatestReleaseVersion(t *testing.T) {
 			want:     "2.0.0",
 		},
 		{
-			name:     "fallback to max semver when no stable",
+			name:     "max semver preferred over prerelease when stable missing",
 			analysis: &domain.Analysis{ReleaseInfo: &domain.ReleaseInfo{MaxSemverVersion: &domain.VersionDetail{Version: "4.5.0"}, PreReleaseVersion: &domain.VersionDetail{Version: "1.0.0-beta.1"}}},
 			want:     "4.5.0",
 		},
@@ -321,28 +321,28 @@ func TestLatestReleaseVersion(t *testing.T) {
 			want:     "1.0.0-beta.1",
 		},
 		{
-			name:     "fallback to requested version when no release candidates",
+			name:     "requested version not used (pinned-version semantics belong to resolvedVersion)",
 			analysis: &domain.Analysis{ReleaseInfo: &domain.ReleaseInfo{RequestedVersion: &domain.VersionDetail{Version: "0.9.0"}}},
-			want:     "0.9.0",
+			want:     "",
 		},
 		{
-			name:     "fallback to package version when no release info",
+			name:     "package version not used (pinned-version semantics belong to resolvedVersion)",
 			analysis: &domain.Analysis{Package: &domain.Package{Version: "7.2.1"}},
-			want:     "7.2.1",
+			want:     "",
 		},
 		{
-			name:     "package version trimmed",
-			analysis: &domain.Analysis{Package: &domain.Package{Version: "  7.2.1  "}},
-			want:     "7.2.1",
+			name:     "nil analysis",
+			analysis: nil,
+			want:     "",
 		},
 		{
-			name:     "nil release info and nil package",
+			name:     "nil release info",
 			analysis: &domain.Analysis{},
 			want:     "",
 		},
 		{
-			name:     "all empty versions",
-			analysis: &domain.Analysis{ReleaseInfo: &domain.ReleaseInfo{StableVersion: &domain.VersionDetail{Version: ""}}, Package: &domain.Package{Version: ""}},
+			name:     "empty stable version",
+			analysis: &domain.Analysis{ReleaseInfo: &domain.ReleaseInfo{StableVersion: &domain.VersionDetail{Version: ""}}},
 			want:     "",
 		},
 	}
@@ -463,23 +463,21 @@ func TestEnrichDependencyCounts(t *testing.T) {
 			wantHasDependencyGraph: map[string]bool{"pkg:pypi/django": true},
 		},
 		{
-			name:  "versionless PURL falls back to package version",
-			purls: []string{"pkg:cargo/serde"},
+			name:  "nil response from deps.dev marks graph absent",
+			purls: []string{"pkg:cargo/serde@1.0.210"},
 			analyses: map[string]*domain.Analysis{
-				"pkg:cargo/serde": {
-					EffectivePURL: "pkg:cargo/serde",
+				"pkg:cargo/serde@1.0.210": {
+					EffectivePURL: "pkg:cargo/serde@1.0.210",
 					Package:       &domain.Package{Ecosystem: "cargo", Version: "1.0.210"},
-					// No ReleaseInfo at all — Package.Version is the last-resort fallback.
 				},
 			},
+			// Explicit nil entry exercises the resp == nil branch distinct from "key missing".
 			stubResults: map[string]*depsdev.DependenciesResponse{
-				"pkg:cargo/serde": {
-					Nodes: []depsdev.DependencyNode{{Relation: "SELF"}, {Relation: "DIRECT"}},
-				},
+				"pkg:cargo/serde": nil,
 			},
-			wantDirect:             map[string]int{"pkg:cargo/serde": 1},
-			wantTransitive:         map[string]int{"pkg:cargo/serde": 0},
-			wantHasDependencyGraph: map[string]bool{"pkg:cargo/serde": true},
+			wantDirect:             map[string]int{"pkg:cargo/serde@1.0.210": 0},
+			wantTransitive:         map[string]int{"pkg:cargo/serde@1.0.210": 0},
+			wantHasDependencyGraph: map[string]bool{"pkg:cargo/serde@1.0.210": false},
 		},
 		{
 			name:  "leaf package with zero deps still marks graph as present",

--- a/internal/infrastructure/integration/purl_batch_test.go
+++ b/internal/infrastructure/integration/purl_batch_test.go
@@ -520,7 +520,8 @@ func TestEnrichDependencyCounts(t *testing.T) {
 					// no ReleaseInfo -> latestReleaseVersion returns ""
 				},
 			},
-			// stub has data, but a versionless PURL must never reach the batch call.
+			// stub has data, but the unresolved versionless PURL is filtered out before lookup;
+			// FetchDependenciesBatch may still be invoked with an empty slice.
 			stubResults: map[string]*depsdev.DependenciesResponse{
 				"pkg:pypi/unknown": {Nodes: []depsdev.DependencyNode{{Relation: "DIRECT"}}},
 			},

--- a/internal/infrastructure/integration/purl_batch_test.go
+++ b/internal/infrastructure/integration/purl_batch_test.go
@@ -311,18 +311,38 @@ func TestLatestReleaseVersion(t *testing.T) {
 			want:     "2.0.0",
 		},
 		{
-			name:     "fallback to prerelease",
+			name:     "fallback to max semver when no stable",
+			analysis: &domain.Analysis{ReleaseInfo: &domain.ReleaseInfo{MaxSemverVersion: &domain.VersionDetail{Version: "4.5.0"}, PreReleaseVersion: &domain.VersionDetail{Version: "1.0.0-beta.1"}}},
+			want:     "4.5.0",
+		},
+		{
+			name:     "fallback to prerelease when no stable or max semver",
 			analysis: &domain.Analysis{ReleaseInfo: &domain.ReleaseInfo{PreReleaseVersion: &domain.VersionDetail{Version: "1.0.0-beta.1"}}},
 			want:     "1.0.0-beta.1",
 		},
 		{
-			name:     "nil release info",
+			name:     "fallback to requested version when no release candidates",
+			analysis: &domain.Analysis{ReleaseInfo: &domain.ReleaseInfo{RequestedVersion: &domain.VersionDetail{Version: "0.9.0"}}},
+			want:     "0.9.0",
+		},
+		{
+			name:     "fallback to package version when no release info",
+			analysis: &domain.Analysis{Package: &domain.Package{Version: "7.2.1"}},
+			want:     "7.2.1",
+		},
+		{
+			name:     "package version trimmed",
+			analysis: &domain.Analysis{Package: &domain.Package{Version: "  7.2.1  "}},
+			want:     "7.2.1",
+		},
+		{
+			name:     "nil release info and nil package",
 			analysis: &domain.Analysis{},
 			want:     "",
 		},
 		{
-			name:     "empty versions",
-			analysis: &domain.Analysis{ReleaseInfo: &domain.ReleaseInfo{StableVersion: &domain.VersionDetail{Version: ""}}},
+			name:     "all empty versions",
+			analysis: &domain.Analysis{ReleaseInfo: &domain.ReleaseInfo{StableVersion: &domain.VersionDetail{Version: ""}}, Package: &domain.Package{Version: ""}},
 			want:     "",
 		},
 	}
@@ -416,6 +436,50 @@ func TestEnrichDependencyCounts(t *testing.T) {
 			wantDirect:             map[string]int{"pkg:npm/beta-only": 1},
 			wantTransitive:         map[string]int{"pkg:npm/beta-only": 1},
 			wantHasDependencyGraph: map[string]bool{"pkg:npm/beta-only": true},
+		},
+		{
+			name:  "versionless PURL falls back to max semver when stable missing",
+			purls: []string{"pkg:pypi/django"},
+			analyses: map[string]*domain.Analysis{
+				"pkg:pypi/django": {
+					EffectivePURL: "pkg:pypi/django",
+					Package:       &domain.Package{Ecosystem: "pypi"},
+					// Upstream release metadata missing stable but has MaxSemver —
+					// the deps query should still succeed using the semver fallback.
+					ReleaseInfo: &domain.ReleaseInfo{MaxSemverVersion: &domain.VersionDetail{Version: "5.1.0"}},
+				},
+			},
+			stubResults: map[string]*depsdev.DependenciesResponse{
+				"pkg:pypi/django": {
+					Nodes: []depsdev.DependencyNode{
+						{Relation: "SELF"},
+						{Relation: "DIRECT"},
+						{Relation: "DIRECT"},
+					},
+				},
+			},
+			wantDirect:             map[string]int{"pkg:pypi/django": 2},
+			wantTransitive:         map[string]int{"pkg:pypi/django": 0},
+			wantHasDependencyGraph: map[string]bool{"pkg:pypi/django": true},
+		},
+		{
+			name:  "versionless PURL falls back to package version",
+			purls: []string{"pkg:cargo/serde"},
+			analyses: map[string]*domain.Analysis{
+				"pkg:cargo/serde": {
+					EffectivePURL: "pkg:cargo/serde",
+					Package:       &domain.Package{Ecosystem: "cargo", Version: "1.0.210"},
+					// No ReleaseInfo at all — Package.Version is the last-resort fallback.
+				},
+			},
+			stubResults: map[string]*depsdev.DependenciesResponse{
+				"pkg:cargo/serde": {
+					Nodes: []depsdev.DependencyNode{{Relation: "SELF"}, {Relation: "DIRECT"}},
+				},
+			},
+			wantDirect:             map[string]int{"pkg:cargo/serde": 1},
+			wantTransitive:         map[string]int{"pkg:cargo/serde": 0},
+			wantHasDependencyGraph: map[string]bool{"pkg:cargo/serde": true},
 		},
 		{
 			name:  "leaf package with zero deps still marks graph as present",

--- a/internal/infrastructure/integration/purl_batch_test.go
+++ b/internal/infrastructure/integration/purl_batch_test.go
@@ -339,12 +339,13 @@ func TestLatestReleaseVersion(t *testing.T) {
 
 func TestEnrichDependencyCounts(t *testing.T) {
 	tests := []struct {
-		name           string
-		purls          []string
-		analyses       map[string]*domain.Analysis
-		stubResults    map[string]*depsdev.DependenciesResponse
-		wantDirect     map[string]int
-		wantTransitive map[string]int
+		name                   string
+		purls                  []string
+		analyses               map[string]*domain.Analysis
+		stubResults            map[string]*depsdev.DependenciesResponse
+		wantDirect             map[string]int
+		wantTransitive         map[string]int
+		wantHasDependencyGraph map[string]bool
 	}{
 		{
 			name:  "versioned PURL populates counts",
@@ -367,8 +368,9 @@ func TestEnrichDependencyCounts(t *testing.T) {
 					},
 				},
 			},
-			wantDirect:     map[string]int{"pkg:npm/express@4.21.2": 2},
-			wantTransitive: map[string]int{"pkg:npm/express@4.21.2": 3},
+			wantDirect:             map[string]int{"pkg:npm/express@4.21.2": 2},
+			wantTransitive:         map[string]int{"pkg:npm/express@4.21.2": 3},
+			wantHasDependencyGraph: map[string]bool{"pkg:npm/express@4.21.2": true},
 		},
 		{
 			name:  "versionless PURL resolved via stable release",
@@ -388,8 +390,9 @@ func TestEnrichDependencyCounts(t *testing.T) {
 					},
 				},
 			},
-			wantDirect:     map[string]int{"pkg:cargo/serde": 1},
-			wantTransitive: map[string]int{"pkg:cargo/serde": 0},
+			wantDirect:             map[string]int{"pkg:cargo/serde": 1},
+			wantTransitive:         map[string]int{"pkg:cargo/serde": 0},
+			wantHasDependencyGraph: map[string]bool{"pkg:cargo/serde": true},
 		},
 		{
 			name:  "versionless PURL falls back to prerelease",
@@ -410,21 +413,58 @@ func TestEnrichDependencyCounts(t *testing.T) {
 					},
 				},
 			},
-			wantDirect:     map[string]int{"pkg:npm/beta-only": 1},
-			wantTransitive: map[string]int{"pkg:npm/beta-only": 1},
+			wantDirect:             map[string]int{"pkg:npm/beta-only": 1},
+			wantTransitive:         map[string]int{"pkg:npm/beta-only": 1},
+			wantHasDependencyGraph: map[string]bool{"pkg:npm/beta-only": true},
 		},
 		{
-			name:  "no match leaves counts at zero",
+			name:  "leaf package with zero deps still marks graph as present",
+			purls: []string{"pkg:npm/react@19.1.0"},
+			analyses: map[string]*domain.Analysis{
+				"pkg:npm/react@19.1.0": {
+					EffectivePURL: "pkg:npm/react@19.1.0",
+					Package:       &domain.Package{Ecosystem: "npm", Version: "19.1.0"},
+				},
+			},
+			stubResults: map[string]*depsdev.DependenciesResponse{
+				// Genuine leaf: deps.dev returned a response, but only the SELF node.
+				"pkg:npm/react": {Nodes: []depsdev.DependencyNode{{Relation: "SELF"}}},
+			},
+			wantDirect:             map[string]int{"pkg:npm/react@19.1.0": 0},
+			wantTransitive:         map[string]int{"pkg:npm/react@19.1.0": 0},
+			wantHasDependencyGraph: map[string]bool{"pkg:npm/react@19.1.0": true},
+		},
+		{
+			name:  "no match leaves counts at zero and graph absent",
+			purls: []string{"pkg:pypi/unknown@1.0.0"},
+			analyses: map[string]*domain.Analysis{
+				"pkg:pypi/unknown@1.0.0": {
+					EffectivePURL: "pkg:pypi/unknown@1.0.0",
+					Package:       &domain.Package{Ecosystem: "pypi", Version: "1.0.0"},
+				},
+			},
+			stubResults:            map[string]*depsdev.DependenciesResponse{},
+			wantDirect:             map[string]int{"pkg:pypi/unknown@1.0.0": 0},
+			wantTransitive:         map[string]int{"pkg:pypi/unknown@1.0.0": 0},
+			wantHasDependencyGraph: map[string]bool{"pkg:pypi/unknown@1.0.0": false},
+		},
+		{
+			name:  "versionless with no resolvable release marks graph absent",
 			purls: []string{"pkg:pypi/unknown"},
 			analyses: map[string]*domain.Analysis{
 				"pkg:pypi/unknown": {
 					EffectivePURL: "pkg:pypi/unknown",
 					Package:       &domain.Package{Ecosystem: "pypi"},
+					// no ReleaseInfo -> latestReleaseVersion returns ""
 				},
 			},
-			stubResults:    map[string]*depsdev.DependenciesResponse{},
-			wantDirect:     map[string]int{"pkg:pypi/unknown": 0},
-			wantTransitive: map[string]int{"pkg:pypi/unknown": 0},
+			// stub has data, but a versionless PURL must never reach the batch call.
+			stubResults: map[string]*depsdev.DependenciesResponse{
+				"pkg:pypi/unknown": {Nodes: []depsdev.DependencyNode{{Relation: "DIRECT"}}},
+			},
+			wantDirect:             map[string]int{"pkg:pypi/unknown": 0},
+			wantTransitive:         map[string]int{"pkg:pypi/unknown": 0},
+			wantHasDependencyGraph: map[string]bool{"pkg:pypi/unknown": false},
 		},
 		{
 			name:  "unsupported ecosystem skipped without API call",
@@ -441,8 +481,9 @@ func TestEnrichDependencyCounts(t *testing.T) {
 					Nodes: []depsdev.DependencyNode{{Relation: "DIRECT"}},
 				},
 			},
-			wantDirect:     map[string]int{"pkg:golang/github.com/gin-gonic/gin@v1.10.0": 0},
-			wantTransitive: map[string]int{"pkg:golang/github.com/gin-gonic/gin@v1.10.0": 0},
+			wantDirect:             map[string]int{"pkg:golang/github.com/gin-gonic/gin@v1.10.0": 0},
+			wantTransitive:         map[string]int{"pkg:golang/github.com/gin-gonic/gin@v1.10.0": 0},
+			wantHasDependencyGraph: map[string]bool{"pkg:golang/github.com/gin-gonic/gin@v1.10.0": false},
 		},
 	}
 
@@ -468,6 +509,15 @@ func TestEnrichDependencyCounts(t *testing.T) {
 				}
 				if a.TransitiveDepsCount != wantTransitive {
 					t.Errorf("TransitiveDepsCount for %s = %d, want %d", purl, a.TransitiveDepsCount, wantTransitive)
+				}
+			}
+			for purl, wantHas := range tt.wantHasDependencyGraph {
+				a := tt.analyses[purl]
+				if a == nil {
+					t.Fatalf("analysis not found for %s", purl)
+				}
+				if a.HasDependencyGraph != wantHas {
+					t.Errorf("HasDependencyGraph for %s = %v, want %v", purl, a.HasDependencyGraph, wantHas)
 				}
 			}
 		})


### PR DESCRIPTION
Fixes #313.

## Summary

`DirectDepsCount` / `TransitiveDepsCount` returning `0` was ambiguous: it could mean "genuinely a leaf package" (e.g., `react@19.1.0` has no runtime deps) or "graph not collected" (unsupported ecosystem, versionless input with no resolvable release, 404, transport error). This PR disambiguates and widens the version-resolution fallback.

## Changes

1. **New `HasDependencyGraph bool` on `domain.Analysis`** — set to `true` when deps.dev's `:dependencies` endpoint actually returned a response, regardless of node counts. Callers can now distinguish "leaf" from "unreached".
2. **Extended `latestReleaseVersion` fallback chain** — was `StableVersion > PreReleaseVersion`; now `StableVersion > MaxSemverVersion > PreReleaseVersion`. The MaxSemver tier is defensive coverage for the rare case where deps.dev's stable flag is sparse/missing for a package. Keep the helper distinct from `resolvedVersion` (which `DependentCount` uses with opposite ordering, preferring `Package.Version` because dependent-count is version-specific).
3. **Skip versionless PURLs locally in `enrichDependencyCounts`** with a debug log (`dependency_count_skipped_versionless`) so the "no resolvable version" condition is diagnosable instead of being silently swallowed inside `FetchDependencies`.
4. **Godoc updated** on `DirectDepsCount` / `TransitiveDepsCount` / `HasDependencyGraph` to spell out the new semantics; `enrichDependencyCounts` godoc explains the intentional divergence with `enrichDependentCounts`.
5. **Tests** — table-driven coverage for: MaxSemver-over-PreRelease priority, explicit negative cases for dropped `RequestedVersion` / `Package.Version` tiers (prevents accidental reintroduction), `resp == nil` branch, leaf-with-HasDependencyGraph=true, versionless-skipped paths. Plus a new end-to-end regression test that mocks deps.dev at the HTTP layer and reproduces the issue's table.

### Also included (incidental, scoped to this fix)

- **New `purl.HasVersion(string) bool` helper** (`internal/common/purl/has_version.go`) — parser-based detection of a `@version` segment. Replaces `strings.Contains(ep, "@")` in both `enrichDependencyCounts` and `enrichDependentCounts`; the naive substring check misclassified npm scoped packages (`pkg:npm/@scope/name`) as versioned because `@` appears in the namespace.
- **Copilot learning log updates** (`.github/instructions/copilot-learned-coding.instructions.md` + synced `.claude/rules/copilot-learned-coding.md`) — promotes two recurring patterns surfaced by this PR's Copilot review to the canonical coding-standards rules ("Preserve Original Input Through Heuristic Fallback Chains", "Use Structured Parsers for Structured Identifier Properties"), plus a pending-pattern entry for a PURL-parser-cache performance note.

## Verification (live deps.dev)

The fix was re-verified by building the PR branch (`1ee8b61`) and calling `uzomuzo.EvaluatePURLs` against the real `api.deps.dev` for the five PURLs from #313, plus the same PURLs with explicit version pins for good measure. Small verification program under `pkg/uzomuzo` (not committed; see "How to reproduce" below).

### Versionless — as in the issue (`pkg:npm/react`, etc.)

| Input | Resolved stable | direct | transitive | HasDependencyGraph | Interpretation |
|---|---|---|---|---|---|
| `pkg:npm/express`    | `5.2.1`   | 28 | 39 | **true**  | graph present; express declares 28 direct deps |
| `pkg:npm/react`      | `19.2.5`  | 0  | 0  | **false** | deps.dev returns 404 on `react@19.2.5:dependencies`; flag correctly reports "graph unavailable" — the zero is NOT a claim that react is a leaf |
| `pkg:pypi/requests`  | `2.33.1`  | 4  | 0  | **true**  | graph present; transitive=0 is a known pypi-on-deps.dev limitation |
| `pkg:pypi/django`    | `6.0.4`   | 2  | 1  | **true**  | graph present; `asgiref`, `sqlparse` (+1 indirect) |
| `pkg:cargo/serde`    | `1.0.228` | 0  | 0  | **true**  | graph present; serde@1.0.228 declares no default-feature runtime deps — the zero is now informative |

### Version-pinned (the exact versions cited in #313)

| Input | direct | transitive | HasDependencyGraph |
|---|---|---|---|
| `pkg:npm/express@4.21.2`   | 31 | 40 | true |
| `pkg:npm/react@19.1.0`     | 0  | 0  | true |
| `pkg:pypi/requests@2.32.3` | 4  | 0  | true |
| `pkg:pypi/django@5.1.0`    | 2  | 1  | true |
| `pkg:cargo/serde@1.0.210`  | 1  | 4  | true |

### Pre-fix vs post-fix (same sandbox, same day; `main@7f9d900` vs this PR)

| PURL (versionless) | main direct/trans | PR direct/trans | `HasDependencyGraph` added by this PR | Observation |
|---|---|---|---|---|
| `pkg:npm/express`  | 28 / 39 | 28 / 39 | **true**  | unchanged counts; flag now makes graph presence explicit |
| `pkg:npm/react`    | 0 / 0   | 0 / 0   | **false** | counts unchanged, but the flag now says "graph unavailable" — the core ambiguity from #313 is resolved for this case |
| `pkg:pypi/requests`| 4 / 0   | 4 / 0   | **true**  | unchanged; transitive=0 is a pypi/deps.dev limit, not a bug |
| `pkg:pypi/django`  | 2 / 1   | 2 / 1   | **true**  | unchanged on today's deps.dev data — see note below about the `MaxSemverVersion` tier |
| `pkg:cargo/serde`  | 0 / 0   | 0 / 0   | **true**  | counts unchanged, but the flag now tells consumers the graph WAS collected — serde@1.0.228 is genuinely a leaf under its default feature set |

**Note on `MaxSemverVersion` tier**: the issue's original reproduction saw `django=0/0`, but on today's deps.dev data `StableVersion` is populated for all five packages, so the new `MaxSemverVersion` fallback tier is not needed to recover a version for any of them — both `main` and this PR produce the same counts. The fallback remains valuable as defensive coverage for packages where `StableVersion` is genuinely sparse (the condition the issue reported); the behavior change that is observable end-to-end *today* is `HasDependencyGraph`, which is what makes the remaining zeros interpretable.

### How to reproduce

```go
ctx, _ := context.WithTimeout(context.Background(), 90*time.Second)
ev := uzomuzo.NewEvaluator(os.Getenv("GITHUB_TOKEN"))
res, _ := ev.EvaluatePURLs(ctx, []string{
    "pkg:npm/express", "pkg:npm/react", "pkg:pypi/requests",
    "pkg:pypi/django", "pkg:cargo/serde",
})
for k, a := range res {
    fmt.Printf("%s: direct=%d transitive=%d has_graph=%v (stable=%v)\n",
        k, a.DirectDepsCount, a.TransitiveDepsCount, a.HasDependencyGraph,
        a.ReleaseInfo != nil && a.ReleaseInfo.StableVersion != nil)
}
```

## Test plan

- [x] `go test ./...` green
- [x] `golangci-lint run` clean
- [x] `TestIssue313Reproduction` (mocked deps.dev at HTTP layer) exercises all five issue PURLs; mock counts re-aligned with live `api.deps.dev` responses as of 2026-04-19 (`ed06f88`)
- [x] Unit tests cover MaxSemver-over-PreRelease priority, `resp == nil` branch, versionless-skip, leaf-with-graph paths, and explicit negative cases for dropped fallback tiers
- [x] **Live deps.dev verification** against the real `api.deps.dev` for all five PURLs (versionless + version-pinned); results above

## Known limitation surfaced by live verification

`pkg:npm/react` (versionless) now resolves to stable `19.2.5`, and `api.deps.dev` returns **HTTP 404** for `/systems/npm/packages/react/versions/19.2.5:dependencies`. With this PR the caller correctly observes `HasDependencyGraph=false` instead of the silent `0/0` from main. A fully informative count would require an extra fallback tier that, on 404, retries with the next-newest version that *does* have a published graph (e.g., `19.1.0`). That is **out of scope** for this PR — the minimal correct fix is the flag, which lets downstream consumers decide whether to retry. Follow-up: #319.

## Out of scope (follow-ups)

- CSV export (`internal/infrastructure/export/csv/scorecard.go`) and CLI box-draw output (`internal/interfaces/cli/boxdraw.go`) do not yet use `HasDependencyGraph`. The CSV comment still says "0 = unknown or unsupported ecosystem" (now partially inaccurate), and the boxdraw gate suppresses the "Depends on:" line for leaf packages (exactly the ambiguity the new field was meant to resolve). Tracked as follow-up — not in this PR.
- `react@19.2.5` 404 fallback — tracked as #319 (see "Known limitation" above).
- Pure-DDD critique: `HasDependencyGraph` is an enrichment/observability signal on a domain aggregate. Consistent with existing convention (`DependentCount`, `ScorecardURL`, `ProjectLicense` are already there), so no new violation, but a future refactor could extract an `EnrichedAnalysis` separate from the pure domain aggregate.

https://claude.ai/code/session_01FZBS4L1weQBjiMXpoJ9PeW
