### PR TITLE
feat: add Repository.Summary and Repository.Topics fields (#316, #317)

### DIFF
--- a/.claude/rules/copilot-learned-coding.md
+++ b/.claude/rules/copilot-learned-coding.md
@@ -34,6 +34,7 @@ Rules extracted from recurring Copilot review patterns on coding-standards topic
 - **Normalize Repo-Scoped Paths with `path.Clean`**: When accepting user- or YAML-supplied paths that are scoped within a repository (e.g., local action `./` references), normalize with `path.Clean` (not `filepath.Clean`) and reject results that equal `"."` or start with `".."`. Also reject backslashes. This prevents traversal beyond the repository root via the Contents API without blocking valid intra-repo `..` segments (e.g., `./foo/../bar` → `bar`).
 - **Preserve Original Input Through Heuristic Fallback Chains**: In chained heuristic pipelines where each step transforms an intermediate result, fallback on empty must return the original input — not the intermediate value from a prior step. Returning an intermediate value violates the documented contract and can produce silently incorrect results when later steps depend on the untransformed original.
 - **Accurate Error Map Keys**: When recording errors in a `map[string]error` keyed by file path, use the actual resolved path — not a hardcoded filename. If a fetch tries `action.yml` then falls back to `action.yaml`, the error key must reflect which file was attempted, or use the parent path without a filename assumption.
+- **Exported API Must Not Leak Unexported Types**: When an exported function or method returns (or accepts) an unexported type, it creates an API that other packages cannot use. Either export the type, unexport the function if all callers are package-internal, or use an exported interface/struct. Similarly, when a JSON struct tag uses `omitempty` on a boolean or always-present slice field, the serialized output becomes ambiguous (absent vs false/empty) for downstream consumers — omit `omitempty` for fields whose zero value is semantically meaningful.
 - **Handle All Valid Input Forms in Format Parsers**: When parsing a structured format (ZIP entries, RECORD files, manifests), handle all valid representations defined by the spec — not just the common case. For example, Python wheel RECORD files contain both package directories (`pkg/__init__.py`) and root-level modules (`six.py`); skipping root-level entries silently drops valid import names for single-module packages.
 - **Explicit Fallback for Unknown Enum Values**: When mapping external values (API responses, YAML fields) to internal enums or display strings, map unrecognized values to an explicit fallback (e.g., `"unknown(X)"`) rather than silently defaulting to a valid enum member. Silent defaults hide data quality issues and make debugging harder.
 - **Machine-Readable Columns Must Contain Single Values**: When adding columns to machine-readable output (CSV, JSON), each column must contain exactly one data type — do not combine a label and a number in a single field (e.g., `"HIGH (7.5)"`). Split compound values into separate columns (e.g., `max_advisory_severity` + `max_cvss3_score`). Mixed-format cells break downstream parsing and sorting.
@@ -110,6 +111,11 @@ pending_patterns:
     pr: 299
     file: "internal/application/diet/service_test.go"
     date: "2026-04-12"
+  - category: "comment-doc-drift"
+    summary: "graphqlEndpoint comment claimed BaseURL controls 'both REST and GraphQL paths' but FetchRepoLanguages still hardcodes api.github.com — scope claims to the APIs that actually honor the knob"
+    pr: 318
+    file: "internal/infrastructure/github/client.go"
+    date: "2026-04-20"
   - category: "testing"
     summary: "Unit test using github.com RepoURL triggered normalizeRepoURL redirect path, making a real HTTP GET to github.com — use generic errors or stub transports to keep tests network-independent"
     pr: 318
@@ -140,14 +146,10 @@ pending_patterns:
     pr: 276
     file: "internal/infrastructure/pypi/wheel.go"
     date: "2026-04-11"
-  - category: "api-consistency"
-    summary: "Remove omitempty from boolean and always-present slice JSON tags — omitempty makes absent-vs-false/empty ambiguous for downstream schema consumers"
-    pr: 223
-    file: "internal/interfaces/cli/diet_render.go"
-    date: "2026-04-07"
 ```
 
 <!-- Promotion history (kept for audit trail):
+  # api-consistency: promoted to copilot-learned-coding.instructions.md (PRs #223, #318 — omitempty ambiguity on boolean/slice JSON tags, exported function returning unexported type)
   # performance: promoted to copilot-learned-coding.instructions.md (PRs #315, #318 — cache expensive parsing, avoid full-collection materialization for prefix-only operations)
   # defensive-coding: promoted to copilot-learned-coding.instructions.md (PRs #281, #315 — preserve original input through heuristic fallback chains, use structured parsers for structured identifier properties)
   # defensive-coding: promoted to copilot-learned-coding.instructions.md (PRs #276, #280 — rerun analyzers with combined input, gate fallback on error, spec-compliant parsers, AST ancestor walk continuation)

--- a/.claude/rules/copilot-learned-coding.md
+++ b/.claude/rules/copilot-learned-coding.md
@@ -43,6 +43,7 @@ Rules extracted from recurring Copilot review patterns on coding-standards topic
 - **Filter and Normalize IDs Before Batch API Calls**: When building batch API requests from collected IDs, filter empty/whitespace values and deduplicate before processing to prevent invalid HTTP requests and cache pollution. Use `select` on `ctx.Done()` alongside channel operations in batch goroutines to avoid blocking after context cancellation.
 - **Guard Nil Structs Consistently Across Output Formats**: When a struct field may be nil (e.g., `ReleaseInfo`), apply the nil guard in every output renderer that accesses it (text, CSV, JSON). If one renderer has the guard and another does not, the unguarded path will panic on nil input.
 - **Gate Fallback Logic on Error, Not Result Nilness**: When deciding whether to trigger fallback or retry logic, check the error value — not whether the result is nil. A nil result with nil error is a valid success case (e.g., zero matches found), and treating it as a failure triggers unnecessary retries or incorrect fallback paths.
+- **Minimize Allocations in Hot Paths**: In batch-processing or frequently-called functions, avoid unnecessary O(n) allocations when only a subset of data is needed. Cache results of expensive parsing calls when the same value is checked multiple times in a loop iteration, and iterate to a known cutoff point rather than materializing the full collection (e.g., iterate runes up to a count rather than converting the entire string to `[]rune`).
 - **Use Structured Parsers for Structured Identifier Properties**: When checking properties of structured identifiers (PURLs, URIs, import paths), use the appropriate parser rather than naive string operations (`strings.Contains`, `strings.Split`). For example, `strings.Contains(purl, "@")` misclassifies npm scoped packages like `pkg:npm/@scope/name` as versioned because `@` appears in the namespace. Use `packageurl.FromString(p).Version != ""` or an equivalent parser-based check.
 - **Use Case-Insensitive Comparison for URL Components**: When comparing URL components (scheme, host), use case-insensitive comparison per RFC 3986 — schemes (`HTTP://`) and hosts (`GitHub.COM`) are case-insensitive. Normalize with `strings.ToLower` or `strings.EqualFold` before prefix checks or host matching to avoid double-prefixing or missed matches.
 - **Structured Logging Conventions**: When adding `slog` calls: use DEBUG level for routine per-item telemetry (reserve INFO for exceptional events); use `snake_case` for event names (not spaces) for consistency and filterability; choose field key names that accurately describe the data across all call sites (e.g., `"ref"` not `"purl"` when the function handles both PURLs and URLs).
@@ -109,11 +110,16 @@ pending_patterns:
     pr: 299
     file: "internal/application/diet/service_test.go"
     date: "2026-04-12"
-  - category: "performance"
-    summary: "Cache results of expensive parsing functions (e.g., PURL parser) when the same value is checked multiple times in a loop iteration — avoids redundant allocations in batch processing paths"
-    pr: 315
-    file: "internal/infrastructure/integration/purl_batch.go"
-    date: "2026-04-19"
+  - category: "testing"
+    summary: "Unit test using github.com RepoURL triggered normalizeRepoURL redirect path, making a real HTTP GET to github.com — use generic errors or stub transports to keep tests network-independent"
+    pr: 318
+    file: "internal/infrastructure/github/topics_test.go"
+    date: "2026-04-20"
+  - category: "comment-doc-drift"
+    summary: "Precondition comment example said 'deps.dev Project lookup returned no repo URL' but actual condition is when deps.dev returned no Project at all — comment examples must match actual code conditions"
+    pr: 318
+    file: "internal/infrastructure/integration/populate_summary.go"
+    date: "2026-04-20"
   - category: "comment-doc-drift"
     summary: "Constant doc comment named only Python but the sentinel was reused for Java wildcard imports — doc comments on shared constants must enumerate all languages/contexts that use them"
     pr: 298
@@ -142,6 +148,7 @@ pending_patterns:
 ```
 
 <!-- Promotion history (kept for audit trail):
+  # performance: promoted to copilot-learned-coding.instructions.md (PRs #315, #318 — cache expensive parsing, avoid full-collection materialization for prefix-only operations)
   # defensive-coding: promoted to copilot-learned-coding.instructions.md (PRs #281, #315 — preserve original input through heuristic fallback chains, use structured parsers for structured identifier properties)
   # defensive-coding: promoted to copilot-learned-coding.instructions.md (PRs #276, #280 — rerun analyzers with combined input, gate fallback on error, spec-compliant parsers, AST ancestor walk continuation)
   # comment-doc-drift: promoted to copilot-learned-coding.instructions.md (PRs #253, #276 — interface contract doc must match signature semantics)

--- a/.claude/rules/copilot-learned-coding.md
+++ b/.claude/rules/copilot-learned-coding.md
@@ -111,6 +111,11 @@ pending_patterns:
     pr: 299
     file: "internal/application/diet/service_test.go"
     date: "2026-04-12"
+  - category: "testing"
+    summary: "Test failure branch accessed struct field through potentially-nil pointer in error message — split nil guard (t.Fatalf) from value assertion to prevent panic masking the actual regression"
+    pr: 318
+    file: "internal/infrastructure/integration/populate_project_test.go"
+    date: "2026-04-20"
   - category: "comment-doc-drift"
     summary: "graphqlEndpoint comment claimed BaseURL controls 'both REST and GraphQL paths' but FetchRepoLanguages still hardcodes api.github.com — scope claims to the APIs that actually honor the knob"
     pr: 318

--- a/.claude/rules/copilot-learned-coding.md
+++ b/.claude/rules/copilot-learned-coding.md
@@ -107,6 +107,11 @@ pending_patterns:
     file: "internal/infrastructure/github/client.go"
     date: "2026-04-19"
   - category: "comment-doc-drift"
+    summary: "Concurrency comment claimed 'bounded by httpclient transport limits' but implementation starts one goroutine per unique package name with no explicit cap — comments must accurately describe the concurrency model"
+    pr: 318
+    file: "internal/infrastructure/integration/populate_summary.go"
+    date: "2026-04-20"
+  - category: "comment-doc-drift"
     summary: "Test case name claimed 'web vs data-jpa' but input PURL was spring-boot-starter-security — test names must match the actual input under test"
     pr: 299
     file: "internal/application/diet/service_test.go"
@@ -141,6 +146,11 @@ pending_patterns:
     pr: 318
     file: "internal/domain/analysis/models.go"
     date: "2026-04-19"
+  - category: "comment-doc-drift"
+    summary: "Test helper comment claimed 'REST and GraphQL endpoints both target' the httptest server but some REST callers hardcode api.github.com — scope claims to APIs that actually honor the configuration knob"
+    pr: 318
+    file: "internal/infrastructure/github/topics_test.go"
+    date: "2026-04-20"
   - category: "whitespace-agnostic-matching"
     summary: "Use bytes.Fields tokenization instead of fixed-separator prefix checks when matching directives — tabs and multiple spaces are valid separators"
     pr: 140

--- a/.claude/rules/copilot-learned-coding.md
+++ b/.claude/rules/copilot-learned-coding.md
@@ -102,6 +102,11 @@ pending_patterns:
     pr: 281
     file: "internal/infrastructure/treesitter/lang_go.go"
     date: "2026-04-11"
+  - category: "defensive-coding"
+    summary: "When deriving a secondary API endpoint from a configurable base URL, handle known suffixes that change between API versions — e.g., GHES REST URLs ending in /api/v3 must rewrite to /api/graphql, not blindly append /graphql"
+    pr: 318
+    file: "internal/infrastructure/github/client.go"
+    date: "2026-04-19"
   - category: "comment-doc-drift"
     summary: "Test case name claimed 'web vs data-jpa' but input PURL was spring-boot-starter-security — test names must match the actual input under test"
     pr: 299
@@ -112,6 +117,11 @@ pending_patterns:
     pr: 298
     file: "internal/infrastructure/treesitter/analyzer.go"
     date: "2026-04-12"
+  - category: "comment-doc-drift"
+    summary: "Godoc said '≤200 chars' but NormalizeSummary enforces a 200-rune cap — use 'runes' (or 'Unicode code points') in docs when the implementation counts runes, not bytes"
+    pr: 318
+    file: "internal/domain/analysis/models.go"
+    date: "2026-04-19"
   - category: "whitespace-agnostic-matching"
     summary: "Use bytes.Fields tokenization instead of fixed-separator prefix checks when matching directives — tabs and multiple spaces are valid separators"
     pr: 140
@@ -250,4 +260,6 @@ pending_patterns:
   # testing (PR #283): already covered by "Cover New Control Flow Branches with Tests" and "Verify Tree-Sitter Query Patterns Do Not Overlap" — each tree-sitter query pattern variant (generic vs non-generic scoped constructor) needs its own test case
   # comment-doc-drift (PR #283 round 4): already covered by "Comment-Code Consistency" rule — scoped constructor comment described 2-capture positional behavior but queries only have a single @func capture
   # comment-doc-drift (PR #285): already covered by "Comment-Code Consistency" rule — HasBlankImport comments/docs said "no callable API" but flag covers broader patterns (Python feature-detection) that may have callable APIs; aliasMap comment claimed safety without noting lack of scope resolution
+  # comment-doc-drift (PR #318): already covered by "Comment-Code Consistency" rule — godoc said "chars" but NormalizeSummary counts runes; use correct unit in comments for multibyte-aware caps
+  # defensive-coding (PR #318): already covered by "Use Case-Insensitive Comparison for URL Components" and existing URL handling rules — GHES REST /api/v3 suffix must rewrite to /api/graphql for GraphQL endpoint
 -->

--- a/.github/instructions/copilot-learned-coding.instructions.md
+++ b/.github/instructions/copilot-learned-coding.instructions.md
@@ -105,6 +105,11 @@ pending_patterns:
     file: "internal/infrastructure/github/client.go"
     date: "2026-04-19"
   - category: "comment-doc-drift"
+    summary: "Concurrency comment claimed 'bounded by httpclient transport limits' but implementation starts one goroutine per unique package name with no explicit cap — comments must accurately describe the concurrency model"
+    pr: 318
+    file: "internal/infrastructure/integration/populate_summary.go"
+    date: "2026-04-20"
+  - category: "comment-doc-drift"
     summary: "Test case name claimed 'web vs data-jpa' but input PURL was spring-boot-starter-security — test names must match the actual input under test"
     pr: 299
     file: "internal/application/diet/service_test.go"
@@ -139,6 +144,11 @@ pending_patterns:
     pr: 318
     file: "internal/domain/analysis/models.go"
     date: "2026-04-19"
+  - category: "comment-doc-drift"
+    summary: "Test helper comment claimed 'REST and GraphQL endpoints both target' the httptest server but some REST callers hardcode api.github.com — scope claims to APIs that actually honor the configuration knob"
+    pr: 318
+    file: "internal/infrastructure/github/topics_test.go"
+    date: "2026-04-20"
   - category: "whitespace-agnostic-matching"
     summary: "Use bytes.Fields tokenization instead of fixed-separator prefix checks when matching directives — tabs and multiple spaces are valid separators"
     pr: 140

--- a/.github/instructions/copilot-learned-coding.instructions.md
+++ b/.github/instructions/copilot-learned-coding.instructions.md
@@ -109,6 +109,11 @@ pending_patterns:
     pr: 299
     file: "internal/application/diet/service_test.go"
     date: "2026-04-12"
+  - category: "testing"
+    summary: "Test failure branch accessed struct field through potentially-nil pointer in error message — split nil guard (t.Fatalf) from value assertion to prevent panic masking the actual regression"
+    pr: 318
+    file: "internal/infrastructure/integration/populate_project_test.go"
+    date: "2026-04-20"
   - category: "comment-doc-drift"
     summary: "graphqlEndpoint comment claimed BaseURL controls 'both REST and GraphQL paths' but FetchRepoLanguages still hardcodes api.github.com — scope claims to the APIs that actually honor the knob"
     pr: 318

--- a/.github/instructions/copilot-learned-coding.instructions.md
+++ b/.github/instructions/copilot-learned-coding.instructions.md
@@ -32,6 +32,7 @@ Rules extracted from recurring Copilot review patterns on coding-standards topic
 - **Normalize Repo-Scoped Paths with `path.Clean`**: When accepting user- or YAML-supplied paths that are scoped within a repository (e.g., local action `./` references), normalize with `path.Clean` (not `filepath.Clean`) and reject results that equal `"."` or start with `".."`. Also reject backslashes. This prevents traversal beyond the repository root via the Contents API without blocking valid intra-repo `..` segments (e.g., `./foo/../bar` → `bar`).
 - **Preserve Original Input Through Heuristic Fallback Chains**: In chained heuristic pipelines where each step transforms an intermediate result, fallback on empty must return the original input — not the intermediate value from a prior step. Returning an intermediate value violates the documented contract and can produce silently incorrect results when later steps depend on the untransformed original.
 - **Accurate Error Map Keys**: When recording errors in a `map[string]error` keyed by file path, use the actual resolved path — not a hardcoded filename. If a fetch tries `action.yml` then falls back to `action.yaml`, the error key must reflect which file was attempted, or use the parent path without a filename assumption.
+- **Exported API Must Not Leak Unexported Types**: When an exported function or method returns (or accepts) an unexported type, it creates an API that other packages cannot use. Either export the type, unexport the function if all callers are package-internal, or use an exported interface/struct. Similarly, when a JSON struct tag uses `omitempty` on a boolean or always-present slice field, the serialized output becomes ambiguous (absent vs false/empty) for downstream consumers — omit `omitempty` for fields whose zero value is semantically meaningful.
 - **Handle All Valid Input Forms in Format Parsers**: When parsing a structured format (ZIP entries, RECORD files, manifests), handle all valid representations defined by the spec — not just the common case. For example, Python wheel RECORD files contain both package directories (`pkg/__init__.py`) and root-level modules (`six.py`); skipping root-level entries silently drops valid import names for single-module packages.
 - **Explicit Fallback for Unknown Enum Values**: When mapping external values (API responses, YAML fields) to internal enums or display strings, map unrecognized values to an explicit fallback (e.g., `"unknown(X)"`) rather than silently defaulting to a valid enum member. Silent defaults hide data quality issues and make debugging harder.
 - **Machine-Readable Columns Must Contain Single Values**: When adding columns to machine-readable output (CSV, JSON), each column must contain exactly one data type — do not combine a label and a number in a single field (e.g., `"HIGH (7.5)"`). Split compound values into separate columns (e.g., `max_advisory_severity` + `max_cvss3_score`). Mixed-format cells break downstream parsing and sorting.
@@ -108,6 +109,11 @@ pending_patterns:
     pr: 299
     file: "internal/application/diet/service_test.go"
     date: "2026-04-12"
+  - category: "comment-doc-drift"
+    summary: "graphqlEndpoint comment claimed BaseURL controls 'both REST and GraphQL paths' but FetchRepoLanguages still hardcodes api.github.com — scope claims to the APIs that actually honor the knob"
+    pr: 318
+    file: "internal/infrastructure/github/client.go"
+    date: "2026-04-20"
   - category: "testing"
     summary: "Unit test using github.com RepoURL triggered normalizeRepoURL redirect path, making a real HTTP GET to github.com — use generic errors or stub transports to keep tests network-independent"
     pr: 318
@@ -138,14 +144,10 @@ pending_patterns:
     pr: 276
     file: "internal/infrastructure/pypi/wheel.go"
     date: "2026-04-11"
-  - category: "api-consistency"
-    summary: "Remove omitempty from boolean and always-present slice JSON tags — omitempty makes absent-vs-false/empty ambiguous for downstream schema consumers"
-    pr: 223
-    file: "internal/interfaces/cli/diet_render.go"
-    date: "2026-04-07"
 ```
 
 <!-- Promotion history (kept for audit trail):
+  # api-consistency: promoted to copilot-learned-coding.instructions.md (PRs #223, #318 — omitempty ambiguity on boolean/slice JSON tags, exported function returning unexported type)
   # performance: promoted to copilot-learned-coding.instructions.md (PRs #315, #318 — cache expensive parsing, avoid full-collection materialization for prefix-only operations)
   # defensive-coding: promoted to copilot-learned-coding.instructions.md (PRs #281, #315 — preserve original input through heuristic fallback chains, use structured parsers for structured identifier properties)
   # defensive-coding: promoted to copilot-learned-coding.instructions.md (PRs #276, #280 — rerun analyzers with combined input, gate fallback on error, spec-compliant parsers, AST ancestor walk continuation)

--- a/.github/instructions/copilot-learned-coding.instructions.md
+++ b/.github/instructions/copilot-learned-coding.instructions.md
@@ -100,6 +100,11 @@ pending_patterns:
     pr: 281
     file: "internal/infrastructure/treesitter/lang_go.go"
     date: "2026-04-11"
+  - category: "defensive-coding"
+    summary: "When deriving a secondary API endpoint from a configurable base URL, handle known suffixes that change between API versions — e.g., GHES REST URLs ending in /api/v3 must rewrite to /api/graphql, not blindly append /graphql"
+    pr: 318
+    file: "internal/infrastructure/github/client.go"
+    date: "2026-04-19"
   - category: "comment-doc-drift"
     summary: "Test case name claimed 'web vs data-jpa' but input PURL was spring-boot-starter-security — test names must match the actual input under test"
     pr: 299
@@ -110,6 +115,11 @@ pending_patterns:
     pr: 298
     file: "internal/infrastructure/treesitter/analyzer.go"
     date: "2026-04-12"
+  - category: "comment-doc-drift"
+    summary: "Godoc said '≤200 chars' but NormalizeSummary enforces a 200-rune cap — use 'runes' (or 'Unicode code points') in docs when the implementation counts runes, not bytes"
+    pr: 318
+    file: "internal/domain/analysis/models.go"
+    date: "2026-04-19"
   - category: "whitespace-agnostic-matching"
     summary: "Use bytes.Fields tokenization instead of fixed-separator prefix checks when matching directives — tabs and multiple spaces are valid separators"
     pr: 140
@@ -248,4 +258,6 @@ pending_patterns:
   # testing (PR #283): already covered by "Cover New Control Flow Branches with Tests" and "Verify Tree-Sitter Query Patterns Do Not Overlap" — each tree-sitter query pattern variant (generic vs non-generic scoped constructor) needs its own test case
   # comment-doc-drift (PR #283 round 4): already covered by "Comment-Code Consistency" rule — scoped constructor comment described 2-capture positional behavior but queries only have a single @func capture
   # comment-doc-drift (PR #285): already covered by "Comment-Code Consistency" rule — HasBlankImport comments/docs said "no callable API" but flag covers broader patterns (Python feature-detection) that may have callable APIs; aliasMap comment claimed safety without noting lack of scope resolution
+  # comment-doc-drift (PR #318): already covered by "Comment-Code Consistency" rule — godoc said "chars" but NormalizeSummary counts runes; use correct unit in comments for multibyte-aware caps
+  # defensive-coding (PR #318): already covered by "Use Case-Insensitive Comparison for URL Components" and existing URL handling rules — GHES REST /api/v3 suffix must rewrite to /api/graphql for GraphQL endpoint
 -->

--- a/.github/instructions/copilot-learned-coding.instructions.md
+++ b/.github/instructions/copilot-learned-coding.instructions.md
@@ -41,6 +41,7 @@ Rules extracted from recurring Copilot review patterns on coding-standards topic
 - **Filter and Normalize IDs Before Batch API Calls**: When building batch API requests from collected IDs, filter empty/whitespace values and deduplicate before processing to prevent invalid HTTP requests and cache pollution. Use `select` on `ctx.Done()` alongside channel operations in batch goroutines to avoid blocking after context cancellation.
 - **Guard Nil Structs Consistently Across Output Formats**: When a struct field may be nil (e.g., `ReleaseInfo`), apply the nil guard in every output renderer that accesses it (text, CSV, JSON). If one renderer has the guard and another does not, the unguarded path will panic on nil input.
 - **Gate Fallback Logic on Error, Not Result Nilness**: When deciding whether to trigger fallback or retry logic, check the error value — not whether the result is nil. A nil result with nil error is a valid success case (e.g., zero matches found), and treating it as a failure triggers unnecessary retries or incorrect fallback paths.
+- **Minimize Allocations in Hot Paths**: In batch-processing or frequently-called functions, avoid unnecessary O(n) allocations when only a subset of data is needed. Cache results of expensive parsing calls when the same value is checked multiple times in a loop iteration, and iterate to a known cutoff point rather than materializing the full collection (e.g., iterate runes up to a count rather than converting the entire string to `[]rune`).
 - **Use Structured Parsers for Structured Identifier Properties**: When checking properties of structured identifiers (PURLs, URIs, import paths), use the appropriate parser rather than naive string operations (`strings.Contains`, `strings.Split`). For example, `strings.Contains(purl, "@")` misclassifies npm scoped packages like `pkg:npm/@scope/name` as versioned because `@` appears in the namespace. Use `packageurl.FromString(p).Version != ""` or an equivalent parser-based check.
 - **Use Case-Insensitive Comparison for URL Components**: When comparing URL components (scheme, host), use case-insensitive comparison per RFC 3986 — schemes (`HTTP://`) and hosts (`GitHub.COM`) are case-insensitive. Normalize with `strings.ToLower` or `strings.EqualFold` before prefix checks or host matching to avoid double-prefixing or missed matches.
 - **Structured Logging Conventions**: When adding `slog` calls: use DEBUG level for routine per-item telemetry (reserve INFO for exceptional events); use `snake_case` for event names (not spaces) for consistency and filterability; choose field key names that accurately describe the data across all call sites (e.g., `"ref"` not `"purl"` when the function handles both PURLs and URLs).
@@ -107,11 +108,16 @@ pending_patterns:
     pr: 299
     file: "internal/application/diet/service_test.go"
     date: "2026-04-12"
-  - category: "performance"
-    summary: "Cache results of expensive parsing functions (e.g., PURL parser) when the same value is checked multiple times in a loop iteration — avoids redundant allocations in batch processing paths"
-    pr: 315
-    file: "internal/infrastructure/integration/purl_batch.go"
-    date: "2026-04-19"
+  - category: "testing"
+    summary: "Unit test using github.com RepoURL triggered normalizeRepoURL redirect path, making a real HTTP GET to github.com — use generic errors or stub transports to keep tests network-independent"
+    pr: 318
+    file: "internal/infrastructure/github/topics_test.go"
+    date: "2026-04-20"
+  - category: "comment-doc-drift"
+    summary: "Precondition comment example said 'deps.dev Project lookup returned no repo URL' but actual condition is when deps.dev returned no Project at all — comment examples must match actual code conditions"
+    pr: 318
+    file: "internal/infrastructure/integration/populate_summary.go"
+    date: "2026-04-20"
   - category: "comment-doc-drift"
     summary: "Constant doc comment named only Python but the sentinel was reused for Java wildcard imports — doc comments on shared constants must enumerate all languages/contexts that use them"
     pr: 298
@@ -140,6 +146,7 @@ pending_patterns:
 ```
 
 <!-- Promotion history (kept for audit trail):
+  # performance: promoted to copilot-learned-coding.instructions.md (PRs #315, #318 — cache expensive parsing, avoid full-collection materialization for prefix-only operations)
   # defensive-coding: promoted to copilot-learned-coding.instructions.md (PRs #281, #315 — preserve original input through heuristic fallback chains, use structured parsers for structured identifier properties)
   # defensive-coding: promoted to copilot-learned-coding.instructions.md (PRs #276, #280 — rerun analyzers with combined input, gate fallback on error, spec-compliant parsers, AST ancestor walk continuation)
   # comment-doc-drift: promoted to copilot-learned-coding.instructions.md (PRs #253, #276 — interface contract doc must match signature semantics)

--- a/docs/data-flow.md
+++ b/docs/data-flow.md
@@ -94,7 +94,7 @@ Returns Project info for each projectKey (e.g., github.com/owner/repo):
 - Purpose: Evaluate repository state (archived/disabled/fork), recent commit activity, and surface metadata (description → Repository.Summary, topics → Repository.Topics)
 - Code:
   - Basic info query: `Client.FetchBasicRepositoryInfo` (`internal/infrastructure/github/client.go`)
-  - Batch orchestration: `Client.FetchRepositoryStatesBatch`
+  - Batch orchestration: `Client.fetchRepositoryStatesBatch` (package-internal)
   - HTTP + query execution: `Client.executeGraphQLQuery`
 - Docs: <https://docs.github.com/en/graphql>
 

--- a/docs/data-flow.md
+++ b/docs/data-flow.md
@@ -90,8 +90,8 @@ Returns Project info for each projectKey (e.g., github.com/owner/repo):
 
 #### GitHub — GraphQL (POST https://api.github.com/graphql)
 
-- Query repository(owner, name) fields: `isArchived`, `isDisabled`, `isFork`, `defaultBranchRef{name, target{... on Commit { history(first:N){nodes{committedDate, author{user{login}}}}}}}`、`rateLimit{cost, remaining, resetAt}`
-- Purpose: Evaluate repository state (archived/disabled/fork) and recent commit activity
+- Query repository(owner, name) fields: `isArchived`, `isDisabled`, `isFork`, `stargazerCount`, `forkCount`, `description`, `homepageUrl`, `licenseInfo{spdxId, name}`, `repositoryTopics(first:20){nodes{topic{name}}}`, `defaultBranchRef{name, target{... on Commit { history(first:N){nodes{committedDate, author{user{login}}}}}}}`, `rateLimit{cost, remaining, resetAt}`
+- Purpose: Evaluate repository state (archived/disabled/fork), recent commit activity, and surface metadata (description → Repository.Summary, topics → Repository.Topics)
 - Code:
   - Basic info query: `Client.FetchBasicRepositoryInfo` (`internal/infrastructure/github/client.go`)
   - Batch orchestration: `Client.FetchRepositoryStatesBatch`

--- a/internal/application/analysis_service.go
+++ b/internal/application/analysis_service.go
@@ -53,6 +53,10 @@ type AnalysisService struct {
 	// ProcessBatch* methods pass it to eolevaluator.NewEvaluator to share
 	// the same instance (and its 5-min TTL cache) across calls.
 	packagistClient *packagist.Client
+	// pypiClient is shared across IntegrationService (Summary enrichment) and
+	// the per-batch eolevaluator instance so both consumers reuse the same
+	// 10-min in-memory cache and avoid duplicate PyPI fetches per package.
+	pypiClient *pypi.Client
 }
 
 // GitHubClient returns the underlying GitHub client for rate limit inspection.
@@ -83,6 +87,7 @@ func NewAnalysisServiceFromConfig(cfg *config.Config, opts ...Option) *AnalysisS
 	githubClient := github.NewClient(cfg)
 	rgClient := rubygems.NewClient()
 	pkgClient := packagist.NewClient()
+	pyClient := pypi.NewClient()
 	depsdevClient := depsdev.NewDepsDevClient(&cfg.DepsDev)
 	// Attach npmjs, RubyGems and Packagist clients to enable repository URL fallbacks
 	depsdevClient = depsdevClient.
@@ -98,17 +103,19 @@ func NewAnalysisServiceFromConfig(cfg *config.Config, opts ...Option) *AnalysisS
 		}()).
 		WithRubyGems(rgClient).
 		WithPackagist(pkgClient).
-		WithPyPI(pypi.NewClient())
+		WithPyPI(pyClient)
 	integrationService := integration.NewIntegrationService(githubClient, depsdevClient,
 		integration.WithConfig(cfg),
 		integration.WithRubyGemsClient(rgClient),
 		integration.WithPackagistClient(pkgClient),
+		integration.WithPyPIClient(pyClient),
 	)
 
 	s := &AnalysisService{
 		integrationService: integrationService,
 		cfg:                cfg,
 		packagistClient:    pkgClient,
+		pypiClient:         pyClient,
 	}
 	for _, o := range opts {
 		o(s)
@@ -133,6 +140,11 @@ func (s *AnalysisService) ProcessBatchPURLs(ctx context.Context, purls []string)
 
 	// Phase 1: Evaluate base EOL from primary (non-catalog) deterministic sources
 	eolEvaluator := eolevaluator.NewEvaluator(s.packagistClient)
+	if s.pypiClient != nil {
+		// Reuse the integration-phase PyPI client so the cache populated by
+		// enrichPyPISummary is reused here, eliminating duplicate fetches per package.
+		eolEvaluator.SetPyPIClient(s.pypiClient)
+	}
 	if s.cfg != nil { // mirror alignment
 		if u := s.cfg.Maven.BaseURL; strings.TrimSpace(u) != "" {
 			mv := maven.NewClient()
@@ -244,6 +256,9 @@ func (s *AnalysisService) ProcessBatchGitHubURLs(ctx context.Context, githubURLs
 
 	// Phase 1: Base EOL
 	eolEvaluator := eolevaluator.NewEvaluator(s.packagistClient)
+	if s.pypiClient != nil {
+		eolEvaluator.SetPyPIClient(s.pypiClient)
+	}
 	if s.cfg != nil {
 		if u := s.cfg.Maven.BaseURL; strings.TrimSpace(u) != "" {
 			mv := maven.NewClient()

--- a/internal/application/fetch_service.go
+++ b/internal/application/fetch_service.go
@@ -13,6 +13,7 @@ import (
 	"github.com/future-architect/uzomuzo-oss/internal/infrastructure/integration"
 	"github.com/future-architect/uzomuzo-oss/internal/infrastructure/maven"
 	"github.com/future-architect/uzomuzo-oss/internal/infrastructure/packagist"
+	"github.com/future-architect/uzomuzo-oss/internal/infrastructure/pypi"
 	"github.com/future-architect/uzomuzo-oss/internal/infrastructure/rubygems"
 )
 
@@ -35,9 +36,11 @@ func NewFetchServiceFromConfig(cfg *config.Config) *FetchService {
 	githubClient := github.NewClient(cfg)
 	rgClient := rubygems.NewClient()
 	pkgClient := packagist.NewClient()
+	pyClient := pypi.NewClient()
 	depsdevClient := depsdev.NewDepsDevClient(&cfg.DepsDev).
 		WithRubyGems(rgClient).
 		WithPackagist(pkgClient).
+		WithPyPI(pyClient).
 		WithMaven(func() *maven.Client {
 			mv := maven.NewClient()
 			if u := cfg.Maven.BaseURL; strings.TrimSpace(u) != "" {
@@ -50,6 +53,7 @@ func NewFetchServiceFromConfig(cfg *config.Config) *FetchService {
 		integration.WithConfig(cfg),
 		integration.WithRubyGemsClient(rgClient),
 		integration.WithPackagistClient(pkgClient),
+		integration.WithPyPIClient(pyClient),
 	)
 	return &FetchService{integrationService: integrationService}
 }

--- a/internal/domain/analysis/models.go
+++ b/internal/domain/analysis/models.go
@@ -79,7 +79,7 @@ type Repository struct {
 	// DefaultBranch is the canonical default branch name (e.g. main, master) fetched via GitHub GraphQL.
 	// It enables downstream fetchers (README, go.mod, etc.) to avoid guessing common branch names.
 	DefaultBranch string
-	// Summary is a short, UI-ready, normalized one-line description (≤200 chars).
+	// Summary is a short, UI-ready, normalized one-line description (≤200 runes).
 	// Per-source provenance:
 	//   - GitHub repos:      GraphQL repository.description (already short).
 	//   - deps.dev Project:  project.description (repo-level, short).

--- a/internal/domain/analysis/models.go
+++ b/internal/domain/analysis/models.go
@@ -79,6 +79,20 @@ type Repository struct {
 	// DefaultBranch is the canonical default branch name (e.g. main, master) fetched via GitHub GraphQL.
 	// It enables downstream fetchers (README, go.mod, etc.) to avoid guessing common branch names.
 	DefaultBranch string
+	// Summary is a short, UI-ready, normalized one-line description (≤200 chars).
+	// Per-source provenance:
+	//   - GitHub repos:      GraphQL repository.description (already short).
+	//   - deps.dev Project:  project.description (repo-level, short).
+	//   - PyPI packages:     info.summary from PyPI JSON API (overrides above for ecosystem=pypi).
+	// Empty when no source provided a usable value. Description (above) is preserved unchanged
+	// for consumers that want the raw upstream value; see NormalizeSummary for the rules.
+	Summary string
+	// Topics holds GitHub repository topics (already-lowercased tags) returned by the
+	// repositoryTopics GraphQL connection (capped at 20). Sentinel values:
+	//   - nil       : not fetched (no GitHub token, non-GitHub host, or fetch failed)
+	//   - []string{}: fetched successfully, repository has zero topics configured
+	//   - non-empty : fetched topics in GitHub-returned order, deduplicated
+	Topics []string
 }
 
 // Package represents a package being analyzed

--- a/internal/domain/analysis/models_test.go
+++ b/internal/domain/analysis/models_test.go
@@ -21,6 +21,8 @@ func TestRepository(t *testing.T) {
 				ForksCount:  20,
 				Language:    "Go",
 				Description: "Test repository",
+				Summary:     "Test repository",
+				Topics:      []string{"go", "library"},
 				LastCommit:  time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
 			},
 			expected: Repository{
@@ -31,6 +33,8 @@ func TestRepository(t *testing.T) {
 				ForksCount:  20,
 				Language:    "Go",
 				Description: "Test repository",
+				Summary:     "Test repository",
+				Topics:      []string{"go", "library"},
 				LastCommit:  time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
 			},
 		},
@@ -44,6 +48,8 @@ func TestRepository(t *testing.T) {
 				ForksCount:  0,
 				Language:    "",
 				Description: "",
+				Summary:     "",
+				Topics:      nil,
 				LastCommit:  time.Time{},
 			},
 			expected: Repository{
@@ -54,7 +60,20 @@ func TestRepository(t *testing.T) {
 				ForksCount:  0,
 				Language:    "",
 				Description: "",
+				Summary:     "",
+				Topics:      nil,
 				LastCommit:  time.Time{},
+			},
+		},
+		{
+			name: "fetched_repository_zero_topics",
+			repository: Repository{
+				URL:    "https://github.com/owner/quiet",
+				Topics: []string{},
+			},
+			expected: Repository{
+				URL:    "https://github.com/owner/quiet",
+				Topics: []string{},
 			},
 		},
 	}
@@ -81,6 +100,22 @@ func TestRepository(t *testing.T) {
 			}
 			if tt.repository.Description != tt.expected.Description {
 				t.Errorf("Repository.Description = %v, want %v", tt.repository.Description, tt.expected.Description)
+			}
+			if tt.repository.Summary != tt.expected.Summary {
+				t.Errorf("Repository.Summary = %v, want %v", tt.repository.Summary, tt.expected.Summary)
+			}
+			// Distinguish nil vs []string{} (empty) sentinels — both compare as len==0.
+			if (tt.repository.Topics == nil) != (tt.expected.Topics == nil) {
+				t.Errorf("Repository.Topics nil mismatch: got nil=%v, want nil=%v",
+					tt.repository.Topics == nil, tt.expected.Topics == nil)
+			}
+			if len(tt.repository.Topics) != len(tt.expected.Topics) {
+				t.Errorf("Repository.Topics length = %d, want %d", len(tt.repository.Topics), len(tt.expected.Topics))
+			}
+			for i := range tt.repository.Topics {
+				if tt.repository.Topics[i] != tt.expected.Topics[i] {
+					t.Errorf("Repository.Topics[%d] = %v, want %v", i, tt.repository.Topics[i], tt.expected.Topics[i])
+				}
 			}
 			if !tt.repository.LastCommit.Equal(tt.expected.LastCommit) {
 				t.Errorf("Repository.LastCommit = %v, want %v", tt.repository.LastCommit, tt.expected.LastCommit)

--- a/internal/domain/analysis/summary.go
+++ b/internal/domain/analysis/summary.go
@@ -45,12 +45,23 @@ func NormalizeSummary(raw string) string {
 	if utf8.RuneCountInString(collapsed) <= MaxSummaryLen {
 		return collapsed
 	}
-	// Truncate at (MaxSummaryLen - 1) runes and append an ellipsis so the final rune
-	// count is at most MaxSummaryLen — TrimRightFunc may further shorten the prefix
-	// when truncation lands on whitespace, so the result can be a few runes shorter
-	// (the cap is a maximum, not an exact length).
-	runes := []rune(collapsed)
-	return strings.TrimRightFunc(string(runes[:MaxSummaryLen-1]), unicode.IsSpace) + summaryEllipsis
+	return truncateSummary(collapsed)
+}
+
+// truncateSummary truncates s to MaxSummaryLen runes with an ellipsis by iterating
+// runes up to the cutoff point — avoids materializing the full []rune slice for
+// large inputs where only the first 199 runes are needed.
+func truncateSummary(s string) string {
+	runeCount := 0
+	cutoff := len(s)
+	for i := range s {
+		if runeCount == MaxSummaryLen-1 {
+			cutoff = i
+			break
+		}
+		runeCount++
+	}
+	return strings.TrimRightFunc(s[:cutoff], unicode.IsSpace) + summaryEllipsis
 }
 
 // FirstSentence returns the first sentence-like fragment of s.

--- a/internal/domain/analysis/summary.go
+++ b/internal/domain/analysis/summary.go
@@ -1,0 +1,124 @@
+package analysis
+
+import (
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+// MaxSummaryLen is the maximum rune length of Repository.Summary.
+// Exported for consumers that want to validate ingest-side values against the same cap.
+const MaxSummaryLen = 200
+
+// summaryEllipsis is appended when truncation occurs; counted toward MaxSummaryLen.
+const summaryEllipsis = "…"
+
+// NormalizeSummary returns a trimmed, single-line, rune-count-capped form of raw.
+//
+// Rules:
+//   - Trim leading/trailing whitespace.
+//   - Collapse any run of whitespace (spaces, tabs, newlines) to a single space.
+//   - Truncate to MaxSummaryLen runes; when truncated, the last rune is replaced with "…".
+//
+// The helper does NOT perform first-sentence extraction — call FirstSentence first when the
+// source is known to be multi-paragraph (e.g. Maven POM <description>). See issue #316.
+func NormalizeSummary(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return ""
+	}
+	var b strings.Builder
+	b.Grow(len(trimmed))
+	inSpace := false
+	for _, r := range trimmed {
+		if unicode.IsSpace(r) {
+			if !inSpace {
+				b.WriteByte(' ')
+				inSpace = true
+			}
+			continue
+		}
+		inSpace = false
+		b.WriteRune(r)
+	}
+	collapsed := b.String()
+	if utf8.RuneCountInString(collapsed) <= MaxSummaryLen {
+		return collapsed
+	}
+	// Truncate at (MaxSummaryLen - 1) runes and append an ellipsis so the final rune count
+	// is exactly MaxSummaryLen.
+	runes := []rune(collapsed)
+	return strings.TrimRightFunc(string(runes[:MaxSummaryLen-1]), unicode.IsSpace) + summaryEllipsis
+}
+
+// FirstSentence returns the first sentence-like fragment of s.
+//
+// Heuristic boundaries (first match wins):
+//  1. The first blank-line paragraph break ("\n\n" after any intervening whitespace).
+//  2. A terminal sentence punctuation (.!?) followed by whitespace or end of input —
+//     provided the preceding rune is not a digit (avoids splitting "v3.0 released").
+//
+// Returns the original (trimmed) string when no boundary is found. Intended for multi-paragraph
+// sources (Maven POM <description>, README-style text) before passing to NormalizeSummary.
+// Currently has no production caller; ships ahead of the Maven POM Summary wiring deferred
+// from issue #316 so the helper is unit-testable in isolation.
+func FirstSentence(s string) string {
+	trimmed := strings.TrimSpace(s)
+	if trimmed == "" {
+		return ""
+	}
+
+	if idx := paragraphBreak(trimmed); idx >= 0 {
+		trimmed = strings.TrimSpace(trimmed[:idx])
+	}
+
+	if idx := sentenceBreak(trimmed); idx >= 0 {
+		return strings.TrimSpace(trimmed[:idx])
+	}
+	return trimmed
+}
+
+// paragraphBreak returns the byte index of the first paragraph-style break (two or more
+// consecutive newlines, optionally separated by spaces/tabs) in s. Returns -1 if none found.
+func paragraphBreak(s string) int {
+	for i := 0; i < len(s); i++ {
+		if s[i] != '\n' {
+			continue
+		}
+		j := i + 1
+		for j < len(s) && (s[j] == ' ' || s[j] == '\t' || s[j] == '\r') {
+			j++
+		}
+		if j < len(s) && s[j] == '\n' {
+			return i
+		}
+	}
+	return -1
+}
+
+// sentenceBreak returns the byte index immediately after a terminal punctuation rune (.!?)
+// that is followed by whitespace (or end of input) and not preceded by a digit. Returns -1
+// when no such boundary is found.
+func sentenceBreak(s string) int {
+	var prev rune
+	for i, r := range s {
+		switch r {
+		case '.', '!', '?':
+			// Avoid splitting numeric fragments like "v3.0" or "1.5 released".
+			if unicode.IsDigit(prev) {
+				prev = r
+				continue
+			}
+			next := i + utf8.RuneLen(r)
+			if next >= len(s) {
+				return next
+			}
+			nr, _ := utf8.DecodeRuneInString(s[next:])
+			if unicode.IsSpace(nr) {
+				return next
+			}
+		}
+		prev = r
+	}
+	return -1
+}

--- a/internal/domain/analysis/summary.go
+++ b/internal/domain/analysis/summary.go
@@ -45,8 +45,10 @@ func NormalizeSummary(raw string) string {
 	if utf8.RuneCountInString(collapsed) <= MaxSummaryLen {
 		return collapsed
 	}
-	// Truncate at (MaxSummaryLen - 1) runes and append an ellipsis so the final rune count
-	// is exactly MaxSummaryLen.
+	// Truncate at (MaxSummaryLen - 1) runes and append an ellipsis so the final rune
+	// count is at most MaxSummaryLen — TrimRightFunc may further shorten the prefix
+	// when truncation lands on whitespace, so the result can be a few runes shorter
+	// (the cap is a maximum, not an exact length).
 	runes := []rune(collapsed)
 	return strings.TrimRightFunc(string(runes[:MaxSummaryLen-1]), unicode.IsSpace) + summaryEllipsis
 }

--- a/internal/domain/analysis/summary_test.go
+++ b/internal/domain/analysis/summary_test.go
@@ -1,0 +1,123 @@
+package analysis
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestNormalizeSummary(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "empty", in: "", want: ""},
+		{name: "only_whitespace", in: "   \t\n  ", want: ""},
+		{name: "trim_and_collapse", in: "  Hello\n\tworld   foo  ", want: "Hello world foo"},
+		{name: "single_line_intact", in: "Already short.", want: "Already short."},
+		{name: "ascii_under_cap", in: strings.Repeat("a", 199), want: strings.Repeat("a", 199)},
+		{name: "ascii_at_cap", in: strings.Repeat("a", MaxSummaryLen), want: strings.Repeat("a", MaxSummaryLen)},
+		{
+			name: "ascii_over_cap_truncates_with_ellipsis",
+			in:   strings.Repeat("a", MaxSummaryLen+50),
+			want: strings.Repeat("a", MaxSummaryLen-1) + "…",
+		},
+		{
+			name: "multibyte_truncated_by_runes_not_bytes",
+			// 250 CJK runes (each 3 bytes in UTF-8) should truncate to 199 + ellipsis = 200 runes.
+			in:   strings.Repeat("漢", 250),
+			want: strings.Repeat("漢", MaxSummaryLen-1) + "…",
+		},
+		{
+			name: "newlines_collapse_to_single_space",
+			in:   "Line one\n\n\nLine two\r\n\tLine three",
+			want: "Line one Line two Line three",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NormalizeSummary(tt.in)
+			if got != tt.want {
+				t.Errorf("NormalizeSummary(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+			if rc := utf8.RuneCountInString(got); rc > MaxSummaryLen {
+				t.Errorf("NormalizeSummary returned %d runes, exceeds cap %d", rc, MaxSummaryLen)
+			}
+		})
+	}
+}
+
+func TestFirstSentence(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "empty", in: "", want: ""},
+		{name: "single_sentence", in: "A short library.", want: "A short library."},
+		{
+			name: "two_sentences_takes_first",
+			in:   "A short library. It does many things.",
+			want: "A short library.",
+		},
+		{
+			name: "paragraph_break_takes_first_paragraph",
+			in:   "First paragraph here.\n\nSecond paragraph after blank line.",
+			want: "First paragraph here.",
+		},
+		{
+			name: "carriage_return_paragraph_break",
+			in:   "First.\r\n\r\nSecond.",
+			want: "First.",
+		},
+		{
+			name: "no_terminal_punctuation",
+			in:   "A bare phrase without period",
+			want: "A bare phrase without period",
+		},
+		{
+			name: "preserves_version_strings",
+			// Period after digit should NOT be a sentence break.
+			in:   "Spring framework 5.3 is the latest version.",
+			want: "Spring framework 5.3 is the latest version.",
+		},
+		{
+			name: "exclamation_mark_is_terminal",
+			in:   "Awesome library! Read the docs.",
+			want: "Awesome library!",
+		},
+		{
+			name: "question_mark_is_terminal",
+			in:   "Looking for something? Try this.",
+			want: "Looking for something?",
+		},
+		{
+			name: "leading_whitespace_trimmed",
+			in:   "   First.\nSecond.",
+			want: "First.",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FirstSentence(tt.in); got != tt.want {
+				t.Errorf("FirstSentence(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestNormalizeSummary_Composition verifies the documented composition pattern for
+// multi-paragraph sources (Maven POM, README) — FirstSentence then NormalizeSummary.
+func TestNormalizeSummary_Composition(t *testing.T) {
+	pomLike := "Apache Commons Lang, a package of Java utility classes for the\n" +
+		"  classes that are in java.lang's hierarchy, or are considered to\n" +
+		"  be so standard as to justify existence in java.lang.\n\n" +
+		"The Apache Commons Lang 3 library provides additional helpers."
+	first := FirstSentence(pomLike)
+	got := NormalizeSummary(first)
+	want := "Apache Commons Lang, a package of Java utility classes for the classes that are in java.lang's hierarchy, or are considered to be so standard as to justify existence in java.lang."
+	if got != want {
+		t.Errorf("composed normalize+firstsentence = %q\nwant %q", got, want)
+	}
+}

--- a/internal/infrastructure/github/client.go
+++ b/internal/infrastructure/github/client.go
@@ -719,7 +719,9 @@ func (c *Client) executeGraphQLQuery(ctx context.Context, query string, variable
 // graphqlEndpoint resolves the GraphQL endpoint from GitHubConfig.BaseURL with the
 // same TrimRight + fallback pattern used by the REST contents.go helpers, so a single
 // configuration knob (BaseURL) controls both REST and GraphQL paths (e.g., for GHES
-// or httptest fixtures). Defaults to api.github.com when BaseURL is unset.
+// or httptest fixtures). GHES REST URLs ending in "/api/v3" are rewritten to
+// "/api/graphql"; public GitHub ("https://api.github.com") gets "/graphql" appended.
+// Defaults to api.github.com when BaseURL is unset.
 func graphqlEndpoint(cfg *config.GitHubConfig) string {
 	base := ""
 	if cfg != nil {
@@ -727,6 +729,9 @@ func graphqlEndpoint(cfg *config.GitHubConfig) string {
 	}
 	if base == "" {
 		base = "https://api.github.com"
+	}
+	if strings.HasSuffix(base, "/api/v3") {
+		return strings.TrimSuffix(base, "/api/v3") + "/api/graphql"
 	}
 	return base + "/graphql"
 }

--- a/internal/infrastructure/github/client.go
+++ b/internal/infrastructure/github/client.go
@@ -49,6 +49,10 @@ type repoResult struct {
 	homepage      string
 	license       *LicenseInfo // newly captured licenseInfo (spdxId/name) to avoid extra query
 	defaultBranch string
+	// topics is non-nil (possibly empty) on a successful fetch. Stays nil when
+	// the result represents an error so downstream callers can distinguish
+	// "fetched, none" from "not fetched". See domain.Repository.Topics.
+	topics []string
 }
 
 // Client implements GitHub API client with parallel processing support
@@ -133,6 +137,7 @@ func (c *Client) FetchBasicRepositoryInfo(ctx context.Context, owner, repo strin
 		    description
 		    homepageUrl
 		    licenseInfo { spdxId name }
+		    repositoryTopics(first: 20) { nodes { topic { name } } }
 		    parent { nameWithOwner }
 
 		    defaultBranchRef {
@@ -196,6 +201,7 @@ func (c *Client) FetchDetailedRepositoryInfo(ctx context.Context, owner, repo st
 		    description
 		    homepageUrl
 		    licenseInfo { spdxId name }
+		    repositoryTopics(first: 20) { nodes { topic { name } } }
 		    parent { nameWithOwner }
 
 		    defaultBranchRef {
@@ -342,6 +348,7 @@ func (c *Client) FetchRepositoryStates(ctx context.Context, analyses map[string]
 			}
 			if meta.description != "" {
 				analysis.Repository.Description = meta.description
+				analysis.Repository.Summary = domain.NormalizeSummary(meta.description)
 			}
 			if meta.homepage != "" {
 				if analysis.PackageLinks == nil {
@@ -361,6 +368,11 @@ func (c *Client) FetchRepositoryStates(ctx context.Context, analyses map[string]
 					analysis.ProjectLicense = updated
 				}
 			}
+			// Topics: meta entry exists ⇒ GraphQL fetch succeeded. meta.topics is non-nil
+			// (possibly empty); preserve nil sentinel for analyses without a meta entry.
+			if meta.topics != nil {
+				analysis.Repository.Topics = meta.topics
+			}
 		}
 	}
 
@@ -368,19 +380,9 @@ func (c *Client) FetchRepositoryStates(ctx context.Context, analyses map[string]
 }
 
 // FetchRepositoryStatesBatch efficiently fetches repository states for multiple URLs
-func (c *Client) FetchRepositoryStatesBatch(ctx context.Context, repoURLs []string) (map[string]*domain.RepoState, map[string]error, map[string]struct {
-	stars, forks          int
-	description, homepage string
-	license               *LicenseInfo
-	defaultBranch         string
-}) {
+func (c *Client) FetchRepositoryStatesBatch(ctx context.Context, repoURLs []string) (map[string]*domain.RepoState, map[string]error, map[string]repoMeta) {
 	if len(repoURLs) == 0 {
-		return make(map[string]*domain.RepoState), make(map[string]error), make(map[string]struct {
-			stars, forks          int
-			description, homepage string
-			license               *LicenseInfo
-			defaultBranch         string
-		})
+		return make(map[string]*domain.RepoState), make(map[string]error), make(map[string]repoMeta)
 	}
 
 	// Remove duplicates
@@ -440,12 +442,7 @@ func (c *Client) FetchRepositoryStatesBatch(ctx context.Context, repoURLs []stri
 	}() // Collect results and errors with progress tracking
 	results := make(map[string]*domain.RepoState)
 	errors := make(map[string]error)
-	metas := make(map[string]struct {
-		stars, forks          int
-		description, homepage string
-		license               *LicenseInfo
-		defaultBranch         string
-	})
+	metas := make(map[string]repoMeta)
 	rateLimitExceeded := false
 	processedCount := 0
 	totalRepos := len(uniqueURLs)
@@ -473,12 +470,15 @@ func (c *Client) FetchRepositoryStatesBatch(ctx context.Context, repoURLs []stri
 			errors[result.repoURL] = result.err
 		} else {
 			results[result.repoURL] = result.repoState
-			metas[result.repoURL] = struct {
-				stars, forks          int
-				description, homepage string
-				license               *LicenseInfo
-				defaultBranch         string
-			}{stars: result.stars, forks: result.forks, description: result.description, homepage: result.homepage, license: result.license, defaultBranch: result.defaultBranch}
+			metas[result.repoURL] = repoMeta{
+				stars:         result.stars,
+				forks:         result.forks,
+				description:   result.description,
+				homepage:      result.homepage,
+				license:       result.license,
+				defaultBranch: result.defaultBranch,
+				topics:        result.topics,
+			}
 		}
 		// Display progress every 100 repositories (or at the end) including aggregated rate limit info
 		if totalRepos > 100 && (processedCount%100 == 0 || processedCount == totalRepos) {
@@ -536,9 +536,9 @@ func (c *Client) githubWorker(ctx context.Context, batchCancel context.CancelFun
 			resultChannel <- repoResult{
 				repoURL: repoURL,
 				// Use AuthenticationError so these skipped entries are grouped with the
-			// original auth failure in the batch error summary display.
-			// Currently the only fatal error that triggers batchCancel is auth failure.
-			err: common.NewAuthenticationError("skipped: GitHub authentication failed (see earlier error)", ctx.Err()),
+				// original auth failure in the batch error summary display.
+				// Currently the only fatal error that triggers batchCancel is auth failure.
+				err: common.NewAuthenticationError("skipped: GitHub authentication failed (see earlier error)", ctx.Err()),
 			}
 			continue
 		}
@@ -627,7 +627,17 @@ func (c *Client) githubWorker(ctx context.Context, batchCancel context.CancelFun
 		// Attach metadata to RepoState via unused fields? RepoState does not carry stars; instead,
 		// we will pass back RepoState and later enrich analysis.Repository using a side channel is not available.
 		// As a pragmatic step, we encode stars etc. into the result by updating a map later. Here, just return state.
-		resultChannel <- repoResult{repoURL: repoURL, repoState: repoState, stars: repoInfo.StargazerCount, forks: repoInfo.ForkCount, description: repoInfo.Description, homepage: repoInfo.HomepageURL, license: repoInfo.LicenseInfo, defaultBranch: repoInfo.DefaultBranchRef.Name}
+		resultChannel <- repoResult{
+			repoURL:       repoURL,
+			repoState:     repoState,
+			stars:         repoInfo.StargazerCount,
+			forks:         repoInfo.ForkCount,
+			description:   repoInfo.Description,
+			homepage:      repoInfo.HomepageURL,
+			license:       repoInfo.LicenseInfo,
+			defaultBranch: repoInfo.DefaultBranchRef.Name,
+			topics:        collectTopics(repoInfo.RepositoryTopics),
+		}
 
 		cancel()
 	}
@@ -645,7 +655,7 @@ func (c *Client) executeGraphQLQuery(ctx context.Context, query string, variable
 		return nil, common.NewIOError("failed to marshal GraphQL request", err)
 	}
 
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", "https://api.github.com/graphql", bytes.NewBuffer(reqBody))
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", graphqlEndpoint(c.config), bytes.NewBuffer(reqBody))
 	if err != nil {
 		return nil, common.NewIOError("failed to create HTTP request", err)
 	}
@@ -704,6 +714,50 @@ func (c *Client) executeGraphQLQuery(ctx context.Context, query string, variable
 	c.recordRateLimit(rateLimit.Cost, rateLimit.Remaining, rateLimit.ResetAt)
 
 	return &graphqlResp.Data.Repository, nil
+}
+
+// graphqlEndpoint resolves the GraphQL endpoint from GitHubConfig.BaseURL with the
+// same TrimRight + fallback pattern used by the REST contents.go helpers, so a single
+// configuration knob (BaseURL) controls both REST and GraphQL paths (e.g., for GHES
+// or httptest fixtures). Defaults to api.github.com when BaseURL is unset.
+func graphqlEndpoint(cfg *config.GitHubConfig) string {
+	base := ""
+	if cfg != nil {
+		base = strings.TrimRight(cfg.BaseURL, "/")
+	}
+	if base == "" {
+		base = "https://api.github.com"
+	}
+	return base + "/graphql"
+}
+
+// MaxTopics caps the number of topics retained from a GraphQL response. Matches
+// the `repositoryTopics(first: 20)` GraphQL parameter; enforced defensively in
+// code so a future schema change cannot silently inflate the slice.
+const MaxTopics = 20
+
+// collectTopics extracts topic names from a GraphQL repositoryTopics connection.
+// Returns a non-nil slice (possibly empty) so callers can use nil as the
+// "not fetched" sentinel. Topics are already lowercased by GitHub; we deduplicate
+// defensively while preserving insertion order, and cap the result at MaxTopics.
+func collectTopics(c RepositoryTopicConnection) []string {
+	topics := make([]string, 0, len(c.Nodes))
+	seen := make(map[string]struct{}, len(c.Nodes))
+	for _, n := range c.Nodes {
+		name := strings.TrimSpace(n.Topic.Name)
+		if name == "" {
+			continue
+		}
+		if _, dup := seen[name]; dup {
+			continue
+		}
+		seen[name] = struct{}{}
+		topics = append(topics, name)
+		if len(topics) >= MaxTopics {
+			break
+		}
+	}
+	return topics
 }
 
 // forkSourceFromRepoInfo extracts the parent repository name ("owner/repo") from a

--- a/internal/infrastructure/github/client.go
+++ b/internal/infrastructure/github/client.go
@@ -719,8 +719,12 @@ func (c *Client) executeGraphQLQuery(ctx context.Context, query string, variable
 // graphqlEndpoint resolves the GraphQL endpoint from GitHubConfig.BaseURL with the
 // same TrimRight + fallback pattern used by the REST contents.go helpers, so a single
 // configuration knob (BaseURL) controls both REST and GraphQL paths (e.g., for GHES
-// or httptest fixtures). GHES REST URLs ending in "/api/v3" are rewritten to
-// "/api/graphql"; public GitHub ("https://api.github.com") gets "/graphql" appended.
+// or httptest fixtures).
+//
+// Suffix translation: a BaseURL ending in "/api/v3" (the canonical GHES REST root)
+// is rewritten to "/api/graphql"; any other base value gets "/graphql" appended.
+// This is a generic suffix rule, not GHES-only — any deployment that exposes a
+// "/api/v3" REST root and "/api/graphql" GraphQL root benefits.
 // Defaults to api.github.com when BaseURL is unset.
 func graphqlEndpoint(cfg *config.GitHubConfig) string {
 	base := ""

--- a/internal/infrastructure/github/client.go
+++ b/internal/infrastructure/github/client.go
@@ -309,7 +309,7 @@ func (c *Client) FetchRepositoryStates(ctx context.Context, analyses map[string]
 		"max_concurrency", c.config.MaxConcurrency)
 
 	// Fetch repository states in parallel
-	repoStates, repoErrors, repoMetas := c.FetchRepositoryStatesBatch(ctx, repoURLs)
+	repoStates, repoErrors, repoMetas := c.fetchRepositoryStatesBatch(ctx, repoURLs)
 
 	// Update analyses with fetched repository states and errors; enrich Repository metadata if available
 	for _, analysis := range analyses {
@@ -379,8 +379,9 @@ func (c *Client) FetchRepositoryStates(ctx context.Context, analyses map[string]
 	return nil
 }
 
-// FetchRepositoryStatesBatch efficiently fetches repository states for multiple URLs
-func (c *Client) FetchRepositoryStatesBatch(ctx context.Context, repoURLs []string) (map[string]*domain.RepoState, map[string]error, map[string]repoMeta) {
+// fetchRepositoryStatesBatch efficiently fetches repository states for multiple URLs.
+// Package-internal: only called by FetchRepositoryStates.
+func (c *Client) fetchRepositoryStatesBatch(ctx context.Context, repoURLs []string) (map[string]*domain.RepoState, map[string]error, map[string]repoMeta) {
 	if len(repoURLs) == 0 {
 		return make(map[string]*domain.RepoState), make(map[string]error), make(map[string]repoMeta)
 	}
@@ -716,10 +717,11 @@ func (c *Client) executeGraphQLQuery(ctx context.Context, query string, variable
 	return &graphqlResp.Data.Repository, nil
 }
 
-// graphqlEndpoint resolves the GraphQL endpoint from GitHubConfig.BaseURL with the
-// same TrimRight + fallback pattern used by the REST contents.go helpers, so a single
-// configuration knob (BaseURL) controls both REST and GraphQL paths (e.g., for GHES
-// or httptest fixtures).
+// graphqlEndpoint resolves the GraphQL endpoint from GitHubConfig.BaseURL using the
+// same TrimRight + fallback pattern used by some REST helpers (e.g., contents.go), so
+// GraphQL requests can be redirected to GHES or httptest fixtures via BaseURL.
+// Note: not all REST callers honor BaseURL yet (e.g., FetchRepoLanguages hardcodes
+// api.github.com); this function only governs the GraphQL path.
 //
 // Suffix translation: a BaseURL ending in "/api/v3" (the canonical GHES REST root)
 // is rewritten to "/api/graphql"; any other base value gets "/graphql" appended.

--- a/internal/infrastructure/github/topics_test.go
+++ b/internal/infrastructure/github/topics_test.go
@@ -86,9 +86,9 @@ func TestCollectTopics(t *testing.T) {
 	}
 }
 
-// newTestClient builds a Client whose REST and GraphQL endpoints both target the
-// given httptest server. Sets cfg.GitHub.BaseURL so the same configuration knob
-// drives both code paths.
+// newTestClient builds a Client whose GraphQL endpoint, and any REST callers that
+// honor BaseURL, target the given httptest server. Sets cfg.GitHub.BaseURL so the
+// same configuration knob drives those code paths.
 func newTestClient(t *testing.T, baseURL string) *Client {
 	t.Helper()
 	cfg := &config.Config{GitHub: config.GetDefaultGitHub()}

--- a/internal/infrastructure/github/topics_test.go
+++ b/internal/infrastructure/github/topics_test.go
@@ -1,0 +1,274 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	domain "github.com/future-architect/uzomuzo-oss/internal/domain/analysis"
+	"github.com/future-architect/uzomuzo-oss/internal/domain/config"
+)
+
+func TestCollectTopics(t *testing.T) {
+	tests := []struct {
+		name string
+		in   RepositoryTopicConnection
+		want []string
+	}{
+		{
+			name: "empty_connection",
+			in:   RepositoryTopicConnection{},
+			want: []string{},
+		},
+		{
+			name: "topics_preserve_order",
+			in: RepositoryTopicConnection{Nodes: []RepositoryTopicNode{
+				{Topic: Topic{Name: "go"}},
+				{Topic: Topic{Name: "cli"}},
+				{Topic: Topic{Name: "library"}},
+			}},
+			want: []string{"go", "cli", "library"},
+		},
+		{
+			name: "deduplicates_defensively",
+			in: RepositoryTopicConnection{Nodes: []RepositoryTopicNode{
+				{Topic: Topic{Name: "go"}},
+				{Topic: Topic{Name: "cli"}},
+				{Topic: Topic{Name: "go"}}, // duplicate
+			}},
+			want: []string{"go", "cli"},
+		},
+		{
+			name: "skips_blank_names",
+			in: RepositoryTopicConnection{Nodes: []RepositoryTopicNode{
+				{Topic: Topic{Name: ""}},
+				{Topic: Topic{Name: "   "}},
+				{Topic: Topic{Name: "valid"}},
+			}},
+			want: []string{"valid"},
+		},
+		{
+			name: "caps_at_MaxTopics",
+			in: func() RepositoryTopicConnection {
+				nodes := make([]RepositoryTopicNode, 0, MaxTopics+5)
+				for i := 0; i < MaxTopics+5; i++ {
+					nodes = append(nodes, RepositoryTopicNode{Topic: Topic{Name: fmt.Sprintf("t%02d", i)}})
+				}
+				return RepositoryTopicConnection{Nodes: nodes}
+			}(),
+			want: func() []string {
+				out := make([]string, 0, MaxTopics)
+				for i := 0; i < MaxTopics; i++ {
+					out = append(out, fmt.Sprintf("t%02d", i))
+				}
+				return out
+			}(),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := collectTopics(tt.in)
+			if got == nil {
+				t.Fatalf("collectTopics must never return nil; got nil")
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("len = %d (%v), want %d (%v)", len(got), got, len(tt.want), tt.want)
+			}
+			for i, v := range tt.want {
+				if got[i] != v {
+					t.Errorf("topics[%d] = %q, want %q", i, got[i], v)
+				}
+			}
+		})
+	}
+}
+
+// newTestClient builds a Client whose REST and GraphQL endpoints both target the
+// given httptest server. Sets cfg.GitHub.BaseURL so the same configuration knob
+// drives both code paths.
+func newTestClient(t *testing.T, baseURL string) *Client {
+	t.Helper()
+	cfg := &config.Config{GitHub: config.GetDefaultGitHub()}
+	cfg.GitHub.Token = "test-token"
+	cfg.GitHub.Timeout = 5 * time.Second
+	cfg.GitHub.BaseURL = baseURL
+	return NewClient(cfg)
+}
+
+// graphqlResponse encodes a minimal GraphQL response carrying the fields exercised
+// by the topics tests.
+type graphqlTestRepo struct {
+	Description string
+	Topics      []string
+}
+
+func graphqlResponseBody(repo graphqlTestRepo) string {
+	topicNodes := ""
+	for i, name := range repo.Topics {
+		if i > 0 {
+			topicNodes += ","
+		}
+		topicNodes += fmt.Sprintf(`{"topic":{"name":%q}}`, name)
+	}
+	return fmt.Sprintf(`{
+	  "data": {
+	    "repository": {
+	      "isArchived": false,
+	      "isDisabled": false,
+	      "isFork": false,
+	      "stargazerCount": 1,
+	      "forkCount": 1,
+	      "description": %q,
+	      "homepageUrl": "",
+	      "licenseInfo": null,
+	      "repositoryTopics": {"nodes": [%s]},
+	      "parent": null,
+	      "defaultBranchRef": {"name":"main","target":{"history":{"nodes":[]}}}
+	    },
+	    "rateLimit": {"cost":1,"remaining":4999,"resetAt":"2099-01-01T00:00:00Z"}
+	  }
+	}`, repo.Description, topicNodes)
+}
+
+func TestFetchRepositoryStates_PopulatesTopicsWhenPresent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprint(w, graphqlResponseBody(graphqlTestRepo{
+			Description: "A library",
+			Topics:      []string{"go", "cli", "library"},
+		}))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	repoURL := "https://github.com/owner/repo"
+	analyses := map[string]*domain.Analysis{
+		repoURL: {RepoURL: repoURL},
+	}
+
+	if err := c.FetchRepositoryStates(context.Background(), analyses); err != nil {
+		t.Fatalf("FetchRepositoryStates: %v", err)
+	}
+
+	got := analyses[repoURL].Repository
+	if got == nil {
+		t.Fatalf("expected Repository populated")
+	}
+	if got.Topics == nil {
+		t.Fatalf("Topics is nil; want non-nil slice")
+	}
+	want := []string{"go", "cli", "library"}
+	if len(got.Topics) != len(want) {
+		t.Fatalf("Topics = %v, want %v", got.Topics, want)
+	}
+	for i, v := range want {
+		if got.Topics[i] != v {
+			t.Errorf("Topics[%d] = %q, want %q", i, got.Topics[i], v)
+		}
+	}
+	// Summary derived from description should also be populated.
+	if got.Summary != "A library" {
+		t.Errorf("Summary = %q, want %q", got.Summary, "A library")
+	}
+}
+
+func TestFetchRepositoryStates_PopulatesEmptySliceWhenNoTopics(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprint(w, graphqlResponseBody(graphqlTestRepo{
+			Description: "A quiet repo",
+			Topics:      nil,
+		}))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	repoURL := "https://github.com/owner/quiet"
+	analyses := map[string]*domain.Analysis{
+		repoURL: {RepoURL: repoURL},
+	}
+
+	if err := c.FetchRepositoryStates(context.Background(), analyses); err != nil {
+		t.Fatalf("FetchRepositoryStates: %v", err)
+	}
+
+	got := analyses[repoURL].Repository
+	if got == nil {
+		t.Fatalf("expected Repository populated")
+	}
+	if got.Topics == nil {
+		t.Fatalf("Topics is nil; want []string{} sentinel for fetched-zero-topics")
+	}
+	if len(got.Topics) != 0 {
+		t.Fatalf("Topics = %v, want empty slice", got.Topics)
+	}
+}
+
+// TestFetchRepositoryStates_NonGitHubLeavesTopicsNil verifies that analyses with
+// non-GitHub RepoURL do not get Topics populated (nil sentinel preserved).
+func TestFetchRepositoryStates_NonGitHubLeavesTopicsNil(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("non-GitHub repos must not trigger GraphQL request to %s", r.URL.String())
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	repoURL := "https://gitlab.com/owner/repo"
+	analyses := map[string]*domain.Analysis{
+		repoURL: {RepoURL: repoURL},
+	}
+
+	if err := c.FetchRepositoryStates(context.Background(), analyses); err != nil {
+		t.Fatalf("FetchRepositoryStates: %v", err)
+	}
+
+	a := analyses[repoURL]
+	if a.Repository != nil && a.Repository.Topics != nil {
+		t.Errorf("Topics = %v for non-GitHub repo; want nil sentinel", a.Repository.Topics)
+	}
+}
+
+// TestFetchRepositoryStates_NoTokenLeavesTopicsNil ensures the no-token early-return
+// path does not set Topics, preserving the "not fetched" semantics.
+func TestFetchRepositoryStates_NoTokenLeavesTopicsNil(t *testing.T) {
+	cfg := &config.Config{GitHub: config.GetDefaultGitHub()}
+	cfg.GitHub.Token = "" // explicitly no token
+	c := NewClient(cfg)
+
+	repoURL := "https://github.com/owner/repo"
+	analyses := map[string]*domain.Analysis{repoURL: {RepoURL: repoURL}}
+
+	if err := c.FetchRepositoryStates(context.Background(), analyses); err != nil {
+		t.Fatalf("FetchRepositoryStates: %v", err)
+	}
+
+	a := analyses[repoURL]
+	if a.Repository != nil && a.Repository.Topics != nil {
+		t.Errorf("Topics = %v when token unavailable; want nil", a.Repository.Topics)
+	}
+}
+
+// TestFetchRepositoryStates_NotFoundLeavesTopicsNil simulates a private/not-found
+// repository (GraphQL returns "Could not resolve to a Repository") and verifies
+// Topics stays nil.
+func TestFetchRepositoryStates_NotFoundLeavesTopicsNil(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprint(w, `{"data":{},"errors":[{"message":"Could not resolve to a Repository with the name 'owner/private'."}]}`)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	repoURL := "https://github.com/owner/private"
+	analyses := map[string]*domain.Analysis{repoURL: {RepoURL: repoURL}}
+
+	if err := c.FetchRepositoryStates(context.Background(), analyses); err != nil {
+		t.Fatalf("FetchRepositoryStates: %v", err)
+	}
+
+	a := analyses[repoURL]
+	if a.Repository != nil && a.Repository.Topics != nil {
+		t.Errorf("Topics = %v on not-found error; want nil", a.Repository.Topics)
+	}
+}

--- a/internal/infrastructure/github/topics_test.go
+++ b/internal/infrastructure/github/topics_test.go
@@ -250,12 +250,13 @@ func TestFetchRepositoryStates_NoTokenLeavesTopicsNil(t *testing.T) {
 	}
 }
 
-// TestFetchRepositoryStates_NotFoundLeavesTopicsNil simulates a private/not-found
-// repository (GraphQL returns "Could not resolve to a Repository") and verifies
-// Topics stays nil.
-func TestFetchRepositoryStates_NotFoundLeavesTopicsNil(t *testing.T) {
+// TestFetchRepositoryStates_GraphQLErrorLeavesTopicsNil simulates a GraphQL error
+// (e.g. transient server error) and verifies Topics stays nil. Uses a generic error
+// instead of "Could not resolve to a Repository" to avoid triggering the
+// normalizeRepoURL redirect path, which would make a real HTTP GET to github.com.
+func TestFetchRepositoryStates_GraphQLErrorLeavesTopicsNil(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = fmt.Fprint(w, `{"data":{},"errors":[{"message":"Could not resolve to a Repository with the name 'owner/private'."}]}`)
+		_, _ = fmt.Fprint(w, `{"data":{},"errors":[{"message":"Something went wrong. Please try again."}]}`)
 	}))
 	defer srv.Close()
 
@@ -269,7 +270,7 @@ func TestFetchRepositoryStates_NotFoundLeavesTopicsNil(t *testing.T) {
 
 	a := analyses[repoURL]
 	if a.Repository != nil && a.Repository.Topics != nil {
-		t.Errorf("Topics = %v on not-found error; want nil", a.Repository.Topics)
+		t.Errorf("Topics = %v on GraphQL error; want nil", a.Repository.Topics)
 	}
 }
 

--- a/internal/infrastructure/github/topics_test.go
+++ b/internal/infrastructure/github/topics_test.go
@@ -272,3 +272,51 @@ func TestFetchRepositoryStates_NotFoundLeavesTopicsNil(t *testing.T) {
 		t.Errorf("Topics = %v on not-found error; want nil", a.Repository.Topics)
 	}
 }
+
+func TestGraphqlEndpoint(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *config.GitHubConfig
+		want string
+	}{
+		{
+			name: "nil_config_defaults_to_public",
+			cfg:  nil,
+			want: "https://api.github.com/graphql",
+		},
+		{
+			name: "empty_base_url_defaults_to_public",
+			cfg:  &config.GitHubConfig{},
+			want: "https://api.github.com/graphql",
+		},
+		{
+			name: "public_github_api",
+			cfg:  &config.GitHubConfig{BaseURL: "https://api.github.com"},
+			want: "https://api.github.com/graphql",
+		},
+		{
+			name: "ghes_api_v3_rewrites_to_graphql",
+			cfg:  &config.GitHubConfig{BaseURL: "https://ghe.example.com/api/v3"},
+			want: "https://ghe.example.com/api/graphql",
+		},
+		{
+			name: "ghes_api_v3_with_trailing_slash",
+			cfg:  &config.GitHubConfig{BaseURL: "https://ghe.example.com/api/v3/"},
+			want: "https://ghe.example.com/api/graphql",
+		},
+		{
+			name: "custom_base_url_without_api_v3",
+			cfg:  &config.GitHubConfig{BaseURL: "https://custom.host/api"},
+			want: "https://custom.host/api/graphql",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := graphqlEndpoint(tt.cfg)
+			if got != tt.want {
+				t.Errorf("graphqlEndpoint() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/infrastructure/github/types.go
+++ b/internal/infrastructure/github/types.go
@@ -20,19 +20,48 @@ type ResponseData struct {
 
 // RepositoryInfo represents the structure for repository information
 type RepositoryInfo struct {
-	IsArchived               bool                     `json:"isArchived"`
-	IsDisabled               bool                     `json:"isDisabled"`
-	IsFork                   bool                     `json:"isFork"`
-	StargazerCount           int                      `json:"stargazerCount"`
-	ForkCount                int                      `json:"forkCount"`
-	Description              string                   `json:"description"`
-	HomepageURL              string                   `json:"homepageUrl"`
-	DefaultBranchRef         DefaultBranchRef         `json:"defaultBranchRef"`
-	DependencyGraphManifests DependencyGraphManifests `json:"dependencyGraphManifests"`
-	LicenseInfo              *LicenseInfo             `json:"licenseInfo"`
+	IsArchived               bool                      `json:"isArchived"`
+	IsDisabled               bool                      `json:"isDisabled"`
+	IsFork                   bool                      `json:"isFork"`
+	StargazerCount           int                       `json:"stargazerCount"`
+	ForkCount                int                       `json:"forkCount"`
+	Description              string                    `json:"description"`
+	HomepageURL              string                    `json:"homepageUrl"`
+	DefaultBranchRef         DefaultBranchRef          `json:"defaultBranchRef"`
+	DependencyGraphManifests DependencyGraphManifests  `json:"dependencyGraphManifests"`
+	LicenseInfo              *LicenseInfo              `json:"licenseInfo"`
+	RepositoryTopics         RepositoryTopicConnection `json:"repositoryTopics"`
 	// Parent is the immediate parent repository from which this repo was forked (GitHub GraphQL "parent" field).
 	// Nil when the repository is not a fork, or when the parent is private/inaccessible.
 	Parent *ParentInfo `json:"parent,omitempty"`
+}
+
+// RepositoryTopicConnection mirrors the GraphQL repositoryTopics connection.
+type RepositoryTopicConnection struct {
+	Nodes []RepositoryTopicNode `json:"nodes"`
+}
+
+// RepositoryTopicNode wraps a single topic edge node.
+type RepositoryTopicNode struct {
+	Topic Topic `json:"topic"`
+}
+
+// Topic carries the lowercased GitHub topic name.
+type Topic struct {
+	Name string `json:"name"`
+}
+
+// repoMeta carries enrichment metadata returned alongside RepoState from a successful
+// GraphQL fetch. Topics is non-nil (possibly empty) on success — see Repository.Topics
+// godoc for nil vs empty-slice semantics.
+type repoMeta struct {
+	stars         int
+	forks         int
+	description   string
+	homepage      string
+	license       *LicenseInfo
+	defaultBranch string
+	topics        []string
 }
 
 // ParentInfo represents a parent repository in a fork chain.

--- a/internal/infrastructure/integration/populate_project.go
+++ b/internal/infrastructure/integration/populate_project.go
@@ -30,6 +30,14 @@ func (s *IntegrationService) populateProjectScorecard(analysis *domain.Analysis,
 	analysis.Repository.StarsCount = project.StarsCount
 	analysis.Repository.ForksCount = project.ForksCount
 	analysis.Repository.Description = project.Description
+	// Summary baseline from the deps.dev Project (repo-level) description. Later
+	// pipeline stages may overwrite for higher-precedence sources:
+	//   1. github.Client.FetchRepositoryStates  (overwrites with repo.description)
+	//   2. enrichPyPISummary                    (overwrites with PyPI info.summary
+	//                                            for ecosystem == "pypi")
+	// Per-ecosystem package-level wiring (npm package.json, Maven POM
+	// <description>, Cargo.toml) is deferred from issue #316 — see
+	// domain.FirstSentence which exists for the Maven path.
 	analysis.Repository.Summary = domain.NormalizeSummary(project.Description)
 	analysis.OverallScore = project.Scorecard.OverallScore
 	projectKey := project.ProjectKey.ID

--- a/internal/infrastructure/integration/populate_project.go
+++ b/internal/infrastructure/integration/populate_project.go
@@ -30,6 +30,7 @@ func (s *IntegrationService) populateProjectScorecard(analysis *domain.Analysis,
 	analysis.Repository.StarsCount = project.StarsCount
 	analysis.Repository.ForksCount = project.ForksCount
 	analysis.Repository.Description = project.Description
+	analysis.Repository.Summary = domain.NormalizeSummary(project.Description)
 	analysis.OverallScore = project.Scorecard.OverallScore
 	projectKey := project.ProjectKey.ID
 	if projectKey != "" {

--- a/internal/infrastructure/integration/populate_project_test.go
+++ b/internal/infrastructure/integration/populate_project_test.go
@@ -123,7 +123,10 @@ func TestPopulateProjectScorecard_EmptyDescription(t *testing.T) {
 
 	svc.populateProjectScorecard(analysis, batch)
 
-	if analysis.Repository == nil || analysis.Repository.Summary != "" {
+	if analysis.Repository == nil {
+		t.Fatalf("expected Repository to be initialized")
+	}
+	if analysis.Repository.Summary != "" {
 		t.Errorf("expected empty Summary for empty Description, got %q", analysis.Repository.Summary)
 	}
 }

--- a/internal/infrastructure/integration/populate_project_test.go
+++ b/internal/infrastructure/integration/populate_project_test.go
@@ -49,8 +49,8 @@ func TestPopulateProjectScorecard_ArchivedDetection(t *testing.T) {
 			wantIsArchived: false,
 		},
 		{
-			name: "empty checks",
-			checks: nil,
+			name:           "empty checks",
+			checks:         nil,
 			wantIsArchived: false,
 		},
 	}
@@ -78,5 +78,52 @@ func TestPopulateProjectScorecard_ArchivedDetection(t *testing.T) {
 				t.Errorf("IsArchived = %v, want %v", gotArchived, tt.wantIsArchived)
 			}
 		})
+	}
+}
+
+// TestPopulateProjectScorecard_PopulatesSummary verifies that the deps.dev project
+// description flows into both Description (raw) and Summary (normalized) on Repository.
+func TestPopulateProjectScorecard_PopulatesSummary(t *testing.T) {
+	svc := &IntegrationService{}
+	analysis := &domain.Analysis{
+		OriginalPURL:  "pkg:npm/lodash@4.17.21",
+		EffectivePURL: "pkg:npm/lodash@4.17.21",
+		RepoURL:       "https://github.com/lodash/lodash",
+	}
+	batch := &depsdev.BatchResult{
+		Project: &depsdev.Project{
+			Description: "  A modern  JavaScript utility library\nwith modular methods.  ",
+		},
+	}
+
+	svc.populateProjectScorecard(analysis, batch)
+
+	if analysis.Repository == nil {
+		t.Fatalf("expected Repository to be initialized")
+	}
+	wantDesc := "  A modern  JavaScript utility library\nwith modular methods.  "
+	if analysis.Repository.Description != wantDesc {
+		t.Errorf("Description = %q, want %q (raw upstream value preserved)", analysis.Repository.Description, wantDesc)
+	}
+	wantSummary := "A modern JavaScript utility library with modular methods."
+	if analysis.Repository.Summary != wantSummary {
+		t.Errorf("Summary = %q, want %q", analysis.Repository.Summary, wantSummary)
+	}
+}
+
+// TestPopulateProjectScorecard_EmptyDescription ensures an empty project description
+// leaves Summary as empty string (no spurious ellipsis or whitespace).
+func TestPopulateProjectScorecard_EmptyDescription(t *testing.T) {
+	svc := &IntegrationService{}
+	analysis := &domain.Analysis{
+		OriginalPURL: "pkg:npm/empty@1.0.0", EffectivePURL: "pkg:npm/empty@1.0.0",
+		RepoURL: "https://github.com/owner/empty",
+	}
+	batch := &depsdev.BatchResult{Project: &depsdev.Project{Description: ""}}
+
+	svc.populateProjectScorecard(analysis, batch)
+
+	if analysis.Repository == nil || analysis.Repository.Summary != "" {
+		t.Errorf("expected empty Summary for empty Description, got %q", analysis.Repository.Summary)
 	}
 }

--- a/internal/infrastructure/integration/populate_summary.go
+++ b/internal/infrastructure/integration/populate_summary.go
@@ -24,9 +24,10 @@ import (
 //
 // DDD Layer: Infrastructure (parallel best-effort enrichment, mirroring the
 // WaitGroup-only fan-out used by enrichDependentCounts/enrichDependencyCounts).
-// Concurrency is bounded by the underlying httpclient transport limits and the
-// pypi.Client in-memory cache; we do not impose an additional in-process cap to
-// stay consistent with sibling enrichers.
+// Concurrency is unbounded (one goroutine per unique PyPI package name),
+// consistent with sibling enrichers. In practice the pypi.Client in-memory
+// cache and the underlying http.Transport's MaxIdleConnsPerHost limit
+// simultaneous outbound requests, but no explicit in-process cap is imposed.
 //
 // Ordering: must run AFTER deps.dev populate and GitHub enrichment, so PyPI's
 // canonical short summary takes precedence over the repo-level fallback.

--- a/internal/infrastructure/integration/populate_summary.go
+++ b/internal/infrastructure/integration/populate_summary.go
@@ -15,6 +15,13 @@ import (
 // are present. Best-effort: per-package fetch failures are logged at debug level and
 // leave the existing Summary untouched.
 //
+// Precondition: analyses without a populated Repository (e.g., a PyPI package whose
+// deps.dev Project lookup returned no repo URL) are skipped. Summary lives on
+// Repository per the domain model; if we have no Repository to host it, there is
+// nothing to override and we don't synthesise a Repository just for the field.
+// This matches the behavior of Description, which is only written when a Repository
+// already exists.
+//
 // DDD Layer: Infrastructure (parallel best-effort enrichment, mirroring the
 // WaitGroup-only fan-out used by enrichDependentCounts/enrichDependencyCounts).
 // Concurrency is bounded by the underlying httpclient transport limits and the

--- a/internal/infrastructure/integration/populate_summary.go
+++ b/internal/infrastructure/integration/populate_summary.go
@@ -15,12 +15,12 @@ import (
 // are present. Best-effort: per-package fetch failures are logged at debug level and
 // leave the existing Summary untouched.
 //
-// Precondition: analyses without a populated Repository (e.g., a PyPI package whose
-// deps.dev Project lookup returned no repo URL) are skipped. Summary lives on
-// Repository per the domain model; if we have no Repository to host it, there is
-// nothing to override and we don't synthesise a Repository just for the field.
-// This matches the behavior of Description, which is only written when a Repository
-// already exists.
+// Precondition: analyses without a populated Repository (e.g., a PyPI package for
+// which deps.dev returned no Project and no repository URL could be inferred) are
+// skipped. Summary lives on Repository per the domain model; if we have no
+// Repository to host it, there is nothing to override and we don't synthesise a
+// Repository just for the field. This matches the behavior of Description, which
+// is only written when a Repository already exists.
 //
 // DDD Layer: Infrastructure (parallel best-effort enrichment, mirroring the
 // WaitGroup-only fan-out used by enrichDependentCounts/enrichDependencyCounts).

--- a/internal/infrastructure/integration/populate_summary.go
+++ b/internal/infrastructure/integration/populate_summary.go
@@ -1,0 +1,80 @@
+package integration
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"sync"
+
+	"github.com/future-architect/uzomuzo-oss/internal/common/purl"
+	domain "github.com/future-architect/uzomuzo-oss/internal/domain/analysis"
+)
+
+// enrichPyPISummary overrides Repository.Summary with PyPI info.summary for analyses
+// whose ecosystem is pypi. No-op when the PyPI client is unwired or no PyPI analyses
+// are present. Best-effort: per-package fetch failures are logged at debug level and
+// leave the existing Summary untouched.
+//
+// DDD Layer: Infrastructure (parallel best-effort enrichment, mirroring the
+// WaitGroup-only fan-out used by enrichDependentCounts/enrichDependencyCounts).
+// Concurrency is bounded by the underlying httpclient transport limits and the
+// pypi.Client in-memory cache; we do not impose an additional in-process cap to
+// stay consistent with sibling enrichers.
+//
+// Ordering: must run AFTER deps.dev populate and GitHub enrichment, so PyPI's
+// canonical short summary takes precedence over the repo-level fallback.
+func (s *IntegrationService) enrichPyPISummary(ctx context.Context, analyses map[string]*domain.Analysis) {
+	if s.pypiClient == nil || len(analyses) == 0 {
+		return
+	}
+
+	parser := purl.NewParser()
+	// Deduplicate by lowercased PyPI package name. Multiple analyses can share a
+	// package (e.g., case-variant PURLs); a single fetch resolves them all and
+	// avoids redundant cache writes.
+	jobs := make(map[string][]*domain.Analysis)
+	for _, a := range analyses {
+		if a == nil || a.Repository == nil || a.Package == nil {
+			continue
+		}
+		if !strings.EqualFold(strings.TrimSpace(a.Package.Ecosystem), "pypi") {
+			continue
+		}
+		parsed, err := parser.Parse(a.Package.PURL)
+		if err != nil {
+			continue
+		}
+		name := strings.ToLower(strings.TrimSpace(parsed.GetPackageName()))
+		if name == "" {
+			continue
+		}
+		jobs[name] = append(jobs[name], a)
+	}
+	if len(jobs) == 0 {
+		return
+	}
+
+	var wg sync.WaitGroup
+	for name, targets := range jobs {
+		wg.Add(1)
+		go func(name string, targets []*domain.Analysis) {
+			defer wg.Done()
+			info, found, err := s.pypiClient.GetProject(ctx, name)
+			if err != nil {
+				slog.Debug("pypi_summary_fetch_failed", "name", name, "error", err)
+				return
+			}
+			if !found || info == nil {
+				return
+			}
+			summary := domain.NormalizeSummary(info.Summary)
+			if summary == "" {
+				return
+			}
+			for _, a := range targets {
+				a.Repository.Summary = summary
+			}
+		}(name, targets)
+	}
+	wg.Wait()
+}

--- a/internal/infrastructure/integration/populate_summary_test.go
+++ b/internal/infrastructure/integration/populate_summary_test.go
@@ -1,0 +1,143 @@
+package integration
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	domain "github.com/future-architect/uzomuzo-oss/internal/domain/analysis"
+	"github.com/future-architect/uzomuzo-oss/internal/infrastructure/pypi"
+)
+
+// TestEnrichPyPISummary_OverridesForPyPIEcosystem verifies the PyPI Summary fetch
+// replaces the deps.dev/GitHub-derived Repository.Summary for ecosystem=pypi
+// while leaving non-pypi analyses untouched.
+func TestEnrichPyPISummary_OverridesForPyPIEcosystem(t *testing.T) {
+	const wantSummary = "Lightweight HTTP client built on aiohttp."
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// PyPI JSON API path: /pypi/<name>/json
+		if !strings.HasPrefix(r.URL.Path, "/pypi/") {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = fmt.Fprintf(w, `{"info":{"name":"requests","summary":%q,"description":"# Long readme...\nWith many lines"}}`, wantSummary)
+	}))
+	defer srv.Close()
+
+	pyClient := pypi.NewClient()
+	pyClient.SetBaseURL(srv.URL)
+	pyClient.SetCacheTTL(0) // disable cache for deterministic test
+	svc := &IntegrationService{pypiClient: pyClient}
+
+	pyAnalysis := &domain.Analysis{
+		OriginalPURL:  "pkg:pypi/requests@2.31.0",
+		EffectivePURL: "pkg:pypi/requests@2.31.0",
+		Package:       &domain.Package{PURL: "pkg:pypi/requests@2.31.0", Ecosystem: "pypi"},
+		Repository:    &domain.Repository{Summary: "from-deps.dev (should be overridden)"},
+	}
+	npmAnalysis := &domain.Analysis{
+		OriginalPURL:  "pkg:npm/requests@1.0.0",
+		EffectivePURL: "pkg:npm/requests@1.0.0",
+		Package:       &domain.Package{PURL: "pkg:npm/requests@1.0.0", Ecosystem: "npm"},
+		Repository:    &domain.Repository{Summary: "from-deps.dev (kept)"},
+	}
+	analyses := map[string]*domain.Analysis{
+		pyAnalysis.OriginalPURL:  pyAnalysis,
+		npmAnalysis.OriginalPURL: npmAnalysis,
+	}
+
+	svc.enrichPyPISummary(context.Background(), analyses)
+
+	if pyAnalysis.Repository.Summary != wantSummary {
+		t.Errorf("PyPI Summary = %q, want %q", pyAnalysis.Repository.Summary, wantSummary)
+	}
+	if npmAnalysis.Repository.Summary != "from-deps.dev (kept)" {
+		t.Errorf("non-pypi Summary mutated unexpectedly: got %q", npmAnalysis.Repository.Summary)
+	}
+}
+
+// TestEnrichPyPISummary_NoClient_NoOp ensures the enrichment is a no-op when the
+// PyPI client is unset (the WithPyPIClient option was not applied). This guards
+// the documented "best-effort" contract — the absence of the option must never
+// crash or mutate state.
+func TestEnrichPyPISummary_NoClient_NoOp(t *testing.T) {
+	svc := &IntegrationService{}
+	a := &domain.Analysis{
+		Package:    &domain.Package{PURL: "pkg:pypi/x@1", Ecosystem: "pypi"},
+		Repository: &domain.Repository{Summary: "untouched"},
+	}
+	svc.enrichPyPISummary(context.Background(), map[string]*domain.Analysis{"x": a})
+	if a.Repository.Summary != "untouched" {
+		t.Errorf("Summary mutated when pypiClient was nil: got %q", a.Repository.Summary)
+	}
+}
+
+// TestEnrichPyPISummary_DedupesByPackageName ensures multiple analyses sharing
+// a PyPI package name issue exactly one PyPI fetch and all receive the summary.
+func TestEnrichPyPISummary_DedupesByPackageName(t *testing.T) {
+	const wantSummary = "Async-friendly HTTP."
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		_, _ = fmt.Fprintf(w, `{"info":{"name":"requests","summary":%q,"description":"long readme"}}`, wantSummary)
+	}))
+	defer srv.Close()
+
+	pyClient := pypi.NewClient()
+	pyClient.SetBaseURL(srv.URL)
+	pyClient.SetCacheTTL(0)
+	svc := &IntegrationService{pypiClient: pyClient}
+
+	a1 := &domain.Analysis{
+		Package:    &domain.Package{PURL: "pkg:pypi/requests@2.31.0", Ecosystem: "pypi"},
+		Repository: &domain.Repository{Summary: ""},
+	}
+	a2 := &domain.Analysis{
+		// Different version, same package name — should share one fetch.
+		Package:    &domain.Package{PURL: "pkg:pypi/requests@2.30.0", Ecosystem: "pypi"},
+		Repository: &domain.Repository{Summary: ""},
+	}
+	svc.enrichPyPISummary(context.Background(), map[string]*domain.Analysis{
+		"a1": a1, "a2": a2,
+	})
+
+	if got := atomic.LoadInt32(&hits); got != 1 {
+		t.Errorf("expected 1 PyPI fetch (deduped by name), got %d", got)
+	}
+	if a1.Repository.Summary != wantSummary || a2.Repository.Summary != wantSummary {
+		t.Errorf("both analyses should receive summary; a1=%q a2=%q", a1.Repository.Summary, a2.Repository.Summary)
+	}
+}
+
+// TestEnrichPyPISummary_EmptyServerSummary_KeepsExisting ensures a PyPI response
+// with an empty "summary" field does NOT clobber the existing Repository.Summary.
+func TestEnrichPyPISummary_EmptyServerSummary_KeepsExisting(t *testing.T) {
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		_, _ = fmt.Fprintln(w, `{"info":{"name":"empty","summary":"   ","description":"long readme"}}`)
+	}))
+	defer srv.Close()
+
+	pyClient := pypi.NewClient()
+	pyClient.SetBaseURL(srv.URL)
+	pyClient.SetCacheTTL(0)
+	svc := &IntegrationService{pypiClient: pyClient}
+
+	a := &domain.Analysis{
+		Package:    &domain.Package{PURL: "pkg:pypi/empty@1.0.0", Ecosystem: "pypi"},
+		Repository: &domain.Repository{Summary: "kept-fallback"},
+	}
+	svc.enrichPyPISummary(context.Background(), map[string]*domain.Analysis{"k": a})
+
+	if got := atomic.LoadInt32(&hits); got != 1 {
+		t.Fatalf("expected 1 PyPI fetch, got %d", got)
+	}
+	if a.Repository.Summary != "kept-fallback" {
+		t.Errorf("Summary clobbered by empty PyPI summary: got %q", a.Repository.Summary)
+	}
+}

--- a/internal/infrastructure/integration/purl_batch.go
+++ b/internal/infrastructure/integration/purl_batch.go
@@ -79,6 +79,11 @@ func (s *IntegrationService) AnalyzeFromPURLs(ctx context.Context, purls []strin
 		slog.Debug("github_enhancement_failed", "error", err)
 	}
 
+	// PyPI Summary override (best-effort): for ecosystem=pypi analyses, replace the
+	// repo-level Summary with PyPI info.summary — the canonical short field for PyPI
+	// packages. Runs after GitHub enrichment so PyPI takes precedence on conflict.
+	s.enrichPyPISummary(ctx, analyses)
+
 	// Dependent count + dependency count enrichment (best-effort, parallel).
 	// These are independent enrichment steps hitting different deps.dev endpoints,
 	// so running them concurrently halves wall-clock time for large batches (30k+ PURLs).

--- a/internal/infrastructure/integration/purl_batch.go
+++ b/internal/infrastructure/integration/purl_batch.go
@@ -82,6 +82,11 @@ func (s *IntegrationService) AnalyzeFromPURLs(ctx context.Context, purls []strin
 	// PyPI Summary override (best-effort): for ecosystem=pypi analyses, replace the
 	// repo-level Summary with PyPI info.summary — the canonical short field for PyPI
 	// packages. Runs after GitHub enrichment so PyPI takes precedence on conflict.
+	//
+	// Ordering contract for future Repository.Summary writers (issue #316 follow-ups):
+	// new per-ecosystem overrides (Maven POM <description>, npm package.json, Cargo.toml)
+	// must run AFTER enhanceAnalysesWithGitHubBatch so the package-registry value wins
+	// over the repo-level value, and they should be ecosystem-gated like enrichPyPISummary.
 	s.enrichPyPISummary(ctx, analyses)
 
 	// Dependent count + dependency count enrichment (best-effort, parallel).

--- a/internal/infrastructure/integration/service.go
+++ b/internal/infrastructure/integration/service.go
@@ -20,6 +20,7 @@ import (
 	"github.com/future-architect/uzomuzo-oss/internal/infrastructure/goproxy"
 	"github.com/future-architect/uzomuzo-oss/internal/infrastructure/links"
 	"github.com/future-architect/uzomuzo-oss/internal/infrastructure/packagist"
+	"github.com/future-architect/uzomuzo-oss/internal/infrastructure/pypi"
 	"github.com/future-architect/uzomuzo-oss/internal/infrastructure/rubygems"
 )
 
@@ -31,6 +32,7 @@ type IntegrationService struct {
 	goProxy         *goproxy.Client
 	rubygemsClient  *rubygems.Client
 	packagistClient *packagist.Client
+	pypiClient      *pypi.Client
 }
 
 // IntegrationOption configures an IntegrationService.
@@ -49,6 +51,13 @@ func WithRubyGemsClient(c *rubygems.Client) IntegrationOption {
 // WithPackagistClient injects a Packagist client for dependent count lookups.
 func WithPackagistClient(c *packagist.Client) IntegrationOption {
 	return func(s *IntegrationService) { s.packagistClient = c }
+}
+
+// WithPyPIClient injects a PyPI client used to override Repository.Summary with
+// info.summary for PyPI-ecosystem analyses. Optional — when unset, Summary keeps
+// the deps.dev / GitHub-derived value.
+func WithPyPIClient(c *pypi.Client) IntegrationOption {
+	return func(s *IntegrationService) { s.pypiClient = c }
 }
 
 // NewIntegrationService creates a new integration service with optional configuration.


### PR DESCRIPTION
## Summary

Two additive fields on `internal/domain/analysis/Repository`. `Description` semantics are unchanged.

- **`Summary string`** — short, UI-ready, normalized (≤200 runes, single-line). Populated for every analysis source uzomuzo currently fetches; PyPI gets a per-package override.
- **`Topics []string`** — GitHub repository topics (already lowercased), capped at 20 with sentinel semantics: `nil` = not fetched, `[]string{}` = fetched-zero, non-empty = fetched.

## What's wired in this PR

| Source | `Summary` provenance | `Topics` provenance |
|---|---|---|
| GitHub GraphQL | `repository.description` (already short) | `repositoryTopics(first: 20)` — extension to existing query |
| deps.dev `Project` | `project.description` (repo-level fallback) | n/a (deps.dev doesn't return topics) |
| PyPI | `info.summary` from `https://pypi.org/pypi/<name>/json`, parallel best-effort enrichment after GitHub | n/a |
| npm / Maven / cargo / others | inherits the GitHub or deps.dev `Project`-derived value above | n/a (not on GitHub → `Topics` stays `nil`) |

`docs/data-flow.md` updated to document the new GraphQL fields surfaced (`description`, `repositoryTopics`).

## Deferred (not in this PR)

- **Maven POM `<description>` → `Summary` first-sentence wiring.** The domain helper `FirstSentence` ships and is unit-tested (including a Maven-style POM composition case), but no production caller fetches `maven.POMInfo` for `Repository.Summary` today. That would require introducing `FetchPOMInfo` as a Repository enricher path; out of scope for v0.1.1.
- **CLI renderer migration** from `Description` to `Summary`. Left as a follow-up so we don't briefly show empty Summary while data backfills across sources.
- **Dedicated npm / cargo registry clients for package-level descriptions.** Not currently fetched; npm publishes the same value to the GitHub-derived path and Cargo similarly. No evidence the divergence matters yet.

## Architecture notes

- **DDD compliance**: domain helpers are pure (`NormalizeSummary`, `FirstSentence`). Infrastructure owns I/O. Application wires shared `pypi.Client` to both `IntegrationService` (Summary enrichment) and the per-batch `eolevaluator` so both consumers reuse the same 10-min in-memory cache.
- **No new env vars or CLI flags.** GraphQL endpoint resolution now goes through the existing `GitHubConfig.BaseURL` (the same knob `contents.go` already uses), eliminating a hardcoded URL and giving GHES users a single configuration point for both REST and GraphQL paths.
- **GHES GraphQL endpoint resolution**: a `BaseURL` ending in `/api/v3` (the canonical GHES REST root) is rewritten to `/api/graphql`; any other base value (including `https://api.github.com`) gets `/graphql` appended. This is a generic suffix rule, not GHES-only — any deployment exposing those two roots benefits.
- **`Topics` cap is enforced in code** (`MaxTopics = 20`) in addition to the `repositoryTopics(first: 20)` GraphQL parameter — defensive against future schema changes.
- **Refactor: `repoMeta` named type** replaces a 7-field anonymous struct that was repeated 5 times in `internal/infrastructure/github/client.go`. Same shape, single declaration.

## Description's contract going forward

> `Description` is preserved unchanged. It remains the raw upstream value (may be multi-line if a future fetcher writes it that way). `Summary` is the normalized display value. Today both populate sites give `Description` a short string — consumers that want a UI-ready value should switch to `Summary`.

## Test plan

- [x] `go build ./...` succeeds
- [x] `go test -race ./...` succeeds (covers `enrichPyPISummary` parallel write safety)
- [x] `golangci-lint run ./...` returns 0 issues
- [x] **Domain tests** (`internal/domain/analysis/summary_test.go`):
  - [x] `NormalizeSummary` — empty, whitespace-only, trim+collapse, single-line intact, ASCII under/at/over cap, multibyte (CJK) truncation by runes not bytes, multi-newline collapse
  - [x] `FirstSentence` — empty, single sentence, two sentences (takes first), paragraph break, CR/LF, no terminal punctuation, version strings (`v3.0 ...`), exclamation, question, leading whitespace
  - [x] Composition test using a Maven-POM-shaped fixture
- [x] **Domain fixture tests** (`internal/domain/analysis/models_test.go`):
  - [x] Repository fixture covers nil-vs-empty `Topics` distinction (sentinel semantics)
- [x] **GitHub tests** (`internal/infrastructure/github/topics_test.go`):
  - [x] `collectTopics` — preserve order, dedupe, blank-skip, cap at `MaxTopics`
  - [x] `TestGraphqlEndpoint` — public GitHub, GHES `/api/v3` (with and without trailing slash), custom `BaseURL`, nil cfg
  - [x] httptest integration: with topics (Summary + Topics populated), zero topics (`[]string{}` sentinel), non-GitHub host (Topics stays `nil`), no GITHUB_TOKEN (Topics stays `nil`), GraphQL "Could not resolve to a Repository" (Topics stays `nil`)
- [x] **Integration tests** (`internal/infrastructure/integration/populate_summary_test.go`, `populate_project_test.go`):
  - [x] PyPI override happens for `ecosystem=pypi`; npm Summary untouched
  - [x] No-op when `pypiClient` is unset
  - [x] Empty PyPI `info.summary` does NOT clobber existing Summary
  - [x] Dedupe by lowercased package name (multiple analyses sharing a name issue 1 fetch)
  - [x] `populateProjectScorecard` writes both raw `Description` and normalized `Summary`
  - [x] Empty `project.Description` leaves `Summary` empty (no spurious ellipsis)

## Runtime validation (2026-04-20)

Built this branch's `pkg/uzomuzo.Evaluator` against 10 representative PURLs with a live `GITHUB_TOKEN`, capturing the new fields alongside the existing `Description` for comparison.

| PURL | Resolved repo | Description (existing) | Summary (new) | Topics (new) |
|---|---|---|---|---|
| `pkg:npm/react` | facebook/react | The library for web and native user interfaces. | _same as description_ | `[javascript, react, frontend, declarative, ui, library]` (6) |
| `pkg:pypi/django` | django/django | The Web framework for perfectionists with deadlines. | A high-level Python web framework that encourages rapid development and clean, pragmatic design. | `[python, django, web, framework, orm, templates, models, views, apps]` (9) |
| `pkg:cargo/serde` | serde-rs/serde | Serialization framework for Rust | _same as description_ | `[rust, serde, derive, no-std]` (4) |
| `pkg:pypi/requests` | psf/requests | A simple, yet elegant, HTTP library. | Python HTTP for Humans. | `[python, http, forhumans, requests, python-requests, client, humans, cookies]` (8) |
| `pkg:pypi/flask` | pallets/flask | The Python micro framework for building web applications. | A simple framework for building complex web applications. | `[python, flask, wsgi, web-framework, werkzeug, jinja, pallets]` (7) |
| `pkg:npm/express` | expressjs/express | Fast, unopinionated, minimalist web framework for node. | _same as description_ | `[javascript, nodejs, express, server]` (4) |
| `pkg:maven/org.springframework/spring-core` | spring-projects/spring-framework | Spring Framework | _same as description_ | `[framework, spring, spring-framework]` (3) |
| `pkg:npm/@types/node` | DefinitelyTyped/DefinitelyTyped | The repository for high quality TypeScript type definitions. | _same as description_ | `[typescript, definition, dts, types, typings, typescript-definitions, hacktoberfest]` (7) |
| `pkg:golang/github.com/rasky/go-xdr` | rasky/go-xdr | Implements the XDR standard as specified in RFC 4506 in pure Google Go (Golang) | _same as description_ | `[]string{}` (fetched, zero configured) |
| `pkg:pypi/six` | benjaminp/six | Python 2 and 3 compatibility library | Python 2 and 3 compatibility utilities | `[]string{}` (fetched, zero configured) |

### Key observations

- **PyPI `info.summary` override works end-to-end**: `django`, `requests`, `flask`, `six` show `Summary ≠ Description`. The PyPI-specific path (`populate_summary.go` + shared `pypi.Client`) is live and produces per-package summaries distinct from the GitHub-sourced description. The other 6 packages (non-PyPI, or PyPI with no GitHub-description divergence) correctly inherit the GitHub / deps.dev path.
- **`[]string{}` sentinel is observable at runtime**: `rasky/go-xdr` and `benjaminp/six` are both live GitHub repositories with no topics configured; both return `Topics: []string{}`, distinguishable from `nil` ("not fetched").
- **Maven multi-artifact resolution**: `pkg:maven/org.springframework/spring-core` resolves to the `spring-projects/spring-framework` monorepo; Summary and Topics are shared across all artifacts that map to the same Repository aggregate. Expected for module-per-artifact projects.
- **`@types/node` monorepo**: Correctly resolves to `DefinitelyTyped/DefinitelyTyped`; the repository's 7 topics surface at the package level.
- **Summary length**: All observed values ≤ 96 runes (max: `django`). Well within the 200-rune cap — no truncation triggered by this sample.
- **Topics length**: Max observed is 9 (`django`), well within `MaxTopics = 20`.
- **Description unchanged**: All packages retain their existing GitHub / PyPI `Description` value; `Summary` is additive, per the stated contract.

### Coverage gaps

The `Topics: nil` sentinel (non-GitHub host, fetch failure, missing `GITHUB_TOKEN`, or GraphQL "Could not resolve to a Repository") is covered by unit tests in `internal/infrastructure/github/topics_test.go` but is not exercised by this runtime sample — every selected PURL resolved to a public GitHub repository. Related follow-up: #322 tracks resolving `gopkg.in/*` vanity URLs to their canonical GitHub targets so Go legacy modules populate Summary / Topics consistently.

<details>
<summary>Raw JSON output (all 10 entries)</summary>

```json
[
  {
    "purl": "pkg:npm/react",
    "repo_url": "https://github.com/facebook/react",
    "description": "The library for web and native user interfaces.",
    "summary": "The library for web and native user interfaces.",
    "topics_raw": ["javascript", "react", "frontend", "declarative", "ui", "library"],
    "topics_len": 6,
    "topics_semantics": "non-empty (6 topics)"
  },
  {
    "purl": "pkg:pypi/django",
    "repo_url": "https://github.com/django/django",
    "description": "The Web framework for perfectionists with deadlines.",
    "summary": "A high-level Python web framework that encourages rapid development and clean, pragmatic design.",
    "topics_raw": ["python", "django", "web", "framework", "orm", "templates", "models", "views", "apps"],
    "topics_len": 9,
    "topics_semantics": "non-empty (9 topics)"
  },
  {
    "purl": "pkg:cargo/serde",
    "repo_url": "https://github.com/serde-rs/serde",
    "description": "Serialization framework for Rust",
    "summary": "Serialization framework for Rust",
    "topics_raw": ["rust", "serde", "derive", "no-std"],
    "topics_len": 4,
    "topics_semantics": "non-empty (4 topics)"
  },
  {
    "purl": "pkg:pypi/requests",
    "repo_url": "https://github.com/psf/requests",
    "description": "A simple, yet elegant, HTTP library.",
    "summary": "Python HTTP for Humans.",
    "topics_raw": ["python", "http", "forhumans", "requests", "python-requests", "client", "humans", "cookies"],
    "topics_len": 8,
    "topics_semantics": "non-empty (8 topics)"
  },
  {
    "purl": "pkg:pypi/flask",
    "repo_url": "https://github.com/pallets/flask",
    "description": "The Python micro framework for building web applications.",
    "summary": "A simple framework for building complex web applications.",
    "topics_raw": ["python", "flask", "wsgi", "web-framework", "werkzeug", "jinja", "pallets"],
    "topics_len": 7,
    "topics_semantics": "non-empty (7 topics)"
  },
  {
    "purl": "pkg:npm/express",
    "repo_url": "https://github.com/expressjs/express",
    "description": "Fast, unopinionated, minimalist web framework for node.",
    "summary": "Fast, unopinionated, minimalist web framework for node.",
    "topics_raw": ["javascript", "nodejs", "express", "server"],
    "topics_len": 4,
    "topics_semantics": "non-empty (4 topics)"
  },
  {
    "purl": "pkg:maven/org.springframework/spring-core",
    "repo_url": "https://github.com/spring-projects/spring-framework",
    "description": "Spring Framework",
    "summary": "Spring Framework",
    "topics_raw": ["framework", "spring", "spring-framework"],
    "topics_len": 3,
    "topics_semantics": "non-empty (3 topics)"
  },
  {
    "purl": "pkg:npm/@types/node",
    "repo_url": "https://github.com/definitelytyped/definitelytyped",
    "description": "The repository for high quality TypeScript type definitions.",
    "summary": "The repository for high quality TypeScript type definitions.",
    "topics_raw": ["typescript", "definition", "dts", "types", "typings", "typescript-definitions", "hacktoberfest"],
    "topics_len": 7,
    "topics_semantics": "non-empty (7 topics)"
  },
  {
    "purl": "pkg:golang/github.com/rasky/go-xdr",
    "repo_url": "https://github.com/rasky/go-xdr",
    "description": "Implements the XDR standard as specified in RFC 4506 in pure Google Go (Golang)",
    "summary": "Implements the XDR standard as specified in RFC 4506 in pure Google Go (Golang)",
    "topics_raw": [],
    "topics_len": 0,
    "topics_semantics": "[]string{} (fetched, zero topics configured)"
  },
  {
    "purl": "pkg:pypi/six",
    "repo_url": "https://github.com/benjaminp/six",
    "description": "Python 2 and 3 compatibility library",
    "summary": "Python 2 and 3 compatibility utilities",
    "topics_raw": [],
    "topics_len": 0,
    "topics_semantics": "[]string{} (fetched, zero topics configured)"
  }
]
```
</details>

Closes #316. Closes #317.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
