### PR TITLE
feat(scan): detect pinned GitHub Action version deprecations via static catalog

### DIFF
--- a/.claude/rules/copilot-learned-coding.md
+++ b/.claude/rules/copilot-learned-coding.md
@@ -15,6 +15,7 @@ Rules extracted from recurring Copilot review patterns on coding-standards topic
 - **Reject Flags That Silently Have No Effect**: When a CLI flag only applies to a specific input mode (e.g., `--sample` for PURL list files), explicitly reject it with a clear error when the input is a different mode (e.g., go.mod or SBOM). Do not silently ignore the flag — users assume their flags take effect.
 - **Deduplicate Inputs Before Batch API Calls**: When accepting user-provided input lists (PURLs, URLs) that feed into batch API calls, deduplicate them while preserving first-seen order before processing. Duplicates cause redundant external calls, skew logging/counts, and waste resources.
 - **Normalize User-Provided Enum Values**: When accepting string values for format selectors, mode switches, or other enums from CLI flags, normalize with `strings.TrimSpace(strings.ToLower(...))` before validation. Case-sensitive matching rejects common inputs like `--format JSON` or `--format "json "`.
+- **Include All Distinguishing Fields in Deduplication Keys**: When using maps or sets for deduplication, ensure the key includes every field that distinguishes semantically different entries. A key that omits a distinguishing dimension (e.g., version ref in a URL dedup map) silently drops distinct entries that share the remaining dimensions, causing data loss.
 - **Interface Contract Documentation Must Match Signature Semantics**: When documenting an interface method, the doc comment must accurately reflect the method's full signature — including error returns, nil semantics, and parameter constraints. If the signature returns `(T, error)`, do not document it as "returns nil/empty on failure" — state that errors may be returned and describe the caller's expected handling (e.g., non-fatal/graceful degradation). Mismatched contract documentation misleads implementers and callers.
 - **GitHub Actions `||` Treats Empty as Falsy**: When a workflow input documents "empty = X behavior", do not use `${{ inputs.foo || 'default' }}` — the `||` operator treats empty string as falsy and applies the default, preventing users from intentionally selecting the empty option. Instead, pass the raw input via an env var and apply defaults conditionally (e.g., only for scheduled triggers).
 - **Guard Downstream Jobs Against Missing Outputs**: When a CI job produces outputs that downstream jobs depend on (exit codes, flags), gate downstream jobs on `needs.<job>.outputs.<key> != ''` to prevent execution when the upstream job fails before setting outputs. Otherwise, empty values may be misinterpreted (e.g., empty exit code `""` compared with `!= "0"` evaluates to true, creating misleading reports).
@@ -42,6 +43,7 @@ Rules extracted from recurring Copilot review patterns on coding-standards topic
 - **Filter and Normalize IDs Before Batch API Calls**: When building batch API requests from collected IDs, filter empty/whitespace values and deduplicate before processing to prevent invalid HTTP requests and cache pollution. Use `select` on `ctx.Done()` alongside channel operations in batch goroutines to avoid blocking after context cancellation.
 - **Guard Nil Structs Consistently Across Output Formats**: When a struct field may be nil (e.g., `ReleaseInfo`), apply the nil guard in every output renderer that accesses it (text, CSV, JSON). If one renderer has the guard and another does not, the unguarded path will panic on nil input.
 - **Gate Fallback Logic on Error, Not Result Nilness**: When deciding whether to trigger fallback or retry logic, check the error value — not whether the result is nil. A nil result with nil error is a valid success case (e.g., zero matches found), and treating it as a failure triggers unnecessary retries or incorrect fallback paths.
+- **Chained Heuristic Fallback Must Preserve Original Input**: In chained heuristic pipelines where each step transforms an intermediate result, fallback on empty must return the original input — not the intermediate value from a prior step — to match the documented contract and avoid silent data transformation.
 - **Use Case-Insensitive Comparison for URL Components**: When comparing URL components (scheme, host), use case-insensitive comparison per RFC 3986 — schemes (`HTTP://`) and hosts (`GitHub.COM`) are case-insensitive. Normalize with `strings.ToLower` or `strings.EqualFold` before prefix checks or host matching to avoid double-prefixing or missed matches.
 - **Structured Logging Conventions**: When adding `slog` calls: use DEBUG level for routine per-item telemetry (reserve INFO for exceptional events); use `snake_case` for event names (not spaces) for consistency and filterability; choose field key names that accurately describe the data across all call sites (e.g., `"ref"` not `"purl"` when the function handles both PURLs and URLs).
 - **Match Validation Format Strings to Production Format Strings**: When a validation or check function mirrors a production function's output (e.g., marker validation vs. marker replacement), use the exact same format strings and delimiters. Mismatched formats allow invalid input to pass validation silently.
@@ -87,31 +89,11 @@ pending_patterns:
     pr: 276
     file: "internal/infrastructure/pypi/wheel.go"
     date: "2026-04-11"
-  - category: "comment-doc-drift"
-    summary: "Test header comment claimed 'no code changes needed' but test relied on newly added bare-decorator capture — comments must reflect current implementation scope"
-    pr: 298
-    file: "internal/infrastructure/treesitter/lang_python_test.go"
-    date: "2026-04-12"
   - category: "security"
     summary: "Cap HTTP response body sizes with io.LimitReader before decoding — uncapped reads from overridden base URLs or mirrors can cause excessive memory usage"
     pr: 276
     file: "internal/infrastructure/pypi/client.go"
     date: "2026-04-11"
-  - category: "defensive-coding"
-    summary: "In chained heuristic pipelines where each step transforms an intermediate result, fallback on empty must return the original input — not the intermediate value from a prior step — to match the documented contract"
-    pr: 281
-    file: "internal/infrastructure/treesitter/lang_go.go"
-    date: "2026-04-11"
-  - category: "comment-doc-drift"
-    summary: "Test case name claimed 'web vs data-jpa' but input PURL was spring-boot-starter-security — test names must match the actual input under test"
-    pr: 299
-    file: "internal/application/diet/service_test.go"
-    date: "2026-04-12"
-  - category: "comment-doc-drift"
-    summary: "Constant doc comment named only Python but the sentinel was reused for Java wildcard imports — doc comments on shared constants must enumerate all languages/contexts that use them"
-    pr: 298
-    file: "internal/infrastructure/treesitter/analyzer.go"
-    date: "2026-04-12"
   - category: "whitespace-agnostic-matching"
     summary: "Use bytes.Fields tokenization instead of fixed-separator prefix checks when matching directives — tabs and multiple spaces are valid separators"
     pr: 140
@@ -130,6 +112,8 @@ pending_patterns:
 ```
 
 <!-- Promotion history (kept for audit trail):
+  # defensive-coding: promoted to copilot-learned-coding.instructions.md (PRs #281, #320 — chained heuristic fallback must preserve original input, include all distinguishing fields in dedup keys)
+  # comment-doc-drift: already covered by "Comment-Code Consistency" and "Match Test Case Names to Exercised Code" (PRs #298, #299, #320 — sort comment overstated sort key set, test name/input mismatch, shared constant doc omitted usage contexts)
   # defensive-coding: promoted to copilot-learned-coding.instructions.md (PRs #276, #280 — rerun analyzers with combined input, gate fallback on error, spec-compliant parsers, AST ancestor walk continuation)
   # comment-doc-drift: promoted to copilot-learned-coding.instructions.md (PRs #253, #276 — interface contract doc must match signature semantics)
   # testing: promoted to testing-performance.instructions.md (PRs #276, #282, #298 — nil map merge tests, sibling assertions, test name/code consistency, unconditional test assertions)

--- a/.claude/rules/copilot-learned-coding.md
+++ b/.claude/rules/copilot-learned-coding.md
@@ -99,6 +99,11 @@ pending_patterns:
     pr: 140
     file: "internal/infrastructure/depparser/detect.go"
     date: "2026-04-05"
+  - category: "defensive-coding"
+    summary: "Deep-copy slice fields in public getter functions that return copies of package-global data — shallow copy via copy() still aliases inner slice backing arrays, allowing callers to mutate the global state"
+    pr: 320
+    file: "internal/domain/actions/catalog.go"
+    date: "2026-04-20"
   - category: "security"
     summary: "Validate URL host non-empty alongside scheme check — hostless URLs like https:///path pass scheme validation but fail later in uncontrolled ways"
     pr: 276
@@ -113,7 +118,7 @@ pending_patterns:
 
 <!-- Promotion history (kept for audit trail):
   # defensive-coding: promoted to copilot-learned-coding.instructions.md (PRs #281, #320 — chained heuristic fallback must preserve original input, include all distinguishing fields in dedup keys)
-  # comment-doc-drift: already covered by "Comment-Code Consistency" and "Match Test Case Names to Exercised Code" (PRs #298, #299, #320 — sort comment overstated sort key set, test name/input mismatch, shared constant doc omitted usage contexts)
+  # comment-doc-drift: already covered by "Comment-Code Consistency" and "Match Test Case Names to Exercised Code" (PRs #298, #299, #320 — sort comment overstated sort key set, test name/input mismatch, shared constant doc omitted usage contexts, discovery doc comment stale after refactor, lexicographic sort comment overstated semantics)
   # defensive-coding: promoted to copilot-learned-coding.instructions.md (PRs #276, #280 — rerun analyzers with combined input, gate fallback on error, spec-compliant parsers, AST ancestor walk continuation)
   # comment-doc-drift: promoted to copilot-learned-coding.instructions.md (PRs #253, #276 — interface contract doc must match signature semantics)
   # testing: promoted to testing-performance.instructions.md (PRs #276, #282, #298 — nil map merge tests, sibling assertions, test name/code consistency, unconditional test assertions)

--- a/.github/instructions/copilot-learned-coding.instructions.md
+++ b/.github/instructions/copilot-learned-coding.instructions.md
@@ -97,6 +97,11 @@ pending_patterns:
     pr: 140
     file: "internal/infrastructure/depparser/detect.go"
     date: "2026-04-05"
+  - category: "defensive-coding"
+    summary: "Deep-copy slice fields in public getter functions that return copies of package-global data — shallow copy via copy() still aliases inner slice backing arrays, allowing callers to mutate the global state"
+    pr: 320
+    file: "internal/domain/actions/catalog.go"
+    date: "2026-04-20"
   - category: "security"
     summary: "Validate URL host non-empty alongside scheme check — hostless URLs like https:///path pass scheme validation but fail later in uncontrolled ways"
     pr: 276
@@ -111,7 +116,7 @@ pending_patterns:
 
 <!-- Promotion history (kept for audit trail):
   # defensive-coding: promoted to copilot-learned-coding.instructions.md (PRs #281, #320 — chained heuristic fallback must preserve original input, include all distinguishing fields in dedup keys)
-  # comment-doc-drift: already covered by "Comment-Code Consistency" and "Match Test Case Names to Exercised Code" (PRs #298, #299, #320 — sort comment overstated sort key set, test name/input mismatch, shared constant doc omitted usage contexts)
+  # comment-doc-drift: already covered by "Comment-Code Consistency" and "Match Test Case Names to Exercised Code" (PRs #298, #299, #320 — sort comment overstated sort key set, test name/input mismatch, shared constant doc omitted usage contexts, discovery doc comment stale after refactor, lexicographic sort comment overstated semantics)
   # defensive-coding: promoted to copilot-learned-coding.instructions.md (PRs #276, #280 — rerun analyzers with combined input, gate fallback on error, spec-compliant parsers, AST ancestor walk continuation)
   # comment-doc-drift: promoted to copilot-learned-coding.instructions.md (PRs #253, #276 — interface contract doc must match signature semantics)
   # testing: promoted to testing-performance.instructions.md (PRs #276, #282, #298 — nil map merge tests, sibling assertions, test name/code consistency, unconditional test assertions)

--- a/.github/instructions/copilot-learned-coding.instructions.md
+++ b/.github/instructions/copilot-learned-coding.instructions.md
@@ -13,6 +13,7 @@ Rules extracted from recurring Copilot review patterns on coding-standards topic
 - **Reject Flags That Silently Have No Effect**: When a CLI flag only applies to a specific input mode (e.g., `--sample` for PURL list files), explicitly reject it with a clear error when the input is a different mode (e.g., go.mod or SBOM). Do not silently ignore the flag — users assume their flags take effect.
 - **Deduplicate Inputs Before Batch API Calls**: When accepting user-provided input lists (PURLs, URLs) that feed into batch API calls, deduplicate them while preserving first-seen order before processing. Duplicates cause redundant external calls, skew logging/counts, and waste resources.
 - **Normalize User-Provided Enum Values**: When accepting string values for format selectors, mode switches, or other enums from CLI flags, normalize with `strings.TrimSpace(strings.ToLower(...))` before validation. Case-sensitive matching rejects common inputs like `--format JSON` or `--format "json "`.
+- **Include All Distinguishing Fields in Deduplication Keys**: When using maps or sets for deduplication, ensure the key includes every field that distinguishes semantically different entries. A key that omits a distinguishing dimension (e.g., version ref in a URL dedup map) silently drops distinct entries that share the remaining dimensions, causing data loss.
 - **Interface Contract Documentation Must Match Signature Semantics**: When documenting an interface method, the doc comment must accurately reflect the method's full signature — including error returns, nil semantics, and parameter constraints. If the signature returns `(T, error)`, do not document it as "returns nil/empty on failure" — state that errors may be returned and describe the caller's expected handling (e.g., non-fatal/graceful degradation). Mismatched contract documentation misleads implementers and callers.
 - **GitHub Actions `||` Treats Empty as Falsy**: When a workflow input documents "empty = X behavior", do not use `${{ inputs.foo || 'default' }}` — the `||` operator treats empty string as falsy and applies the default, preventing users from intentionally selecting the empty option. Instead, pass the raw input via an env var and apply defaults conditionally (e.g., only for scheduled triggers).
 - **Guard Downstream Jobs Against Missing Outputs**: When a CI job produces outputs that downstream jobs depend on (exit codes, flags), gate downstream jobs on `needs.<job>.outputs.<key> != ''` to prevent execution when the upstream job fails before setting outputs. Otherwise, empty values may be misinterpreted (e.g., empty exit code `""` compared with `!= "0"` evaluates to true, creating misleading reports).
@@ -40,6 +41,7 @@ Rules extracted from recurring Copilot review patterns on coding-standards topic
 - **Filter and Normalize IDs Before Batch API Calls**: When building batch API requests from collected IDs, filter empty/whitespace values and deduplicate before processing to prevent invalid HTTP requests and cache pollution. Use `select` on `ctx.Done()` alongside channel operations in batch goroutines to avoid blocking after context cancellation.
 - **Guard Nil Structs Consistently Across Output Formats**: When a struct field may be nil (e.g., `ReleaseInfo`), apply the nil guard in every output renderer that accesses it (text, CSV, JSON). If one renderer has the guard and another does not, the unguarded path will panic on nil input.
 - **Gate Fallback Logic on Error, Not Result Nilness**: When deciding whether to trigger fallback or retry logic, check the error value — not whether the result is nil. A nil result with nil error is a valid success case (e.g., zero matches found), and treating it as a failure triggers unnecessary retries or incorrect fallback paths.
+- **Chained Heuristic Fallback Must Preserve Original Input**: In chained heuristic pipelines where each step transforms an intermediate result, fallback on empty must return the original input — not the intermediate value from a prior step — to match the documented contract and avoid silent data transformation.
 - **Use Case-Insensitive Comparison for URL Components**: When comparing URL components (scheme, host), use case-insensitive comparison per RFC 3986 — schemes (`HTTP://`) and hosts (`GitHub.COM`) are case-insensitive. Normalize with `strings.ToLower` or `strings.EqualFold` before prefix checks or host matching to avoid double-prefixing or missed matches.
 - **Structured Logging Conventions**: When adding `slog` calls: use DEBUG level for routine per-item telemetry (reserve INFO for exceptional events); use `snake_case` for event names (not spaces) for consistency and filterability; choose field key names that accurately describe the data across all call sites (e.g., `"ref"` not `"purl"` when the function handles both PURLs and URLs).
 - **Match Validation Format Strings to Production Format Strings**: When a validation or check function mirrors a production function's output (e.g., marker validation vs. marker replacement), use the exact same format strings and delimiters. Mismatched formats allow invalid input to pass validation silently.
@@ -85,31 +87,11 @@ pending_patterns:
     pr: 276
     file: "internal/infrastructure/pypi/wheel.go"
     date: "2026-04-11"
-  - category: "comment-doc-drift"
-    summary: "Test header comment claimed 'no code changes needed' but test relied on newly added bare-decorator capture — comments must reflect current implementation scope"
-    pr: 298
-    file: "internal/infrastructure/treesitter/lang_python_test.go"
-    date: "2026-04-12"
   - category: "security"
     summary: "Cap HTTP response body sizes with io.LimitReader before decoding — uncapped reads from overridden base URLs or mirrors can cause excessive memory usage"
     pr: 276
     file: "internal/infrastructure/pypi/client.go"
     date: "2026-04-11"
-  - category: "defensive-coding"
-    summary: "In chained heuristic pipelines where each step transforms an intermediate result, fallback on empty must return the original input — not the intermediate value from a prior step — to match the documented contract"
-    pr: 281
-    file: "internal/infrastructure/treesitter/lang_go.go"
-    date: "2026-04-11"
-  - category: "comment-doc-drift"
-    summary: "Test case name claimed 'web vs data-jpa' but input PURL was spring-boot-starter-security — test names must match the actual input under test"
-    pr: 299
-    file: "internal/application/diet/service_test.go"
-    date: "2026-04-12"
-  - category: "comment-doc-drift"
-    summary: "Constant doc comment named only Python but the sentinel was reused for Java wildcard imports — doc comments on shared constants must enumerate all languages/contexts that use them"
-    pr: 298
-    file: "internal/infrastructure/treesitter/analyzer.go"
-    date: "2026-04-12"
   - category: "whitespace-agnostic-matching"
     summary: "Use bytes.Fields tokenization instead of fixed-separator prefix checks when matching directives — tabs and multiple spaces are valid separators"
     pr: 140
@@ -128,6 +110,8 @@ pending_patterns:
 ```
 
 <!-- Promotion history (kept for audit trail):
+  # defensive-coding: promoted to copilot-learned-coding.instructions.md (PRs #281, #320 — chained heuristic fallback must preserve original input, include all distinguishing fields in dedup keys)
+  # comment-doc-drift: already covered by "Comment-Code Consistency" and "Match Test Case Names to Exercised Code" (PRs #298, #299, #320 — sort comment overstated sort key set, test name/input mismatch, shared constant doc omitted usage contexts)
   # defensive-coding: promoted to copilot-learned-coding.instructions.md (PRs #276, #280 — rerun analyzers with combined input, gate fallback on error, spec-compliant parsers, AST ancestor walk continuation)
   # comment-doc-drift: promoted to copilot-learned-coding.instructions.md (PRs #253, #276 — interface contract doc must match signature semantics)
   # testing: promoted to testing-performance.instructions.md (PRs #276, #282, #298 — nil map merge tests, sibling assertions, test name/code consistency, unconditional test assertions)

--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ uzomuzo classifies each package into one of seven lifecycle states using a multi
 | **Evidence trails** | Every label includes a reason string and decision trace, so security teams can audit *why* a package was flagged. |
 | **Graduated precision** | Works without GitHub token (deps.dev only); adding a token unlocks commit history and Scorecard for high-precision assessment. |
 | **GitHub Actions supply chain scanning** | CI/CD workflows depend on third-party Actions that are themselves OSS. uzomuzo extracts `uses:` directives, recursively resolves composite actions (including local `./` references), and evaluates each Action's lifecycle. |
+| **Pinned-version Action EOL detection** | Repository-level scanning misses force-sunset majors like `actions/upload-artifact@v3` (EOL 2025-01-30) while the action repo is still active. uzomuzo consults a curated, source-cited catalog and flips those pins to `replace` with a dated rationale suitable for upgrade PRs. |
 
 <details>
 <summary><strong>Sample Output — All lifecycle states (detailed format)</strong></summary>

--- a/docs/adr/0016-action-pin-version-eol-detection.md
+++ b/docs/adr/0016-action-pin-version-eol-detection.md
@@ -1,0 +1,73 @@
+# ADR-0016: Pinned GitHub Action Version EOL Detection
+
+## Status
+
+Accepted (2026-04-19)
+
+## Context
+
+`--include-actions` (ADR-0005) evaluates Actions discovered in a target repository's workflows, but its verdicts are derived from **repository-level** lifecycle signals alone. Empirical scans against goreleaser, gitleaks, flask, jabref, and axios produced zero `replace` verdicts even though these repositories can ship workflows pinned to known-deprecated versions such as `actions/upload-artifact@v3` (force-sunset by GitHub on 2025-01-30) or `actions/checkout@v2` (Node 12 runtime removed in 2023-06).
+
+The root cause: the parser captures the `@ref` suffix (`v2`, `v3`, a commit SHA, ...) but the evaluator receives only `owner/repo`, so every pinned version of a still-active action is treated as `ok`. This prevents uzomuzo from surfacing the most strongly-documented class of Action deprecations — those with a fixed GitHub announcement date and an obvious upgrade target.
+
+A secondary consideration is reputational: because uzomuzo is used to author PRs against external OSS, every EOL claim must be grounded in a verifiable primary source. Any version-level detection must ship with load-bearing, auditable evidence rather than heuristics.
+
+## Decision
+
+Add a static, pure-domain catalog of GitHub Action version deprecations and propagate ref information through the scan pipeline so every action-sourced entry can be matched against it.
+
+### Data flow
+
+1. `ghaworkflow.ParseWorkflowAllWithRefs` preserves the `@ref` suffix as `ActionRef`. `ParseWorkflowAll` becomes a thin URL-dedup wrapper so existing callers keep their signature.
+2. `actionscan.DiscoveryService` threads refs through direct, local composite, and transitive BFS paths into a new `map[string][]string` return (GitHub URL → sorted distinct refs).
+3. `application/scan.Service` attaches refs to each `AuditEntry.ActionRefs` (new field) and, before fail-policy evaluation, calls `applyActionPinCatalog` to flip the entry's `EOLStatus` to `EOLEndOfLife` when any pinned ref matches a catalog entry. `DeriveVerdict` then yields `VerdictReplace` without any verdict-specific branching.
+4. Renderers expose two additive fields: `eol_reason` (from `EOL.FinalReason()`) and `action_refs` in JSON and CSV output.
+
+### Catalog design
+
+- **Location**: `internal/domain/actions/` — pure domain, standard library only.
+- **Shape**: `DeprecatedEntry{Owner, Repo, DeprecatedMajors, Reason, EOLDate, SuggestedVersion, ReferenceURL}` — each entry cites an upstream GitHub announcement.
+- **Matching**: major-version prefix (`v2` matches `v2`, `v2.3`, `v2.3.1`) via `MatchesMajor` + `MajorOf`. Non-tag refs (commit SHAs, branch names, empty) are rejected by `IsTagRef` and fall back to repository-level evaluation.
+- **Seed scope**: **hard** deprecations with dated GitHub announcements only (`actions/upload-artifact` v1–v3, `actions/download-artifact` v1–v3, `actions/checkout` v1–v2 at initial release). Entries with only "recommended upgrade" warnings are excluded to prevent false EOL claims in PR bodies.
+- **Invariants enforced by tests**: every entry has a valid `ReferenceURL`, a `SuggestedVersion` not itself in `DeprecatedMajors`, and a `Reason` containing its `EOLDate` when known.
+
+## Alternatives considered
+
+### A. Encode the ref inside the PURL
+
+Rejected. Rewriting `https://github.com/actions/checkout` as `pkg:githubactions/actions/checkout@v3` would ripple through deps.dev clients, license resolvers, CSV/JSON schema consumers, the `pkg/uzomuzo` public facade, and the successor-fallback logic. Action-scoped behavior would leak into every ecosystem-neutral code path.
+
+### B. Add `ActionRefs` directly on `domain/analysis.Analysis`
+
+Rejected. `Analysis` is used by every ecosystem (npm, Maven, Go modules, ...). Placing Action-specific data on it couples the generic domain type to a single scan mode. Keeping `ActionRefs` on `AuditEntry` (a scan-orchestration type) preserves domain purity.
+
+### C. Use the existing `AnalysisEnricher` hook
+
+Rejected for the same reason as (B). The enricher receives `map[string]*Analysis` and has no access to the per-entry ref context. Running catalog application inside Application-layer orchestration (in `RunFromPURLsWithActions`, after entries are built) keeps the mutation target close to the data it needs.
+
+### D. Auto-fetch deprecation announcements from GitHub
+
+Rejected as YAGNI. The announcements are formal, low-frequency events (2–3 per year for the core `actions/*` family). Static catalog entries are auditable in code review and unit-tested; a dynamic fetcher adds API calls, rate-limit budgeting, HTML parsing, and a failure mode that has no analogue in the current scan pipeline.
+
+### E. Resolve SHA pins to tags via the GitHub API
+
+Deferred. Many repositories pin actions to a commit SHA (often with a `# v4.2.0` comment). Resolving SHA → tag requires a new `github.Client.ListTags` method, cache, and rate-limit budget. For the initial PR, SHA and branch refs (`main`, `master`, ...) deterministically fall back to repository-level evaluation, producing the same verdicts as before this change. A follow-up ADR can cover SHA resolution when the volume of false negatives justifies it.
+
+## Consequences
+
+### Positive
+
+- **Catches the highest-value deprecations**: `upload-artifact@v3`, `checkout@v2`, and related force-sunset majors are now `VerdictReplace` with a dated, citable reason suitable for PR bodies.
+- **Auditable claims**: each catalog entry carries a `ReferenceURL` to the authoritative GitHub announcement; tests enforce this invariant.
+- **Additive schema change**: `ActionRefs` on `AuditEntry`, `eol_reason` and `action_refs` in JSON/CSV — no removal of existing fields. CSV consumers that index by column position see new columns appended at the tail.
+- **Composable with `--fail-on`**: because the catalog is applied before fail-policy evaluation, `--fail-on eol-confirmed` now trips on pinned-version deprecations as expected.
+
+### Negative
+
+- **Catalog authoring is load-bearing**: a wrong date or a mis-categorized major would appear verbatim in external PR bodies. Mitigated by (a) tight seed scope (3 action families at release), (b) test-enforced invariants, and (c) per-entry `ReferenceURL` review.
+- **SHA-pinned actions remain invisible**: pipelines that follow the Scorecard-recommended SHA pin pattern will not see version-level findings until the SHA → tag resolver lands. The existing repository-level verdict still applies.
+- **Follow-up work**: the `--file .github/workflows/ci.yml` path currently bypasses `RunFromPURLsWithActions` and does not receive the catalog treatment. Extending that path requires a parallel `WorkflowRefParser` injection point in `interfaces/cli` and is tracked separately.
+
+### Neutral
+
+- No new CLI flag, no new environment variable. Catalog is always active for action-sourced entries, matching the `project-conventions.md` "Configuration & Flags Policy".

--- a/internal/application/scan/actions_pin_catalog_test.go
+++ b/internal/application/scan/actions_pin_catalog_test.go
@@ -3,6 +3,7 @@ package scan
 import (
 	"testing"
 
+	domainactions "github.com/future-architect/uzomuzo-oss/internal/domain/actions"
 	"github.com/future-architect/uzomuzo-oss/internal/domain/analysis"
 	domainaudit "github.com/future-architect/uzomuzo-oss/internal/domain/audit"
 )
@@ -34,8 +35,8 @@ func TestApplyActionPinCatalog_FlipsDeprecatedPin(t *testing.T) {
 		t.Fatal("expected at least one ActionPinCatalog evidence")
 	}
 	ev := got.Analysis.EOL.Evidences[len(got.Analysis.EOL.Evidences)-1]
-	if ev.Source != "ActionPinCatalog" {
-		t.Errorf("evidence source = %q, want ActionPinCatalog", ev.Source)
+	if ev.Source != domainactions.EvidenceSource {
+		t.Errorf("evidence source = %q, want %q", ev.Source, domainactions.EvidenceSource)
 	}
 	if ev.Reference == "" {
 		t.Error("evidence reference URL must not be empty")

--- a/internal/application/scan/actions_pin_catalog_test.go
+++ b/internal/application/scan/actions_pin_catalog_test.go
@@ -1,0 +1,140 @@
+package scan
+
+import (
+	"testing"
+
+	"github.com/future-architect/uzomuzo-oss/internal/domain/analysis"
+	domainaudit "github.com/future-architect/uzomuzo-oss/internal/domain/audit"
+)
+
+func TestApplyActionPinCatalog_FlipsDeprecatedPin(t *testing.T) {
+	entries := []domainaudit.AuditEntry{
+		{
+			PURL:       "https://github.com/actions/upload-artifact",
+			Source:     domainaudit.SourceActions,
+			Verdict:    domainaudit.VerdictOK,
+			Analysis:   &analysis.Analysis{EOL: analysis.EOLStatus{State: analysis.EOLNotEOL}},
+			ActionRefs: []string{"v3"},
+		},
+	}
+
+	applyActionPinCatalog(entries)
+
+	got := entries[0]
+	if got.Verdict != domainaudit.VerdictReplace {
+		t.Errorf("verdict = %q, want %q", got.Verdict, domainaudit.VerdictReplace)
+	}
+	if got.Analysis.EOL.State != analysis.EOLEndOfLife {
+		t.Errorf("EOL state = %q, want %q", got.Analysis.EOL.State, analysis.EOLEndOfLife)
+	}
+	if got.Analysis.EOL.Successor != "v4" {
+		t.Errorf("successor = %q, want %q", got.Analysis.EOL.Successor, "v4")
+	}
+	if len(got.Analysis.EOL.Evidences) == 0 {
+		t.Fatal("expected at least one ActionPinCatalog evidence")
+	}
+	ev := got.Analysis.EOL.Evidences[len(got.Analysis.EOL.Evidences)-1]
+	if ev.Source != "ActionPinCatalog" {
+		t.Errorf("evidence source = %q, want ActionPinCatalog", ev.Source)
+	}
+	if ev.Reference == "" {
+		t.Error("evidence reference URL must not be empty")
+	}
+}
+
+func TestApplyActionPinCatalog_LeavesCurrentPinUntouched(t *testing.T) {
+	entries := []domainaudit.AuditEntry{
+		{
+			PURL:       "https://github.com/actions/upload-artifact",
+			Source:     domainaudit.SourceActions,
+			Verdict:    domainaudit.VerdictOK,
+			Analysis:   &analysis.Analysis{EOL: analysis.EOLStatus{State: analysis.EOLNotEOL}},
+			ActionRefs: []string{"v4"}, // current major
+		},
+	}
+	applyActionPinCatalog(entries)
+	if entries[0].Verdict != domainaudit.VerdictOK {
+		t.Errorf("verdict = %q, want OK (v4 is current)", entries[0].Verdict)
+	}
+	if entries[0].Analysis.EOL.State != analysis.EOLNotEOL {
+		t.Errorf("EOL state changed unexpectedly: %q", entries[0].Analysis.EOL.State)
+	}
+}
+
+func TestApplyActionPinCatalog_SkipsNonActionSources(t *testing.T) {
+	entries := []domainaudit.AuditEntry{
+		{
+			PURL:       "pkg:npm/express@4.18.2",
+			Source:     domainaudit.SourceDirect,
+			Verdict:    domainaudit.VerdictOK,
+			Analysis:   &analysis.Analysis{EOL: analysis.EOLStatus{State: analysis.EOLNotEOL}},
+			ActionRefs: []string{"v3"}, // would match upload-artifact but source is not actions
+		},
+	}
+	applyActionPinCatalog(entries)
+	if entries[0].Verdict != domainaudit.VerdictOK {
+		t.Errorf("non-action source must not be affected by catalog; got verdict %q", entries[0].Verdict)
+	}
+}
+
+func TestApplyActionPinCatalog_SkipsSHAAndBranchPins(t *testing.T) {
+	tests := []struct {
+		name string
+		ref  string
+	}{
+		{"SHA", "de0fac2e4500dabe0009e67214ff5f5447ce83dd"},
+		{"branch main", "main"},
+		{"branch master", "master"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			entries := []domainaudit.AuditEntry{
+				{
+					PURL:       "https://github.com/actions/checkout",
+					Source:     domainaudit.SourceActions,
+					Verdict:    domainaudit.VerdictOK,
+					Analysis:   &analysis.Analysis{EOL: analysis.EOLStatus{State: analysis.EOLNotEOL}},
+					ActionRefs: []string{tt.ref},
+				},
+			}
+			applyActionPinCatalog(entries)
+			if entries[0].Verdict != domainaudit.VerdictOK {
+				t.Errorf("unresolvable ref %q should not flip verdict; got %q", tt.ref, entries[0].Verdict)
+			}
+		})
+	}
+}
+
+func TestApplyActionPinCatalog_MixedPinsFlipOnAnyMatch(t *testing.T) {
+	entries := []domainaudit.AuditEntry{
+		{
+			PURL:       "https://github.com/actions/checkout",
+			Source:     domainaudit.SourceActions,
+			Verdict:    domainaudit.VerdictOK,
+			Analysis:   &analysis.Analysis{EOL: analysis.EOLStatus{State: analysis.EOLNotEOL}},
+			ActionRefs: []string{"v4", "v2"}, // one current, one EOL
+		},
+	}
+	applyActionPinCatalog(entries)
+	if entries[0].Verdict != domainaudit.VerdictReplace {
+		t.Errorf("verdict should be replace when any ref is deprecated; got %q", entries[0].Verdict)
+	}
+}
+
+func TestApplyActionRefs_PopulatesOnlyActionSources(t *testing.T) {
+	entries := []domainaudit.AuditEntry{
+		{PURL: "https://github.com/actions/checkout", Source: domainaudit.SourceActions},
+		{PURL: "pkg:npm/express@4.18.2", Source: domainaudit.SourceDirect},
+	}
+	refs := map[string][]string{
+		"https://github.com/actions/checkout": {"v4"},
+		"pkg:npm/express@4.18.2":              {"ignored"},
+	}
+	applyActionRefs(entries, refs)
+	if len(entries[0].ActionRefs) != 1 || entries[0].ActionRefs[0] != "v4" {
+		t.Errorf("action entry refs = %v, want [v4]", entries[0].ActionRefs)
+	}
+	if len(entries[1].ActionRefs) != 0 {
+		t.Errorf("non-action entry must not receive refs, got %v", entries[1].ActionRefs)
+	}
+}

--- a/internal/application/scan/actions_pin_catalog_test.go
+++ b/internal/application/scan/actions_pin_catalog_test.go
@@ -1,6 +1,7 @@
 package scan
 
 import (
+	"strings"
 	"testing"
 
 	domainactions "github.com/future-architect/uzomuzo-oss/internal/domain/actions"
@@ -103,6 +104,43 @@ func TestApplyActionPinCatalog_SkipsSHAAndBranchPins(t *testing.T) {
 				t.Errorf("unresolvable ref %q should not flip verdict; got %q", tt.ref, entries[0].Verdict)
 			}
 		})
+	}
+}
+
+func TestApplyActionPinCatalog_MultipleDeprecatedMajors_SingleEvidence(t *testing.T) {
+	// When an entry pins to two separately-deprecated majors (e.g., v2 and v3
+	// both in the catalog), only one evidence is emitted to keep downstream
+	// rendering single-valued. ActionRefs is sorted ascending by the discovery
+	// layer, so the lowest deprecated major wins.
+	entries := []domainaudit.AuditEntry{
+		{
+			PURL:       "https://github.com/actions/upload-artifact",
+			Source:     domainaudit.SourceActions,
+			Verdict:    domainaudit.VerdictOK,
+			Analysis:   &analysis.Analysis{EOL: analysis.EOLStatus{State: analysis.EOLNotEOL}},
+			ActionRefs: []string{"v2", "v3"},
+		},
+	}
+	applyActionPinCatalog(entries)
+	if entries[0].Verdict != domainaudit.VerdictReplace {
+		t.Errorf("verdict = %q, want replace", entries[0].Verdict)
+	}
+	catalogEvidences := 0
+	var matched string
+	for _, ev := range entries[0].Analysis.EOL.Evidences {
+		if ev.Source == domainactions.EvidenceSource {
+			catalogEvidences++
+			if matched == "" {
+				// Extract the pinned ref from the summary "Pinned to X; ..." prefix.
+				matched = ev.Summary
+			}
+		}
+	}
+	if catalogEvidences != 1 {
+		t.Errorf("got %d ActionPinCatalog evidences, want exactly 1", catalogEvidences)
+	}
+	if !strings.HasPrefix(matched, "Pinned to v2;") {
+		t.Errorf("evidence summary = %q, want to start with 'Pinned to v2;' (lowest deprecated major)", matched)
 	}
 }
 

--- a/internal/application/scan/actions_pin_catalog_test.go
+++ b/internal/application/scan/actions_pin_catalog_test.go
@@ -121,6 +121,52 @@ func TestApplyActionPinCatalog_MixedPinsFlipOnAnyMatch(t *testing.T) {
 	}
 }
 
+func TestApplyActionPinCatalog_DuplicatePURLAcrossSources(t *testing.T) {
+	// A single action can appear as SourceActions (direct) and SourceActionsTransitive
+	// in one scan if a workflow uses it directly AND a composite action also uses it.
+	// Both entries must be flipped independently.
+	entries := []domainaudit.AuditEntry{
+		{
+			PURL:       "https://github.com/actions/upload-artifact",
+			Source:     domainaudit.SourceActions,
+			Verdict:    domainaudit.VerdictOK,
+			Analysis:   &analysis.Analysis{EOL: analysis.EOLStatus{State: analysis.EOLNotEOL}},
+			ActionRefs: []string{"v3"},
+		},
+		{
+			PURL:       "https://github.com/actions/upload-artifact",
+			Source:     domainaudit.SourceActionsTransitive,
+			Verdict:    domainaudit.VerdictOK,
+			Analysis:   &analysis.Analysis{EOL: analysis.EOLStatus{State: analysis.EOLNotEOL}},
+			ActionRefs: []string{"v3"},
+		},
+	}
+	applyActionPinCatalog(entries)
+	for i, e := range entries {
+		if e.Verdict != domainaudit.VerdictReplace {
+			t.Errorf("entries[%d].Verdict = %q, want replace", i, e.Verdict)
+		}
+		if len(e.Analysis.EOL.Evidences) == 0 {
+			t.Errorf("entries[%d] expected ActionPinCatalog evidence", i)
+		}
+	}
+}
+
+func TestApplyActionRefs_IdempotentOnRepeatedInvocation(t *testing.T) {
+	// Calling applyActionRefs twice with the same input must not duplicate refs.
+	entries := []domainaudit.AuditEntry{
+		{PURL: "https://github.com/actions/checkout", Source: domainaudit.SourceActions},
+	}
+	refs := map[string][]string{
+		"https://github.com/actions/checkout": {"v2", "v4"},
+	}
+	applyActionRefs(entries, refs)
+	applyActionRefs(entries, refs)
+	if len(entries[0].ActionRefs) != 2 {
+		t.Errorf("ActionRefs = %v, want exactly [v2 v4] after 2 invocations", entries[0].ActionRefs)
+	}
+}
+
 func TestApplyActionRefs_PopulatesOnlyActionSources(t *testing.T) {
 	entries := []domainaudit.AuditEntry{
 		{PURL: "https://github.com/actions/checkout", Source: domainaudit.SourceActions},

--- a/internal/application/scan/actions_test.go
+++ b/internal/application/scan/actions_test.go
@@ -11,14 +11,15 @@ import (
 
 // mockDiscoverer implements scan.ActionsDiscoverer for testing.
 type mockDiscoverer struct {
-	directURLs       []string
-	localActions     map[string]string
+	directURLs        []string
+	localActions      map[string]string
 	transitiveActions map[string]string
-	errors           map[string]error
+	actionRefs        map[string][]string
+	errors            map[string]error
 }
 
-func (m *mockDiscoverer) DiscoverActions(_ context.Context, _ []string, _ bool) ([]string, map[string]string, map[string]string, map[string]error, error) {
-	return m.directURLs, m.localActions, m.transitiveActions, m.errors, nil
+func (m *mockDiscoverer) DiscoverActions(_ context.Context, _ []string, _ bool) ([]string, map[string]string, map[string]string, map[string][]string, map[string]error, error) {
+	return m.directURLs, m.localActions, m.transitiveActions, m.actionRefs, m.errors, nil
 }
 
 func TestActionsConfig_DisabledByDefault(t *testing.T) {

--- a/internal/application/scan/service.go
+++ b/internal/application/scan/service.go
@@ -354,7 +354,7 @@ func applyActionPinCatalog(entries []domainaudit.AuditEntry) {
 			// upgrade target, so the summary does not repeat it.
 			reason := strings.TrimRight(entry.Reason, ".")
 			e.Analysis.EOL.Evidences = append(e.Analysis.EOL.Evidences, analysis.EOLEvidence{
-				Source:     "ActionPinCatalog",
+				Source:     domainactions.EvidenceSource,
 				Summary:    fmt.Sprintf("Pinned to %s; %s.", ref, reason),
 				Reference:  entry.ReferenceURL,
 				Confidence: 1.0,

--- a/internal/application/scan/service.go
+++ b/internal/application/scan/service.go
@@ -321,8 +321,13 @@ func isActionSource(src domainaudit.EntrySource) bool {
 //
 // A single entry may carry multiple pins (e.g., checkout@v2 in one job,
 // checkout@v4 in another). One deprecated pin is sufficient to flip the
-// entry; the evidence records only the first matching ref so downstream
-// rendering stays single-valued.
+// entry; only the first matching ref in ActionRefs iteration order produces
+// catalog evidence (ActionRefs is sorted ascending, so the lowest deprecated
+// major wins). The full ref list is still surfaced separately via
+// AuditEntry.ActionRefs for text/JSON/CSV rendering.
+//
+// Not idempotent: repeated invocation appends duplicate evidence. The
+// production pipeline calls this exactly once, after entries are built.
 func applyActionPinCatalog(entries []domainaudit.AuditEntry) {
 	for i := range entries {
 		e := &entries[i]
@@ -341,10 +346,7 @@ func applyActionPinCatalog(entries []domainaudit.AuditEntry) {
 			if !ok {
 				continue
 			}
-			// Do not overwrite stronger existing state.
-			if e.Analysis.EOL.State != analysis.EOLEndOfLife {
-				e.Analysis.EOL.State = analysis.EOLEndOfLife
-			}
+			e.Analysis.EOL.State = analysis.EOLEndOfLife
 			if e.Analysis.EOL.Successor == "" {
 				e.Analysis.EOL.Successor = entry.SuggestedVersion
 			}

--- a/internal/application/scan/service.go
+++ b/internal/application/scan/service.go
@@ -322,8 +322,7 @@ func isActionSource(src domainaudit.EntrySource) bool {
 // A single entry may carry multiple pins (e.g., checkout@v2 in one job,
 // checkout@v4 in another). One deprecated pin is sufficient to flip the
 // entry; only the first matching ref in ActionRefs iteration order produces
-// catalog evidence (ActionRefs is sorted ascending, so the lowest deprecated
-// major wins). The full ref list is still surfaced separately via
+// catalog evidence. The full ref list is still surfaced separately via
 // AuditEntry.ActionRefs for text/JSON/CSV rendering.
 //
 // Not idempotent: repeated invocation appends duplicate evidence. The

--- a/internal/application/scan/service.go
+++ b/internal/application/scan/service.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"sort"
+	"strings"
 
 	"github.com/future-architect/uzomuzo-oss/internal/application"
 	"github.com/future-architect/uzomuzo-oss/internal/common"
@@ -281,6 +282,11 @@ func (s *Service) RunFromPURLsWithActions(ctx context.Context, purls, githubURLs
 
 // applyActionRefs populates AuditEntry.ActionRefs for every entry whose Source
 // belongs to the actions family. Non-action entries are untouched.
+//
+// Refs are assigned (not appended) so repeated invocations are idempotent:
+// the upstream DiscoveryService already deduplicates refs per URL, and a
+// caller that re-runs this helper (e.g., after promoting transitive entries)
+// should see the same set rather than accumulating duplicates.
 func applyActionRefs(entries []domainaudit.AuditEntry, actionRefs map[string][]string) {
 	if len(actionRefs) == 0 {
 		return
@@ -294,7 +300,7 @@ func applyActionRefs(entries []domainaudit.AuditEntry, actionRefs map[string][]s
 		if !ok || len(refs) == 0 {
 			continue
 		}
-		e.ActionRefs = append(e.ActionRefs, refs...)
+		e.ActionRefs = append([]string(nil), refs...)
 	}
 }
 
@@ -342,9 +348,14 @@ func applyActionPinCatalog(entries []domainaudit.AuditEntry) {
 			if e.Analysis.EOL.Successor == "" {
 				e.Analysis.EOL.Successor = entry.SuggestedVersion
 			}
+			// Strip any trailing period from the catalog reason so the summary
+			// never produces double punctuation (entries like "... replaced by v4."
+			// + fixed suffix would otherwise read "v4. ."). Successor carries the
+			// upgrade target, so the summary does not repeat it.
+			reason := strings.TrimRight(entry.Reason, ".")
 			e.Analysis.EOL.Evidences = append(e.Analysis.EOL.Evidences, analysis.EOLEvidence{
 				Source:     "ActionPinCatalog",
-				Summary:    fmt.Sprintf("Pinned to %s; %s Upgrade to %s.", ref, entry.Reason, entry.SuggestedVersion),
+				Summary:    fmt.Sprintf("Pinned to %s; %s.", ref, reason),
 				Reference:  entry.ReferenceURL,
 				Confidence: 1.0,
 			})

--- a/internal/application/scan/service.go
+++ b/internal/application/scan/service.go
@@ -10,6 +10,8 @@ import (
 	"sort"
 
 	"github.com/future-architect/uzomuzo-oss/internal/application"
+	"github.com/future-architect/uzomuzo-oss/internal/common"
+	domainactions "github.com/future-architect/uzomuzo-oss/internal/domain/actions"
 	"github.com/future-architect/uzomuzo-oss/internal/domain/analysis"
 	domainaudit "github.com/future-architect/uzomuzo-oss/internal/domain/audit"
 	"github.com/future-architect/uzomuzo-oss/internal/domain/depparser"
@@ -153,7 +155,9 @@ type ActionsDiscoverer interface {
 	// Direct URLs are Actions referenced in workflow files; local actions (map of URL → local path)
 	// are discovered inside local composite actions (./.github/actions/foo); transitive actions
 	// (map of URL → via parent URL) are discovered by recursively resolving composite action dependencies.
-	DiscoverActions(ctx context.Context, repoURLs []string, resolveTransitive bool) (directURLs []string, localActions map[string]string, transitiveActions map[string]string, errors map[string]error, err error)
+	// actionRefs maps each discovered GitHub URL to the sorted distinct version refs ("v3", "v4", a commit SHA, ...)
+	// pinned against it across the scanned workflows. Absent keys indicate no ref was observed; empty values are not expected.
+	DiscoverActions(ctx context.Context, repoURLs []string, resolveTransitive bool) (directURLs []string, localActions map[string]string, transitiveActions map[string]string, actionRefs map[string][]string, errors map[string]error, err error)
 }
 
 // ActionsConfig configures optional GitHub Actions health scanning.
@@ -210,7 +214,7 @@ func (s *Service) RunFromPURLsWithActions(ctx context.Context, purls, githubURLs
 		return nil, fmt.Errorf("actions discovery is enabled but discoverer is nil")
 	}
 	if actionsCfg.Enabled && len(githubURLs) > 0 {
-		directActionURLs, localActions, transitiveActions, discoveryErrors, err := actionsCfg.Discoverer.DiscoverActions(ctx, githubURLs, actionsCfg.ShowTransitive)
+		directActionURLs, localActions, transitiveActions, actionRefs, discoveryErrors, err := actionsCfg.Discoverer.DiscoverActions(ctx, githubURLs, actionsCfg.ShowTransitive)
 		if err != nil {
 			return nil, fmt.Errorf("actions discovery failed: %w", err)
 		}
@@ -263,10 +267,91 @@ func (s *Service) RunFromPURLsWithActions(ctx context.Context, purls, githubURLs
 			}
 			entries = append(entries, transitiveEntries...)
 		}
+
+		// Attach discovered version refs to every action-sourced entry.
+		applyActionRefs(entries, actionRefs)
+		// Apply the pinned-version deprecation catalog before policy evaluation
+		// so --fail-on can see the catalog-driven EOL verdict.
+		applyActionPinCatalog(entries)
 	}
 
 	hasFailure := policy.Evaluate(entries)
 	return &Result{Entries: entries, HasFailure: hasFailure}, nil
+}
+
+// applyActionRefs populates AuditEntry.ActionRefs for every entry whose Source
+// belongs to the actions family. Non-action entries are untouched.
+func applyActionRefs(entries []domainaudit.AuditEntry, actionRefs map[string][]string) {
+	if len(actionRefs) == 0 {
+		return
+	}
+	for i := range entries {
+		e := &entries[i]
+		if !isActionSource(e.Source) {
+			continue
+		}
+		refs, ok := actionRefs[e.PURL]
+		if !ok || len(refs) == 0 {
+			continue
+		}
+		e.ActionRefs = append(e.ActionRefs, refs...)
+	}
+}
+
+func isActionSource(src domainaudit.EntrySource) bool {
+	switch src {
+	case domainaudit.SourceActions,
+		domainaudit.SourceActionsTransitive,
+		domainaudit.SourceActionsLocal:
+		return true
+	}
+	return false
+}
+
+// applyActionPinCatalog consults the pinned-version deprecation catalog for
+// every action-sourced entry and, when any of its pinned refs matches a
+// deprecated major, flips the entry's analysis to EOL and re-derives its
+// verdict. Non-action entries and entries without pinned refs are untouched.
+//
+// A single entry may carry multiple pins (e.g., checkout@v2 in one job,
+// checkout@v4 in another). One deprecated pin is sufficient to flip the
+// entry; the evidence records only the first matching ref so downstream
+// rendering stays single-valued.
+func applyActionPinCatalog(entries []domainaudit.AuditEntry) {
+	for i := range entries {
+		e := &entries[i]
+		if !isActionSource(e.Source) {
+			continue
+		}
+		if e.Analysis == nil || len(e.ActionRefs) == 0 {
+			continue
+		}
+		owner, repo, err := common.ExtractGitHubOwnerRepo(e.PURL)
+		if err != nil {
+			continue
+		}
+		for _, ref := range e.ActionRefs {
+			entry, ok := domainactions.Lookup(owner, repo, ref)
+			if !ok {
+				continue
+			}
+			// Do not overwrite stronger existing state.
+			if e.Analysis.EOL.State != analysis.EOLEndOfLife {
+				e.Analysis.EOL.State = analysis.EOLEndOfLife
+			}
+			if e.Analysis.EOL.Successor == "" {
+				e.Analysis.EOL.Successor = entry.SuggestedVersion
+			}
+			e.Analysis.EOL.Evidences = append(e.Analysis.EOL.Evidences, analysis.EOLEvidence{
+				Source:     "ActionPinCatalog",
+				Summary:    fmt.Sprintf("Pinned to %s; %s Upgrade to %s.", ref, entry.Reason, entry.SuggestedVersion),
+				Reference:  entry.ReferenceURL,
+				Confidence: 1.0,
+			})
+			e.Verdict = domainaudit.DeriveVerdict(e.Analysis)
+			break
+		}
+	}
 }
 
 // evaluateActionURLs filters, evaluates, and tags action URLs with the given source.

--- a/internal/domain/actions/catalog.go
+++ b/internal/domain/actions/catalog.go
@@ -5,6 +5,11 @@ import (
 	"strings"
 )
 
+// EvidenceSource is the EOLEvidence.Source value used for evidence emitted
+// by this catalog. Kept exported so producers and tests reference the same
+// literal and downstream consumers can filter by source.
+const EvidenceSource = "ActionPinCatalog"
+
 // DeprecatedEntry records that specific major versions of a GitHub Action
 // are known to be deprecated or end-of-life by the upstream maintainer.
 //

--- a/internal/domain/actions/catalog.go
+++ b/internal/domain/actions/catalog.go
@@ -71,7 +71,7 @@ var deprecatedActions = []DeprecatedEntry{
 }
 
 func init() {
-	// Deterministic lookup order: sort by Owner+Repo+Major.
+	// Deterministic lookup order: sort by Owner+Repo; majors sorted within each entry.
 	sort.SliceStable(deprecatedActions, func(i, j int) bool {
 		a := deprecatedActions[i]
 		b := deprecatedActions[j]

--- a/internal/domain/actions/catalog.go
+++ b/internal/domain/actions/catalog.go
@@ -116,11 +116,17 @@ func Lookup(owner, repo, pin string) (DeprecatedEntry, bool) {
 	return DeprecatedEntry{}, false
 }
 
-// AllEntries returns a copy of the seed catalog for diagnostic/testing use.
+// AllEntries returns a deep copy of the seed catalog for diagnostic/testing use.
 // The returned slice is sorted deterministically; callers must not assume
 // the order matches the source declaration.
 func AllEntries() []DeprecatedEntry {
 	out := make([]DeprecatedEntry, len(deprecatedActions))
-	copy(out, deprecatedActions)
+	for i, entry := range deprecatedActions {
+		cloned := entry
+		if entry.DeprecatedMajors != nil {
+			cloned.DeprecatedMajors = append([]string(nil), entry.DeprecatedMajors...)
+		}
+		out[i] = cloned
+	}
 	return out
 }

--- a/internal/domain/actions/catalog.go
+++ b/internal/domain/actions/catalog.go
@@ -1,0 +1,121 @@
+package actions
+
+import (
+	"sort"
+	"strings"
+)
+
+// DeprecatedEntry records that specific major versions of a GitHub Action
+// are known to be deprecated or end-of-life by the upstream maintainer.
+//
+// Each entry must cite a verifiable primary source in ReferenceURL; this
+// reputational guarantee is load-bearing because uzomuzo surfaces these
+// claims in PR bodies against external projects.
+type DeprecatedEntry struct {
+	// Owner is the GitHub owner (e.g. "actions").
+	Owner string
+	// Repo is the GitHub repository name (e.g. "checkout").
+	Repo string
+	// DeprecatedMajors is the set of major-version tags (canonical "v<N>" form)
+	// that are deprecated or EOL. Minor/patch pins within a deprecated major
+	// are matched by MatchesMajor.
+	DeprecatedMajors []string
+	// Reason is a concise, date-bearing rationale suitable for PR body text
+	// (e.g. "Sunset 2025-01-30 per GitHub announcement").
+	Reason string
+	// EOLDate is the ISO 8601 date on which the deprecation takes effect.
+	// Empty for cases where the upstream did not publish a hard date.
+	EOLDate string
+	// SuggestedVersion is the recommended upgrade target in canonical "v<N>" form.
+	SuggestedVersion string
+	// ReferenceURL points to the authoritative upstream announcement.
+	ReferenceURL string
+}
+
+// deprecatedActions is the initial seed catalog. Each entry has been
+// verified against the primary source cited in ReferenceURL.
+//
+// Seed scope: actions with hard, dated EOL announcements from GitHub.
+// "Soft deprecations" (Node runtime recommended-upgrade warnings without
+// a removal date) are intentionally excluded to prevent false claims in
+// generated PR bodies. Additional entries may be appended in follow-up
+// PRs after verification.
+var deprecatedActions = []DeprecatedEntry{
+	{
+		Owner:            "actions",
+		Repo:             "upload-artifact",
+		DeprecatedMajors: []string{"v1", "v2", "v3"},
+		Reason:           "Sunset on 2024-11-30 (v1-v2) and 2025-01-30 (v3); artifact service v4 is the only supported version.",
+		EOLDate:          "2025-01-30",
+		SuggestedVersion: "v4",
+		ReferenceURL:     "https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/",
+	},
+	{
+		Owner:            "actions",
+		Repo:             "download-artifact",
+		DeprecatedMajors: []string{"v1", "v2", "v3"},
+		Reason:           "Sunset on 2024-11-30 (v1-v2) and 2025-01-30 (v3); artifact service v4 is the only supported version.",
+		EOLDate:          "2025-01-30",
+		SuggestedVersion: "v4",
+		ReferenceURL:     "https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/",
+	},
+	{
+		Owner:            "actions",
+		Repo:             "checkout",
+		DeprecatedMajors: []string{"v1", "v2"},
+		Reason:           "Uses Node 12, removed from GitHub-hosted runners on 2023-06-30. Action has been replaced by v4 (Node 20).",
+		EOLDate:          "2023-06-30",
+		SuggestedVersion: "v4",
+		ReferenceURL:     "https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/",
+	},
+}
+
+func init() {
+	// Deterministic lookup order: sort by Owner+Repo+Major.
+	sort.SliceStable(deprecatedActions, func(i, j int) bool {
+		a := deprecatedActions[i]
+		b := deprecatedActions[j]
+		if a.Owner != b.Owner {
+			return a.Owner < b.Owner
+		}
+		return a.Repo < b.Repo
+	})
+	for i := range deprecatedActions {
+		majors := deprecatedActions[i].DeprecatedMajors
+		sort.Strings(majors)
+	}
+}
+
+// Lookup returns the catalog entry matching owner/repo/pin, if any.
+// Matching semantics:
+//   - owner/repo must match an entry exactly (case-insensitive).
+//   - pin must be a tag ref (see IsTagRef) and resolve to one of the entry's
+//     DeprecatedMajors (see MatchesMajor).
+//
+// Non-tag refs (branches, commit SHAs, empty) never match: callers should
+// fall back to repository-level lifecycle evaluation for those pins.
+func Lookup(owner, repo, pin string) (DeprecatedEntry, bool) {
+	if !IsTagRef(pin) {
+		return DeprecatedEntry{}, false
+	}
+	for _, e := range deprecatedActions {
+		if !strings.EqualFold(e.Owner, owner) || !strings.EqualFold(e.Repo, repo) {
+			continue
+		}
+		for _, major := range e.DeprecatedMajors {
+			if MatchesMajor(pin, major) {
+				return e, true
+			}
+		}
+	}
+	return DeprecatedEntry{}, false
+}
+
+// AllEntries returns a copy of the seed catalog for diagnostic/testing use.
+// The returned slice is sorted deterministically; callers must not assume
+// the order matches the source declaration.
+func AllEntries() []DeprecatedEntry {
+	out := make([]DeprecatedEntry, len(deprecatedActions))
+	copy(out, deprecatedActions)
+	return out
+}

--- a/internal/domain/actions/catalog_test.go
+++ b/internal/domain/actions/catalog_test.go
@@ -1,0 +1,102 @@
+package actions_test
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/future-architect/uzomuzo-oss/internal/domain/actions"
+)
+
+func TestLookup_KnownDeprecations(t *testing.T) {
+	tests := []struct {
+		name  string
+		owner string
+		repo  string
+		pin   string
+		want  bool
+	}{
+		{"upload-artifact v3 is EOL", "actions", "upload-artifact", "v3", true},
+		{"upload-artifact v3.0.0 matches major", "actions", "upload-artifact", "v3.0.0", true},
+		{"upload-artifact v4 is current", "actions", "upload-artifact", "v4", false},
+		{"download-artifact v2 is EOL", "actions", "download-artifact", "v2", true},
+		{"checkout v2 is EOL", "actions", "checkout", "v2", true},
+		{"checkout v3 not in initial seed", "actions", "checkout", "v3", false},
+		{"checkout v4 is current", "actions", "checkout", "v4", false},
+		{"case-insensitive owner", "Actions", "checkout", "v2", true},
+		{"case-insensitive repo", "actions", "CHECKOUT", "v2", true},
+		{"unknown repo", "actions", "unknown-action", "v1", false},
+		{"SHA pin never matches", "actions", "checkout", "de0fac2e4500dabe0009e67214ff5f5447ce83dd", false},
+		{"branch pin never matches", "actions", "checkout", "main", false},
+		{"empty pin never matches", "actions", "checkout", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, got := actions.Lookup(tt.owner, tt.repo, tt.pin)
+			if got != tt.want {
+				t.Errorf("Lookup(%q, %q, %q) = %v, want %v", tt.owner, tt.repo, tt.pin, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLookup_ReturnsCorrectEntry(t *testing.T) {
+	entry, ok := actions.Lookup("actions", "upload-artifact", "v3")
+	if !ok {
+		t.Fatal("expected match for upload-artifact@v3")
+	}
+	if entry.SuggestedVersion != "v4" {
+		t.Errorf("SuggestedVersion = %q, want v4", entry.SuggestedVersion)
+	}
+	if entry.Reason == "" {
+		t.Error("Reason must be non-empty")
+	}
+	if entry.EOLDate == "" {
+		t.Error("EOLDate must be non-empty for this entry")
+	}
+	if entry.ReferenceURL == "" {
+		t.Error("ReferenceURL must be non-empty")
+	}
+}
+
+// TestCatalogInvariants guards against common authoring errors in future entries:
+// the suggested upgrade must not itself be listed as deprecated, every reference
+// URL must be a valid HTTP(S) URL, and each reason string should mention a date
+// so the PR body carries the authority the design intends.
+func TestCatalogInvariants(t *testing.T) {
+	for _, e := range actions.AllEntries() {
+		name := e.Owner + "/" + e.Repo
+		t.Run(name, func(t *testing.T) {
+			if e.Owner == "" || e.Repo == "" {
+				t.Errorf("%s: Owner and Repo must be set", name)
+			}
+			if len(e.DeprecatedMajors) == 0 {
+				t.Errorf("%s: DeprecatedMajors must not be empty", name)
+			}
+			if e.SuggestedVersion == "" {
+				t.Errorf("%s: SuggestedVersion must be set", name)
+			}
+			for _, m := range e.DeprecatedMajors {
+				if m == e.SuggestedVersion {
+					t.Errorf("%s: SuggestedVersion %q is itself listed as deprecated", name, m)
+				}
+			}
+			if e.ReferenceURL == "" {
+				t.Errorf("%s: ReferenceURL must be set (reputational guarantee)", name)
+			} else {
+				u, err := url.Parse(e.ReferenceURL)
+				if err != nil || (u.Scheme != "https" && u.Scheme != "http") || u.Host == "" {
+					t.Errorf("%s: ReferenceURL %q is not a valid http(s) URL", name, e.ReferenceURL)
+				}
+			}
+			if e.Reason == "" {
+				t.Errorf("%s: Reason must be set (shown in PR bodies)", name)
+			}
+			// Reason should contain the EOL date when one is known, so PR
+			// bodies carry the "EOL since YYYY-MM-DD" authority the design intends.
+			if e.EOLDate != "" && !strings.Contains(e.Reason, e.EOLDate) {
+				t.Errorf("%s: Reason should mention EOLDate %q, got %q", name, e.EOLDate, e.Reason)
+			}
+		})
+	}
+}

--- a/internal/domain/actions/version.go
+++ b/internal/domain/actions/version.go
@@ -1,0 +1,55 @@
+// Package actions contains pure-domain logic for GitHub Actions pinned-version analysis,
+// including a static catalog of known-deprecated versions and matching helpers.
+//
+// DDD Layer: Domain (no I/O, no external dependencies beyond the standard library).
+package actions
+
+import (
+	"regexp"
+	"strings"
+)
+
+// tagRefPattern matches semver-like tag refs: "v1", "v1.2", "v1.2.3", "1", "1.2", "1.2.3".
+// Pre-release suffixes (e.g. "-rc1", "+build") are intentionally rejected; deprecation
+// catalog entries target major versions and maintainers rarely pin pre-releases.
+var tagRefPattern = regexp.MustCompile(`^v?\d+(\.\d+){0,2}$`)
+
+// IsTagRef reports whether ref looks like a semver tag (e.g., "v4", "v3.1.0", "1.2").
+// Returns false for commit SHAs, branch names ("main", "master"), empty strings,
+// and any other unparseable reference.
+//
+// Callers use this to decide whether the deprecated-actions catalog can be
+// consulted for a given pin. Unresolvable refs fall back to repo-level evaluation.
+func IsTagRef(ref string) bool {
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return false
+	}
+	return tagRefPattern.MatchString(ref)
+}
+
+// MajorOf returns the canonical major component of a tag ref, always prefixed with "v".
+// Examples: "v2" → "v2", "v2.3.1" → "v2", "3" → "v3", "3.4" → "v3".
+// Returns "" for non-tag refs (branches, SHAs, empty).
+func MajorOf(ref string) string {
+	if !IsTagRef(ref) {
+		return ""
+	}
+	ref = strings.TrimSpace(ref)
+	ref = strings.TrimPrefix(ref, "v")
+	if i := strings.Index(ref, "."); i >= 0 {
+		ref = ref[:i]
+	}
+	return "v" + ref
+}
+
+// MatchesMajor reports whether pin resolves to the same major as catalogMajor.
+// catalogMajor must be in canonical form (e.g., "v2"). pin may be any tag form.
+// Non-tag refs (branches, SHAs) always return false.
+func MatchesMajor(pin, catalogMajor string) bool {
+	m := MajorOf(pin)
+	if m == "" {
+		return false
+	}
+	return m == catalogMajor
+}

--- a/internal/domain/actions/version_test.go
+++ b/internal/domain/actions/version_test.go
@@ -8,29 +8,30 @@ import (
 
 func TestIsTagRef(t *testing.T) {
 	tests := []struct {
+		name string
 		ref  string
 		want bool
 	}{
-		{"v1", true},
-		{"v2", true},
-		{"v3.1", true},
-		{"v4.2.0", true},
-		{"1", true},
-		{"1.2", true},
-		{"1.2.3", true},
-		{"  v4  ", true}, // whitespace tolerated
-		{"", false},
-		{"main", false},
-		{"master", false},
-		{"develop", false},
-		{"de0fac2e4500dabe0009e67214ff5f5447ce83dd", false}, // SHA
-		{"v", false},
-		{"v1.2.3-rc1", false}, // pre-release rejected (out of scope)
-		{"v1.2.3+build", false},
-		{"latest", false},
+		{"v1", "v1", true},
+		{"v2", "v2", true},
+		{"v3.1", "v3.1", true},
+		{"v4.2.0", "v4.2.0", true},
+		{"1", "1", true},
+		{"1.2", "1.2", true},
+		{"1.2.3", "1.2.3", true},
+		{"whitespace tolerated", "  v4  ", true},
+		{"empty", "", false},
+		{"main", "main", false},
+		{"master", "master", false},
+		{"develop", "develop", false},
+		{"SHA", "de0fac2e4500dabe0009e67214ff5f5447ce83dd", false},
+		{"bare v", "v", false},
+		{"pre-release -rc1", "v1.2.3-rc1", false},
+		{"pre-release +build", "v1.2.3+build", false},
+		{"latest", "latest", false},
 	}
 	for _, tt := range tests {
-		t.Run(tt.ref, func(t *testing.T) {
+		t.Run(tt.name, func(t *testing.T) {
 			if got := actions.IsTagRef(tt.ref); got != tt.want {
 				t.Errorf("IsTagRef(%q) = %v, want %v", tt.ref, got, tt.want)
 			}
@@ -40,22 +41,23 @@ func TestIsTagRef(t *testing.T) {
 
 func TestMajorOf(t *testing.T) {
 	tests := []struct {
+		name string
 		ref  string
 		want string
 	}{
-		{"v1", "v1"},
-		{"v2", "v2"},
-		{"v3.1", "v3"},
-		{"v4.2.0", "v4"},
-		{"1", "v1"},
-		{"1.2", "v1"},
-		{"1.2.3", "v1"},
-		{"main", ""},
-		{"", ""},
-		{"abc123", ""},
+		{"v1", "v1", "v1"},
+		{"v2", "v2", "v2"},
+		{"v3.1 → v3", "v3.1", "v3"},
+		{"v4.2.0 → v4", "v4.2.0", "v4"},
+		{"bare 1 → v1", "1", "v1"},
+		{"bare 1.2 → v1", "1.2", "v1"},
+		{"bare 1.2.3 → v1", "1.2.3", "v1"},
+		{"branch main → empty", "main", ""},
+		{"empty → empty", "", ""},
+		{"non-numeric → empty", "abc123", ""},
 	}
 	for _, tt := range tests {
-		t.Run(tt.ref, func(t *testing.T) {
+		t.Run(tt.name, func(t *testing.T) {
 			if got := actions.MajorOf(tt.ref); got != tt.want {
 				t.Errorf("MajorOf(%q) = %q, want %q", tt.ref, got, tt.want)
 			}
@@ -65,22 +67,23 @@ func TestMajorOf(t *testing.T) {
 
 func TestMatchesMajor(t *testing.T) {
 	tests := []struct {
+		name         string
 		pin          string
 		catalogMajor string
 		want         bool
 	}{
-		{"v2", "v2", true},
-		{"v2.3", "v2", true},
-		{"v2.3.1", "v2", true},
-		{"2", "v2", true},
-		{"v3", "v2", false},
-		{"main", "v2", false},
-		{"", "v2", false},
-		{"v11", "v1", false}, // major boundary
-		{"v1", "v11", false},
+		{"v2 matches v2", "v2", "v2", true},
+		{"v2.3 matches v2", "v2.3", "v2", true},
+		{"v2.3.1 matches v2", "v2.3.1", "v2", true},
+		{"bare 2 matches v2", "2", "v2", true},
+		{"v3 does not match v2", "v3", "v2", false},
+		{"branch does not match", "main", "v2", false},
+		{"empty does not match", "", "v2", false},
+		{"v11 does not match v1", "v11", "v1", false},
+		{"v1 does not match v11", "v1", "v11", false},
 	}
 	for _, tt := range tests {
-		t.Run(tt.pin+"_"+tt.catalogMajor, func(t *testing.T) {
+		t.Run(tt.name, func(t *testing.T) {
 			if got := actions.MatchesMajor(tt.pin, tt.catalogMajor); got != tt.want {
 				t.Errorf("MatchesMajor(%q, %q) = %v, want %v", tt.pin, tt.catalogMajor, got, tt.want)
 			}

--- a/internal/domain/actions/version_test.go
+++ b/internal/domain/actions/version_test.go
@@ -1,0 +1,89 @@
+package actions_test
+
+import (
+	"testing"
+
+	"github.com/future-architect/uzomuzo-oss/internal/domain/actions"
+)
+
+func TestIsTagRef(t *testing.T) {
+	tests := []struct {
+		ref  string
+		want bool
+	}{
+		{"v1", true},
+		{"v2", true},
+		{"v3.1", true},
+		{"v4.2.0", true},
+		{"1", true},
+		{"1.2", true},
+		{"1.2.3", true},
+		{"  v4  ", true}, // whitespace tolerated
+		{"", false},
+		{"main", false},
+		{"master", false},
+		{"develop", false},
+		{"de0fac2e4500dabe0009e67214ff5f5447ce83dd", false}, // SHA
+		{"v", false},
+		{"v1.2.3-rc1", false}, // pre-release rejected (out of scope)
+		{"v1.2.3+build", false},
+		{"latest", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.ref, func(t *testing.T) {
+			if got := actions.IsTagRef(tt.ref); got != tt.want {
+				t.Errorf("IsTagRef(%q) = %v, want %v", tt.ref, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMajorOf(t *testing.T) {
+	tests := []struct {
+		ref  string
+		want string
+	}{
+		{"v1", "v1"},
+		{"v2", "v2"},
+		{"v3.1", "v3"},
+		{"v4.2.0", "v4"},
+		{"1", "v1"},
+		{"1.2", "v1"},
+		{"1.2.3", "v1"},
+		{"main", ""},
+		{"", ""},
+		{"abc123", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.ref, func(t *testing.T) {
+			if got := actions.MajorOf(tt.ref); got != tt.want {
+				t.Errorf("MajorOf(%q) = %q, want %q", tt.ref, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMatchesMajor(t *testing.T) {
+	tests := []struct {
+		pin          string
+		catalogMajor string
+		want         bool
+	}{
+		{"v2", "v2", true},
+		{"v2.3", "v2", true},
+		{"v2.3.1", "v2", true},
+		{"2", "v2", true},
+		{"v3", "v2", false},
+		{"main", "v2", false},
+		{"", "v2", false},
+		{"v11", "v1", false}, // major boundary
+		{"v1", "v11", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.pin+"_"+tt.catalogMajor, func(t *testing.T) {
+			if got := actions.MatchesMajor(tt.pin, tt.catalogMajor); got != tt.want {
+				t.Errorf("MatchesMajor(%q, %q) = %v, want %v", tt.pin, tt.catalogMajor, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/domain/audit/entry.go
+++ b/internal/domain/audit/entry.go
@@ -43,4 +43,10 @@ type AuditEntry struct {
 	// ViaParents lists short names of direct dependencies through which this
 	// transitive dependency is pulled in. Populated when input is an SBOM.
 	ViaParents []string
+	// ActionRefs lists the distinct version refs (e.g., "v3", "v4", a commit SHA)
+	// pinned against this action across the scanned workflow(s). Populated only
+	// when Source is SourceActions, SourceActionsTransitive, or SourceActionsLocal.
+	// Callers use these refs to detect pinned-version deprecations that are not
+	// visible from repository-level evaluation alone.
+	ActionRefs []string
 }

--- a/internal/infrastructure/actionscan/discovery.go
+++ b/internal/infrastructure/actionscan/discovery.go
@@ -101,8 +101,8 @@ func NewDiscoveryService(githubClient *github.Client, maxConcurrency int) (*Disc
 //   - directURLs: actions referenced directly in workflow files
 //   - localActions: actions found inside local composite actions (URL → local path)
 //   - transitiveActions: actions found via composite action BFS (URL → parent action URL)
-//   - actionRefs: GitHub URL → sorted distinct version refs ("v3", "v4", SHA, ...) pinned across workflows.
-//     Empty for URLs where no ref was observed (e.g., local composite discovery).
+//   - actionRefs: GitHub URL → sorted distinct version refs ("v3", "v4", SHA, ...) observed across workflows
+//     and resolved local composite actions. URLs are omitted when no ref was observed.
 //
 // The returned slices are sorted lexicographically for deterministic output.
 // This method satisfies scan.ActionsDiscoverer.

--- a/internal/infrastructure/actionscan/discovery.go
+++ b/internal/infrastructure/actionscan/discovery.go
@@ -307,18 +307,22 @@ func (s *DiscoveryService) resolveTransitiveActions(ctx context.Context, initial
 			}
 
 			for _, ref := range refs {
+				ghURL := ref.GitHubURL()
+				// Always record the ref even if this action was already visited
+				// at a different version — distinct pins must propagate for
+				// deprecation detection.
+				result.addRef(ghURL, ref.Ref)
+
 				key := actionRefKey(ref)
 				if _, exists := seen[key]; exists {
 					continue
 				}
 				seen[key] = struct{}{}
 
-				ghURL := ref.GitHubURL()
 				if _, exists := result.Actions[ghURL]; !exists {
 					result.Actions[ghURL] = 1
 					transitiveActions[ghURL] = item.via
 				}
-				result.addRef(ghURL, ref.Ref)
 				queue = append(queue, queueItem{ref: ref, url: ghURL, via: item.via})
 			}
 		}

--- a/internal/infrastructure/actionscan/discovery.go
+++ b/internal/infrastructure/actionscan/discovery.go
@@ -26,6 +26,45 @@ type DiscoveryResult struct {
 	Actions map[string]int
 	// Errors collects non-fatal fetch/parse errors keyed by source URL or path.
 	Errors map[string]error
+	// refsByURL maps GitHub URL → set of distinct version refs (e.g., "v2", "v4", SHA)
+	// observed across all scanned workflows. Used internally for deduplication;
+	// converted to sorted slices when exposed to callers.
+	refsByURL map[string]map[string]struct{}
+}
+
+// addRef records a version ref observed for the given GitHub URL.
+// Empty refs are ignored. Safe for concurrent use only when called under the
+// caller's lock.
+func (r *DiscoveryResult) addRef(ghURL, ref string) {
+	if ref == "" {
+		return
+	}
+	if r.refsByURL == nil {
+		r.refsByURL = make(map[string]map[string]struct{})
+	}
+	set, ok := r.refsByURL[ghURL]
+	if !ok {
+		set = make(map[string]struct{})
+		r.refsByURL[ghURL] = set
+	}
+	set[ref] = struct{}{}
+}
+
+// sortedRefs returns the recorded refs as URL → sorted slice of distinct refs.
+func (r *DiscoveryResult) sortedRefs() map[string][]string {
+	if len(r.refsByURL) == 0 {
+		return nil
+	}
+	out := make(map[string][]string, len(r.refsByURL))
+	for u, set := range r.refsByURL {
+		refs := make([]string, 0, len(set))
+		for ref := range set {
+			refs = append(refs, ref)
+		}
+		sort.Strings(refs)
+		out[u] = refs
+	}
+	return out
 }
 
 // maxFileFetchConcurrency limits concurrent workflow file fetches within a single repository.
@@ -62,13 +101,16 @@ func NewDiscoveryService(githubClient *github.Client, maxConcurrency int) (*Disc
 //   - directURLs: actions referenced directly in workflow files
 //   - localActions: actions found inside local composite actions (URL → local path)
 //   - transitiveActions: actions found via composite action BFS (URL → parent action URL)
+//   - actionRefs: GitHub URL → sorted distinct version refs ("v3", "v4", SHA, ...) pinned across workflows.
+//     Empty for URLs where no ref was observed (e.g., local composite discovery).
 //
 // The returned slices are sorted lexicographically for deterministic output.
 // This method satisfies scan.ActionsDiscoverer.
-func (s *DiscoveryService) DiscoverActions(ctx context.Context, repoURLs []string, resolveTransitive bool) (directURLs []string, localActions map[string]string, transitiveActions map[string]string, errors map[string]error, err error) {
+func (s *DiscoveryService) DiscoverActions(ctx context.Context, repoURLs []string, resolveTransitive bool) (directURLs []string, localActions map[string]string, transitiveActions map[string]string, actionRefs map[string][]string, errors map[string]error, err error) {
 	result := &DiscoveryResult{
-		Actions: make(map[string]int),
-		Errors:  make(map[string]error),
+		Actions:   make(map[string]int),
+		Errors:    make(map[string]error),
+		refsByURL: make(map[string]map[string]struct{}),
 	}
 
 	localActions = make(map[string]string)
@@ -101,13 +143,18 @@ func (s *DiscoveryService) DiscoverActions(ctx context.Context, repoURLs []strin
 				return
 			}
 
-			urls, repoLocalActions, errs := s.discoverFromRepo(ctx, owner, repo)
+			urls, repoLocalActions, repoRefs, errs := s.discoverFromRepo(ctx, owner, repo)
 
 			mu.Lock()
 			for _, u := range urls {
 				if _, exists := result.Actions[u]; !exists {
 					result.Actions[u] = 0
 					directURLs = append(directURLs, u)
+				}
+			}
+			for u, refs := range repoRefs {
+				for _, ref := range refs {
+					result.addRef(u, ref)
 				}
 			}
 			if len(repoLocalActions) > 0 {
@@ -162,7 +209,7 @@ func (s *DiscoveryService) DiscoverActions(ctx context.Context, repoURLs []strin
 		"errors", len(result.Errors),
 	)
 
-	return directURLs, localActions, transitiveActions, result.Errors, nil
+	return directURLs, localActions, transitiveActions, result.sortedRefs(), result.Errors, nil
 }
 
 // actionRefKey returns a dedup key for BFS traversal that includes the subdirectory path.
@@ -271,6 +318,7 @@ func (s *DiscoveryService) resolveTransitiveActions(ctx context.Context, initial
 					result.Actions[ghURL] = 1
 					transitiveActions[ghURL] = item.via
 				}
+				result.addRef(ghURL, ref.Ref)
 				queue = append(queue, queueItem{ref: ref, url: ghURL, via: item.via})
 			}
 		}
@@ -310,18 +358,19 @@ func (s *DiscoveryService) fetchActionYAML(ctx context.Context, ref ghaworkflow.
 // Returns:
 //   - directURLs: external action URLs referenced directly in workflow files
 //   - localActions: external action URLs found inside local composite actions (URL → local path)
+//   - refs: GitHub URL → distinct version refs observed across this repo's workflows
 //   - errs: non-fatal errors keyed by source path
-func (s *DiscoveryService) discoverFromRepo(ctx context.Context, owner, repo string) (directURLs []string, localActions map[string]string, errs map[string]error) {
+func (s *DiscoveryService) discoverFromRepo(ctx context.Context, owner, repo string) (directURLs []string, localActions map[string]string, refs map[string][]string, errs map[string]error) {
 	errs = make(map[string]error)
 
 	entries, err := s.githubClient.FetchDirectoryContents(ctx, owner, repo, ".github/workflows")
 	if err != nil {
 		errs[fmt.Sprintf("%s/%s/.github/workflows", owner, repo)] = err
-		return nil, nil, errs
+		return nil, nil, nil, errs
 	}
 	if entries == nil {
 		slog.Debug("no .github/workflows directory", "owner", owner, "repo", repo)
-		return nil, nil, nil
+		return nil, nil, nil, nil
 	}
 
 	// Filter to YAML files only.
@@ -338,7 +387,7 @@ func (s *DiscoveryService) discoverFromRepo(ctx context.Context, owner, repo str
 
 	if len(yamlFiles) == 0 {
 		slog.Debug("no workflow YAML files found", "owner", owner, "repo", repo)
-		return nil, nil, nil
+		return nil, nil, nil, nil
 	}
 
 	slog.Debug("fetching workflow files", "owner", owner, "repo", repo, "count", len(yamlFiles))
@@ -346,6 +395,7 @@ func (s *DiscoveryService) discoverFromRepo(ctx context.Context, owner, repo str
 	seen := make(map[string]struct{})
 	var localPaths []string
 	localSeen := make(map[string]struct{})
+	refSets := make(map[string]map[string]struct{}) // URL → set of refs
 
 	// Fetch and parse workflow files concurrently to reduce sequential API latency.
 	var (
@@ -391,7 +441,7 @@ func (s *DiscoveryService) discoverFromRepo(ctx context.Context, owner, repo str
 				return // 404 — file disappeared between listing and fetch
 			}
 
-			urls, locals, parseErr := ghaworkflow.ParseWorkflowAll(data)
+			parsedRefs, locals, parseErr := ghaworkflow.ParseWorkflowAllWithRefs(data)
 			if parseErr != nil {
 				fileMu.Lock()
 				errs[fmt.Sprintf("%s/%s/%s", owner, repo, yf.Path)] = parseErr
@@ -400,10 +450,19 @@ func (s *DiscoveryService) discoverFromRepo(ctx context.Context, owner, repo str
 			}
 
 			fileMu.Lock()
-			for _, u := range urls {
+			for _, r := range parsedRefs {
+				u := r.GitHubURL()
 				if _, exists := seen[u]; !exists {
 					seen[u] = struct{}{}
 					directURLs = append(directURLs, u)
+				}
+				if r.Ref != "" {
+					set, ok := refSets[u]
+					if !ok {
+						set = make(map[string]struct{})
+						refSets[u] = set
+					}
+					set[r.Ref] = struct{}{}
 				}
 			}
 			for _, lp := range locals {
@@ -422,17 +481,42 @@ func (s *DiscoveryService) discoverFromRepo(ctx context.Context, owner, repo str
 	// Sort for deterministic BFS "first-seen wins" Via provenance.
 	if len(localPaths) > 0 {
 		sort.Strings(localPaths)
-		localActions = s.resolveLocalActions(ctx, owner, repo, localPaths, errs)
+		var localRefs map[string][]string
+		localActions, localRefs = s.resolveLocalActions(ctx, owner, repo, localPaths, errs)
+		for u, rs := range localRefs {
+			for _, r := range rs {
+				set, ok := refSets[u]
+				if !ok {
+					set = make(map[string]struct{})
+					refSets[u] = set
+				}
+				set[r] = struct{}{}
+			}
+		}
 	}
 
-	return directURLs, localActions, errs
+	if len(refSets) > 0 {
+		refs = make(map[string][]string, len(refSets))
+		for u, set := range refSets {
+			list := make([]string, 0, len(set))
+			for r := range set {
+				list = append(list, r)
+			}
+			sort.Strings(list)
+			refs[u] = list
+		}
+	}
+
+	return directURLs, localActions, refs, errs
 }
 
 // resolveLocalActions performs BFS over local composite actions within a repository,
 // fetching action.yml for each local path, extracting external action URLs, and
 // following nested local references (uses: ./) with cycle detection.
-// It returns a map of external GitHub URL → local action path that contained it (first-seen wins).
-func (s *DiscoveryService) resolveLocalActions(ctx context.Context, owner, repo string, initialPaths []string, errs map[string]error) map[string]string {
+// Returns:
+//   - externalActions: external GitHub URL → local action path that contained it (first-seen wins)
+//   - actionRefs: GitHub URL → distinct version refs pinned in the local composites
+func (s *DiscoveryService) resolveLocalActions(ctx context.Context, owner, repo string, initialPaths []string, errs map[string]error) (map[string]string, map[string][]string) {
 	seen := make(map[string]struct{})
 	for _, p := range initialPaths {
 		seen[p] = struct{}{}
@@ -441,6 +525,8 @@ func (s *DiscoveryService) resolveLocalActions(ctx context.Context, owner, repo 
 	queue := append([]string(nil), initialPaths...)
 	// external URL → originating local action path (first-seen wins)
 	externalActions := make(map[string]string)
+	// external URL → set of distinct refs pinned across local composites
+	refSets := make(map[string]map[string]struct{})
 
 	for len(queue) > 0 {
 		current := queue
@@ -467,6 +553,14 @@ func (s *DiscoveryService) resolveLocalActions(ctx context.Context, owner, repo 
 				if _, exists := externalActions[ghURL]; !exists {
 					externalActions[ghURL] = localPath
 				}
+				if ref.Ref != "" {
+					set, ok := refSets[ghURL]
+					if !ok {
+						set = make(map[string]struct{})
+						refSets[ghURL] = set
+					}
+					set[ref.Ref] = struct{}{}
+				}
 			}
 
 			for _, nested := range nestedLocals {
@@ -486,7 +580,20 @@ func (s *DiscoveryService) resolveLocalActions(ctx context.Context, owner, repo 
 		)
 	}
 
-	return externalActions
+	var actionRefs map[string][]string
+	if len(refSets) > 0 {
+		actionRefs = make(map[string][]string, len(refSets))
+		for u, set := range refSets {
+			list := make([]string, 0, len(set))
+			for r := range set {
+				list = append(list, r)
+			}
+			sort.Strings(list)
+			actionRefs[u] = list
+		}
+	}
+
+	return externalActions, actionRefs
 }
 
 // fetchLocalActionYAML fetches action.yml (or action.yaml as fallback) for a local action

--- a/internal/infrastructure/actionscan/discovery.go
+++ b/internal/infrastructure/actionscan/discovery.go
@@ -33,8 +33,8 @@ type DiscoveryResult struct {
 }
 
 // addRef records a version ref observed for the given GitHub URL.
-// Empty refs are ignored. Safe for concurrent use only when called under the
-// caller's lock.
+// Empty refs are ignored. Not goroutine-safe; callers must serialize access
+// (phase-1 callers hold `mu`; the transitive BFS path is single-goroutine).
 func (r *DiscoveryResult) addRef(ghURL, ref string) {
 	if ref == "" {
 		return
@@ -362,7 +362,8 @@ func (s *DiscoveryService) fetchActionYAML(ctx context.Context, ref ghaworkflow.
 // Returns:
 //   - directURLs: external action URLs referenced directly in workflow files
 //   - localActions: external action URLs found inside local composite actions (URL → local path)
-//   - refs: GitHub URL → distinct version refs observed across this repo's workflows
+//   - refs: GitHub URL → distinct sorted version refs observed across this repo's workflows
+//     (direct workflow pins merged with local-composite pins)
 //   - errs: non-fatal errors keyed by source path
 func (s *DiscoveryService) discoverFromRepo(ctx context.Context, owner, repo string) (directURLs []string, localActions map[string]string, refs map[string][]string, errs map[string]error) {
 	errs = make(map[string]error)

--- a/internal/infrastructure/actionscan/discovery_test.go
+++ b/internal/infrastructure/actionscan/discovery_test.go
@@ -37,7 +37,7 @@ func TestDiscoverActions_InvalidURLs(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	directURLs, localActions, transitiveActions, errs, err := svc.DiscoverActions(context.Background(), []string{"not-a-url", "https://gitlab.com/foo/bar"}, false)
+	directURLs, localActions, transitiveActions, _, errs, err := svc.DiscoverActions(context.Background(), []string{"not-a-url", "https://gitlab.com/foo/bar"}, false)
 	if err != nil {
 		t.Fatalf("DiscoverActions should not return fatal error: %v", err)
 	}
@@ -168,7 +168,7 @@ func TestDiscoverActions_EmptyInput(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	directURLs, localActions, transitiveActions, errs, err := svc.DiscoverActions(context.Background(), nil, false)
+	directURLs, localActions, transitiveActions, _, errs, err := svc.DiscoverActions(context.Background(), nil, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -253,7 +253,7 @@ func TestDiscoverFromRepo_ContextCancellation(t *testing.T) {
 	done.Add(1)
 	go func() {
 		defer done.Done()
-		resultURLs, _, resultErrs = svc.discoverFromRepo(ctx, "testowner", "testrepo")
+		resultURLs, _, _, resultErrs = svc.discoverFromRepo(ctx, "testowner", "testrepo")
 	}()
 
 	// Wait until all semaphore slots are occupied (maxFileFetchConcurrency goroutines

--- a/internal/infrastructure/actionscan/discovery_transitive_test.go
+++ b/internal/infrastructure/actionscan/discovery_transitive_test.go
@@ -131,15 +131,15 @@ runs:
 	routes := map[string][]byte{
 		"myorg/myrepo/.github/workflows":        directoryJSON(t, []string{"ci.yml"}),
 		"myorg/myrepo/.github/workflows/ci.yml": workflowYAML,
-		"alpha/action-a/action.yml":              compositeActionA,
-		"beta/action-b/action.yml":               nodeActionB,
+		"alpha/action-a/action.yml":             compositeActionA,
+		"beta/action-b/action.yml":              nodeActionB,
 	}
 
 	srv := fakeGitHubAPI(t, routes)
 	defer srv.Close()
 
 	svc := newTestService(t, srv.URL)
-	directURLs, _, transitiveActions, errs, err := svc.DiscoverActions(
+	directURLs, _, transitiveActions, _, errs, err := svc.DiscoverActions(
 		context.Background(),
 		[]string{"https://github.com/myorg/myrepo"},
 		true,
@@ -215,16 +215,16 @@ runs:
 	routes := map[string][]byte{
 		"myorg/myrepo/.github/workflows":        directoryJSON(t, []string{"ci.yml"}),
 		"myorg/myrepo/.github/workflows/ci.yml": workflowYAML,
-		"alpha/action-a/action.yml":              compositeA,
-		"beta/action-b/action.yml":               compositeB,
-		"gamma/action-c/action.yml":              nodeC,
+		"alpha/action-a/action.yml":             compositeA,
+		"beta/action-b/action.yml":              compositeB,
+		"gamma/action-c/action.yml":             nodeC,
 	}
 
 	srv := fakeGitHubAPI(t, routes)
 	defer srv.Close()
 
 	svc := newTestService(t, srv.URL)
-	directURLs, _, transitiveActions, _, err := svc.DiscoverActions(
+	directURLs, _, transitiveActions, _, _, err := svc.DiscoverActions(
 		context.Background(),
 		[]string{"https://github.com/myorg/myrepo"},
 		true,
@@ -286,15 +286,15 @@ runs:
 	routes := map[string][]byte{
 		"myorg/myrepo/.github/workflows":        directoryJSON(t, []string{"ci.yml"}),
 		"myorg/myrepo/.github/workflows/ci.yml": workflowYAML,
-		"alpha/action-a/action.yml":              compositeA,
-		"beta/action-b/action.yml":               compositeB,
+		"alpha/action-a/action.yml":             compositeA,
+		"beta/action-b/action.yml":              compositeB,
 	}
 
 	srv := fakeGitHubAPI(t, routes)
 	defer srv.Close()
 
 	svc := newTestService(t, srv.URL)
-	directURLs, _, transitiveActions, _, err := svc.DiscoverActions(
+	directURLs, _, transitiveActions, _, _, err := svc.DiscoverActions(
 		context.Background(),
 		[]string{"https://github.com/myorg/myrepo"},
 		true,
@@ -348,15 +348,15 @@ runs:
 	routes := map[string][]byte{
 		"myorg/myrepo/.github/workflows":        directoryJSON(t, []string{"ci.yml"}),
 		"myorg/myrepo/.github/workflows/ci.yml": workflowYAML,
-		"alpha/node-action/action.yml":           nodeAction,
-		"beta/docker-action/action.yml":          dockerAction,
+		"alpha/node-action/action.yml":          nodeAction,
+		"beta/docker-action/action.yml":         dockerAction,
 	}
 
 	srv := fakeGitHubAPI(t, routes)
 	defer srv.Close()
 
 	svc := newTestService(t, srv.URL)
-	directURLs, _, transitiveActions, _, err := svc.DiscoverActions(
+	directURLs, _, transitiveActions, _, _, err := svc.DiscoverActions(
 		context.Background(),
 		[]string{"https://github.com/myorg/myrepo"},
 		true,
@@ -410,7 +410,7 @@ runs:
 	defer srv.Close()
 
 	svc := newTestService(t, srv.URL)
-	directURLs, _, transitiveActions, _, err := svc.DiscoverActions(
+	directURLs, _, transitiveActions, _, _, err := svc.DiscoverActions(
 		context.Background(),
 		[]string{"https://github.com/myorg/myrepo"},
 		false, // disabled
@@ -461,7 +461,7 @@ runs:
 	defer srv.Close()
 
 	svc := newTestService(t, srv.URL)
-	directURLs, localActions, _, _, err := svc.DiscoverActions(
+	directURLs, localActions, _, _, _, err := svc.DiscoverActions(
 		context.Background(),
 		[]string{"https://github.com/myorg/myrepo"},
 		false, // transitive disabled — local resolution is part of Phase 1
@@ -521,17 +521,17 @@ runs:
 `)
 
 	routes := map[string][]byte{
-		"myorg/myrepo/.github/workflows":                    directoryJSON(t, []string{"ci.yml"}),
-		"myorg/myrepo/.github/workflows/ci.yml":             workflowYAML,
-		"myorg/myrepo/.github/actions/wrapper/action.yml":   wrapperComposite,
-		"myorg/myrepo/.github/actions/inner/action.yml":     innerComposite,
+		"myorg/myrepo/.github/workflows":                  directoryJSON(t, []string{"ci.yml"}),
+		"myorg/myrepo/.github/workflows/ci.yml":           workflowYAML,
+		"myorg/myrepo/.github/actions/wrapper/action.yml": wrapperComposite,
+		"myorg/myrepo/.github/actions/inner/action.yml":   innerComposite,
 	}
 
 	srv := fakeGitHubAPI(t, routes)
 	defer srv.Close()
 
 	svc := newTestService(t, srv.URL)
-	directURLs, localActions, _, _, err := svc.DiscoverActions(
+	directURLs, localActions, _, _, _, err := svc.DiscoverActions(
 		context.Background(),
 		[]string{"https://github.com/myorg/myrepo"},
 		false,
@@ -590,17 +590,17 @@ runs:
 `)
 
 	routes := map[string][]byte{
-		"myorg/myrepo/.github/workflows":                    directoryJSON(t, []string{"ci.yml"}),
-		"myorg/myrepo/.github/workflows/ci.yml":             workflowYAML,
-		"myorg/myrepo/.github/actions/action-a/action.yml":  localA,
-		"myorg/myrepo/.github/actions/action-b/action.yml":  localB,
+		"myorg/myrepo/.github/workflows":                   directoryJSON(t, []string{"ci.yml"}),
+		"myorg/myrepo/.github/workflows/ci.yml":            workflowYAML,
+		"myorg/myrepo/.github/actions/action-a/action.yml": localA,
+		"myorg/myrepo/.github/actions/action-b/action.yml": localB,
 	}
 
 	srv := fakeGitHubAPI(t, routes)
 	defer srv.Close()
 
 	svc := newTestService(t, srv.URL)
-	_, localActions, _, _, err := svc.DiscoverActions(
+	_, localActions, _, _, _, err := svc.DiscoverActions(
 		context.Background(),
 		[]string{"https://github.com/myorg/myrepo"},
 		false,
@@ -661,15 +661,15 @@ runs:
 		"myorg/myrepo/.github/workflows":                directoryJSON(t, []string{"ci.yml"}),
 		"myorg/myrepo/.github/workflows/ci.yml":         workflowYAML,
 		"myorg/myrepo/.github/actions/setup/action.yml": localSetup,
-		"alpha/action-a/action.yml":                      compositeA,
-		"beta/action-b/action.yml":                       nodeB,
+		"alpha/action-a/action.yml":                     compositeA,
+		"beta/action-b/action.yml":                      nodeB,
 	}
 
 	srv := fakeGitHubAPI(t, routes)
 	defer srv.Close()
 
 	svc := newTestService(t, srv.URL)
-	directURLs, localActions, transitiveActions, _, err := svc.DiscoverActions(
+	directURLs, localActions, transitiveActions, _, _, err := svc.DiscoverActions(
 		context.Background(),
 		[]string{"https://github.com/myorg/myrepo"},
 		true, // Enable transitive resolution
@@ -724,8 +724,8 @@ runs:
 `)
 
 	routes := map[string][]byte{
-		"myorg/myrepo/.github/workflows":                     directoryJSON(t, []string{"ci.yml"}),
-		"myorg/myrepo/.github/workflows/ci.yml":              workflowYAML,
+		"myorg/myrepo/.github/workflows":                      directoryJSON(t, []string{"ci.yml"}),
+		"myorg/myrepo/.github/workflows/ci.yml":               workflowYAML,
 		"myorg/myrepo/.github/actions/node-action/action.yml": nodeAction,
 	}
 
@@ -733,7 +733,7 @@ runs:
 	defer srv.Close()
 
 	svc := newTestService(t, srv.URL)
-	directURLs, _, _, _, err := svc.DiscoverActions(
+	directURLs, _, _, _, _, err := svc.DiscoverActions(
 		context.Background(),
 		[]string{"https://github.com/myorg/myrepo"},
 		false,
@@ -795,17 +795,17 @@ runs:
 	routes := map[string][]byte{
 		"myorg/myrepo/.github/workflows":        directoryJSON(t, []string{"ci.yml"}),
 		"myorg/myrepo/.github/workflows/ci.yml": workflowYAML,
-		"alpha/action-a/action.yml":              compositeA,
-		"beta/action-b/action.yml":               compositeB,
-		"gamma/action-c/action.yml":              compositeC,
-		"delta/action-d/action.yml":              nodeD,
+		"alpha/action-a/action.yml":             compositeA,
+		"beta/action-b/action.yml":              compositeB,
+		"gamma/action-c/action.yml":             compositeC,
+		"delta/action-d/action.yml":             nodeD,
 	}
 
 	srv := fakeGitHubAPI(t, routes)
 	defer srv.Close()
 
 	svc := newTestService(t, srv.URL)
-	_, _, transitiveActions, _, err := svc.DiscoverActions(
+	_, _, transitiveActions, _, _, err := svc.DiscoverActions(
 		context.Background(),
 		[]string{"https://github.com/myorg/myrepo"},
 		true,
@@ -878,18 +878,18 @@ runs:
 `)
 
 	routes := map[string][]byte{
-		"myorg/myrepo/.github/workflows":                  directoryJSON(t, []string{"ci.yml"}),
-		"myorg/myrepo/.github/workflows/ci.yml":           workflowYAML,
-		"myorg/myrepo/.github/actions/level1/action.yml":  level1,
-		"myorg/myrepo/.github/actions/level2/action.yml":  level2,
-		"myorg/myrepo/.github/actions/level3/action.yml":  level3,
+		"myorg/myrepo/.github/workflows":                 directoryJSON(t, []string{"ci.yml"}),
+		"myorg/myrepo/.github/workflows/ci.yml":          workflowYAML,
+		"myorg/myrepo/.github/actions/level1/action.yml": level1,
+		"myorg/myrepo/.github/actions/level2/action.yml": level2,
+		"myorg/myrepo/.github/actions/level3/action.yml": level3,
 	}
 
 	srv := fakeGitHubAPI(t, routes)
 	defer srv.Close()
 
 	svc := newTestService(t, srv.URL)
-	directURLs, localActions, _, _, err := svc.DiscoverActions(
+	directURLs, localActions, _, _, _, err := svc.DiscoverActions(
 		context.Background(),
 		[]string{"https://github.com/myorg/myrepo"},
 		false,
@@ -946,7 +946,7 @@ jobs:
 	defer srv.Close()
 
 	svc := newTestService(t, srv.URL)
-	directURLs, localActions, _, _, err := svc.DiscoverActions(
+	directURLs, localActions, _, _, _, err := svc.DiscoverActions(
 		context.Background(),
 		[]string{"https://github.com/myorg/myrepo"},
 		false,
@@ -1009,7 +1009,7 @@ runs:
 	defer srv.Close()
 
 	svc := newTestService(t, srv.URL)
-	directURLs, localActions, _, _, err := svc.DiscoverActions(
+	directURLs, localActions, _, _, _, err := svc.DiscoverActions(
 		context.Background(),
 		[]string{"https://github.com/myorg/myrepo"},
 		false,

--- a/internal/infrastructure/depparser/ghaworkflow/parser.go
+++ b/internal/infrastructure/depparser/ghaworkflow/parser.go
@@ -385,6 +385,12 @@ func ParseCompositeAll(data []byte) (refs []ActionRef, localPaths []string, isCo
 			if ref.Path != "" {
 				key += "/" + ref.Path
 			}
+			// Include @ref in the dedup key so a single composite step pinning
+			// the same action at multiple versions (e.g., @v2 and @v4) yields
+			// distinct ActionRef entries. This matches ParseWorkflowAllWithRefs
+			// and ParseCompositeActionURLs, keeping pinned-version deprecation
+			// detection consistent across every discovery path.
+			key += "@" + ref.Ref
 			if _, exists := refSeen[key]; !exists {
 				refSeen[key] = struct{}{}
 				refs = append(refs, ref)

--- a/internal/infrastructure/depparser/ghaworkflow/parser.go
+++ b/internal/infrastructure/depparser/ghaworkflow/parser.go
@@ -286,6 +286,7 @@ func ParseCompositeActionURLs(data []byte) (refs []ActionRef, isComposite bool, 
 		if ref.Path != "" {
 			key += "/" + ref.Path
 		}
+		key += "@" + ref.Ref
 		if _, exists := seen[key]; exists {
 			continue
 		}

--- a/internal/infrastructure/depparser/ghaworkflow/parser.go
+++ b/internal/infrastructure/depparser/ghaworkflow/parser.go
@@ -78,6 +78,37 @@ func ParseGitHubURLs(data []byte) ([]string, error) {
 // This avoids double-parsing for callers that need both results.
 // Jobs are iterated in sorted key order for deterministic output.
 func ParseWorkflowAll(data []byte) (urls []string, localPaths []string, err error) {
+	refs, localPaths, err := ParseWorkflowAllWithRefs(data)
+	if err != nil {
+		return nil, nil, err
+	}
+	seen := make(map[string]struct{}, len(refs))
+	urls = make([]string, 0, len(refs))
+	for _, r := range refs {
+		u := r.GitHubURL()
+		if _, exists := seen[u]; exists {
+			continue
+		}
+		seen[u] = struct{}{}
+		urls = append(urls, u)
+	}
+	return urls, localPaths, nil
+}
+
+// ParseWorkflowAllWithRefs reads a GitHub Actions workflow YAML file and returns
+// both the parsed ActionRef values (preserving owner/repo/path/ref) and the
+// step-level local action paths.
+//
+// Unlike ParseWorkflowAll, this function does NOT deduplicate by GitHub URL:
+// the same owner/repo pinned to different versions (e.g., actions/checkout@v2
+// and actions/checkout@v4 in different jobs) yields multiple ActionRef entries,
+// one per distinct (URL, Ref) pair. Callers that need URL-level deduplication
+// should aggregate the returned refs themselves.
+//
+// Local action paths are extracted only from step `uses:` values (matching
+// ParseLocalActionPaths); job-level `uses:` values are not included in localPaths.
+// Jobs are iterated in sorted key order for deterministic output.
+func ParseWorkflowAllWithRefs(data []byte) (refs []ActionRef, localPaths []string, err error) {
 	var wf workflowFile
 	if err := yaml.Unmarshal(data, &wf); err != nil {
 		return nil, nil, fmt.Errorf("failed to parse GitHub Actions workflow YAML: %w", err)
@@ -89,25 +120,32 @@ func ParseWorkflowAll(data []byte) (urls []string, localPaths []string, err erro
 	}
 	sort.Strings(jobNames)
 
-	urlSeen := make(map[string]struct{})
+	refSeen := make(map[string]struct{})
 	localSeen := make(map[string]struct{})
+
+	addRef := func(uses string) {
+		ref, ok := ExtractActionRef(uses)
+		if !ok {
+			return
+		}
+		key := ref.GitHubURL()
+		if ref.Path != "" {
+			key += "/" + ref.Path
+		}
+		key += "@" + ref.Ref
+		if _, exists := refSeen[key]; exists {
+			return
+		}
+		refSeen[key] = struct{}{}
+		refs = append(refs, ref)
+	}
 
 	for _, name := range jobNames {
 		j := wf.Jobs[name]
 		// Reusable workflow reference at job level (GitHub URLs only).
-		if u := extractGitHubURL(j.Uses); u != "" {
-			if _, exists := urlSeen[u]; !exists {
-				urlSeen[u] = struct{}{}
-				urls = append(urls, u)
-			}
-		}
+		addRef(j.Uses)
 		for _, s := range j.Steps {
-			if u := extractGitHubURL(s.Uses); u != "" {
-				if _, exists := urlSeen[u]; !exists {
-					urlSeen[u] = struct{}{}
-					urls = append(urls, u)
-				}
-			}
+			addRef(s.Uses)
 			if p := ExtractLocalActionPath(s.Uses); p != "" {
 				if _, exists := localSeen[p]; !exists {
 					localSeen[p] = struct{}{}
@@ -117,7 +155,7 @@ func ParseWorkflowAll(data []byte) (urls []string, localPaths []string, err erro
 		}
 	}
 
-	return urls, localPaths, nil
+	return refs, localPaths, nil
 }
 
 // extractGitHubURL converts a `uses:` value to a GitHub repository URL.

--- a/internal/infrastructure/depparser/ghaworkflow/parser_test.go
+++ b/internal/infrastructure/depparser/ghaworkflow/parser_test.go
@@ -571,6 +571,105 @@ jobs:
 	}
 }
 
+func TestParseWorkflowAllWithRefs(t *testing.T) {
+	type refExpect struct {
+		owner string
+		repo  string
+		path  string
+		ref   string
+	}
+	tests := []struct {
+		name     string
+		file     string
+		wantRefs []refExpect
+	}{
+		{
+			name: "deprecated pins fixture captures distinct refs per action",
+			file: "deprecated-pins.yml",
+			wantRefs: []refExpect{
+				{owner: "actions", repo: "checkout", ref: "v2"},
+				{owner: "actions", repo: "setup-node", ref: "v2"},
+				{owner: "actions", repo: "upload-artifact", ref: "v3"},
+				{owner: "actions", repo: "checkout", ref: "v4"},
+				{owner: "actions", repo: "setup-python", ref: "v5"},
+				{owner: "actions", repo: "cache", ref: "v3"},
+				{owner: "actions", repo: "cache", ref: "v4"},
+				{owner: "actions", repo: "checkout", ref: "main"},
+				{owner: "actions", repo: "checkout", ref: "de0fac2e4500dabe0009e67214ff5f5447ce83dd"},
+			},
+		},
+		{
+			name: "standard CI workflow (ref preserved)",
+			file: "ci.yml",
+			wantRefs: []refExpect{
+				{owner: "actions", repo: "checkout", ref: "v4"},
+				{owner: "actions", repo: "setup-go", ref: "v5"},
+				{owner: "golangci", repo: "golangci-lint-action", ref: "v6"},
+				{owner: "actions", repo: "checkout", ref: "de0fac2e4500dabe0009e67214ff5f5447ce83dd"},
+				{owner: "github", repo: "codeql-action", path: "init", ref: "v4"},
+				{owner: "github", repo: "codeql-action", path: "analyze", ref: "v4"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := os.ReadFile(filepath.Join("testdata", tt.file))
+			if err != nil {
+				t.Fatalf("failed to read testdata: %v", err)
+			}
+
+			refs, _, err := ghaworkflow.ParseWorkflowAllWithRefs(data)
+			if err != nil {
+				t.Fatalf("ParseWorkflowAllWithRefs() error = %v", err)
+			}
+
+			if len(refs) != len(tt.wantRefs) {
+				t.Fatalf("got %d refs, want %d\ngot:  %+v\nwant: %+v", len(refs), len(tt.wantRefs), refs, tt.wantRefs)
+			}
+
+			seen := make(map[refExpect]bool, len(tt.wantRefs))
+			for _, r := range refs {
+				key := refExpect{owner: r.Owner, repo: r.Repo, path: r.Path, ref: r.Ref}
+				seen[key] = true
+			}
+			for _, want := range tt.wantRefs {
+				if !seen[want] {
+					t.Errorf("missing ref %+v in %+v", want, refs)
+				}
+			}
+		})
+	}
+}
+
+func TestParseWorkflowAllWithRefs_MultiPinSameAction(t *testing.T) {
+	yaml := `
+on: push
+jobs:
+  a:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+  b:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+`
+	refs, _, err := ghaworkflow.ParseWorkflowAllWithRefs([]byte(yaml))
+	if err != nil {
+		t.Fatalf("ParseWorkflowAllWithRefs() error = %v", err)
+	}
+	// job b duplicates v2 — should be deduplicated. v2 and v4 remain as distinct refs.
+	if len(refs) != 2 {
+		t.Fatalf("want 2 distinct refs (v2,v4), got %d: %+v", len(refs), refs)
+	}
+	gotRefs := map[string]bool{refs[0].Ref: true, refs[1].Ref: true}
+	if !gotRefs["v2"] || !gotRefs["v4"] {
+		t.Errorf("expected both v2 and v4, got %+v", refs)
+	}
+}
+
 func TestParseCompositeLocalActionPaths(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/internal/infrastructure/depparser/ghaworkflow/parser_test.go
+++ b/internal/infrastructure/depparser/ghaworkflow/parser_test.go
@@ -670,6 +670,34 @@ jobs:
 	}
 }
 
+func TestParseCompositeAll_DistinctRefsForSameAction(t *testing.T) {
+	// A composite action that pins the same upstream action at two versions
+	// must surface both refs so pinned-version deprecation detection sees
+	// both. The dedup key therefore includes @ref.
+	yaml := `
+name: Build
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
+`
+	refs, _, isComposite, err := ghaworkflow.ParseCompositeAll([]byte(yaml))
+	if err != nil {
+		t.Fatalf("ParseCompositeAll() error = %v", err)
+	}
+	if !isComposite {
+		t.Fatal("expected composite action")
+	}
+	if len(refs) != 2 {
+		t.Fatalf("want 2 distinct refs (v2,v4), got %d: %+v", len(refs), refs)
+	}
+	got := map[string]bool{refs[0].Ref: true, refs[1].Ref: true}
+	if !got["v2"] || !got["v4"] {
+		t.Errorf("expected both v2 and v4, got %+v", refs)
+	}
+}
+
 func TestParseCompositeLocalActionPaths(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/internal/infrastructure/depparser/ghaworkflow/testdata/deprecated-pins.yml
+++ b/internal/infrastructure/depparser/ghaworkflow/testdata/deprecated-pins.yml
@@ -1,0 +1,25 @@
+name: Deprecated Pins Fixture
+on:
+  push:
+
+jobs:
+  legacy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+      - uses: actions/upload-artifact@v3
+
+  current:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+
+  refs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/cache@v3
+      - uses: actions/cache@v4
+      - uses: actions/checkout@main
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/internal/interfaces/cli/boxdraw.go
+++ b/internal/interfaces/cli/boxdraw.go
@@ -616,6 +616,14 @@ func writeBoxEOL(ctx *boxContext) error {
 			return err
 		}
 	}
+	// Surface the observed pinned refs for action-sourced entries so PR authors
+	// can see at a glance which @ref triggered the catalog verdict. Machine-
+	// readable formats (JSON/CSV) already carry this field.
+	if len(ctx.entry.ActionRefs) > 0 {
+		if err := writeLine(ctx, "📌 Pinned refs: %s", strings.Join(ctx.entry.ActionRefs, ", ")); err != nil {
+			return err
+		}
+	}
 	if a.EOL.Reason != "" {
 		if err := writeLine(ctx, "Catalog Reason: %s", a.EOL.Reason); err != nil {
 			return err

--- a/internal/interfaces/cli/scan_render.go
+++ b/internal/interfaces/cli/scan_render.go
@@ -401,8 +401,8 @@ type enrichedJSONEntry struct {
 	Reason string `json:"reason,omitempty"`
 	// EOLReason surfaces the authoritative EOL rationale from EOL.FinalReason(),
 	// covering catalog-based pinned-Action deprecations as well as registry signals.
-	EOLReason string `json:"eol_reason,omitempty"`
-	Error     string `json:"error,omitempty"`
+	EOLReason   string   `json:"eol_reason,omitempty"`
+	Error       string   `json:"error,omitempty"`
 	Source      string   `json:"source,omitempty"`
 	Via         string   `json:"via,omitempty"`
 	Relation    string   `json:"relation,omitempty"`

--- a/internal/interfaces/cli/scan_render.go
+++ b/internal/interfaces/cli/scan_render.go
@@ -398,9 +398,11 @@ type enrichedJSONEntry struct {
 	MaxTransitiveAdvisorySeverity string  `json:"max_transitive_advisory_severity,omitempty"`
 	MaxTransitiveCVSS3Score       float64 `json:"max_transitive_cvss3_score,omitempty"`
 
-	Reason      string   `json:"reason,omitempty"`
-	EOLReason   string   `json:"eol_reason,omitempty"`
-	Error       string   `json:"error,omitempty"`
+	Reason string `json:"reason,omitempty"`
+	// EOLReason surfaces the authoritative EOL rationale from EOL.FinalReason(),
+	// covering catalog-based pinned-Action deprecations as well as registry signals.
+	EOLReason string `json:"eol_reason,omitempty"`
+	Error     string `json:"error,omitempty"`
 	Source      string   `json:"source,omitempty"`
 	Via         string   `json:"via,omitempty"`
 	Relation    string   `json:"relation,omitempty"`

--- a/internal/interfaces/cli/scan_render.go
+++ b/internal/interfaces/cli/scan_render.go
@@ -399,11 +399,15 @@ type enrichedJSONEntry struct {
 	MaxTransitiveCVSS3Score       float64 `json:"max_transitive_cvss3_score,omitempty"`
 
 	Reason      string   `json:"reason,omitempty"`
+	EOLReason   string   `json:"eol_reason,omitempty"`
 	Error       string   `json:"error,omitempty"`
 	Source      string   `json:"source,omitempty"`
 	Via         string   `json:"via,omitempty"`
 	Relation    string   `json:"relation,omitempty"`
 	RelationVia []string `json:"relation_via,omitempty"`
+	// ActionRefs lists the distinct pinned refs (e.g., "v3", a commit SHA) for
+	// action-sourced entries. Omitted when no refs are known.
+	ActionRefs []string `json:"action_refs,omitempty"`
 }
 
 type enrichedJSONOutput struct {
@@ -449,6 +453,7 @@ func newEnrichedJSONEntry(e *domainaudit.AuditEntry) enrichedJSONEntry {
 		Via:         e.Via,
 		Relation:    e.Relation.String(),
 		RelationVia: e.ViaParents,
+		ActionRefs:  e.ActionRefs,
 	}
 
 	a := e.Analysis
@@ -495,6 +500,7 @@ func newEnrichedJSONEntry(e *domainaudit.AuditEntry) enrichedJSONEntry {
 	if lr := a.GetLifecycleResult(); lr != nil {
 		je.Reason = lr.Reason
 	}
+	je.EOLReason = a.EOL.FinalReason()
 	if br := a.GetBuildHealthResult(); br != nil && br.Label != "" {
 		je.BuildIntegrity = br.Label
 		if scoreStr, ok := br.Meta["score"]; ok && scoreStr != "" && scoreStr != domain.ScoreUngraded {
@@ -519,7 +525,7 @@ func renderScanCSV(w io.Writer, entries []domainaudit.AuditEntry) error {
 	}
 	header = append(header, "lifecycle", "build_integrity", "build_integrity_score", "successor", "advisory_count", "max_advisory_severity", "max_cvss3_score",
 		"direct_advisory_count", "transitive_advisory_count", "max_transitive_advisory_severity", "max_transitive_cvss3_score",
-		"repo_url", "source", "via")
+		"repo_url", "source", "via", "action_refs", "eol_reason")
 	if err := cw.Write(header); err != nil {
 		return fmt.Errorf("failed to write CSV header: %w", err)
 	}
@@ -573,9 +579,13 @@ func renderScanCSV(w io.Writer, entries []domainaudit.AuditEntry) error {
 		if showRelation {
 			row = append(row, e.Relation.String(), strings.Join(e.ViaParents, ";"))
 		}
+		eolReason := ""
+		if a := e.Analysis; a != nil {
+			eolReason = a.EOL.FinalReason()
+		}
 		row = append(row, maintenance, buildIntegrity, buildIntegrityScore, successor, advisoryCount, maxSeverity, maxCVSS3Score,
 			directAdvisoryCount, transitiveAdvisoryCount, maxTransitiveSeverity, maxTransitiveCVSS3Score,
-			repoURL, string(e.Source), e.Via)
+			repoURL, string(e.Source), e.Via, strings.Join(e.ActionRefs, ";"), eolReason)
 		if err := cw.Write(row); err != nil {
 			return fmt.Errorf("failed to write CSV row for %s: %w", e.PURL, err)
 		}

--- a/internal/interfaces/cli/scan_render_test.go
+++ b/internal/interfaces/cli/scan_render_test.go
@@ -132,12 +132,19 @@ func TestRenderScanCSV(t *testing.T) {
 	if !strings.Contains(lines[0], "lifecycle") {
 		t.Errorf("CSV header = %q, want to contain 'lifecycle'", lines[0])
 	}
-	for _, removed := range []string{"eol", "eol_reason"} {
+	for _, removed := range []string{"eol"} {
 		for _, col := range strings.Split(lines[0], ",") {
 			if col == removed {
 				t.Errorf("CSV header should not contain removed column %q, got header: %s", removed, lines[0])
 			}
 		}
+	}
+	// eol_reason is re-added to surface pinned-Action deprecation rationale in machine-readable output.
+	if !strings.Contains(lines[0], "eol_reason") {
+		t.Errorf("CSV header should contain 'eol_reason' column, got: %s", lines[0])
+	}
+	if !strings.Contains(lines[0], "action_refs") {
+		t.Errorf("CSV header should contain 'action_refs' column, got: %s", lines[0])
 	}
 }
 


### PR DESCRIPTION
## Summary

Extend `--include-actions` to catch pinned version deprecations (e.g., `actions/upload-artifact@v3` — force-EOL'd 2025-01-30; `actions/checkout@v2` — Node 12 runtime EOL 2023-06-30) that repository-level evaluation misses. Adds a static, source-cited catalog in `internal/domain/actions/` and propagates the `@ref` suffix through the scan pipeline so every action-sourced entry can be matched.

## Why this matters

Before this PR, scans of goreleaser, gitleaks, flask, jabref, and axios returned **zero `replace` verdicts** under `--include-actions`, because the parser captured refs but the evaluator discarded them. GitHub-announced force-EOL majors remained invisible. This PR closes that gap with auditable, date-bearing evidence suitable for upgrade-PR bodies.

## Key design choices

- **Additive data flow**: new `AuditEntry.ActionRefs`, new `actionRefs map[string][]string` return from `DiscoverActions`, new `eol_reason` + `action_refs` JSON/CSV fields. Nothing removed.
- **Catalog lives in domain layer**: pure data + `Lookup` / `IsTagRef` / `MatchesMajor` helpers, no I/O, no external deps.
- **Catalog applied in Application layer** (`applyActionPinCatalog` in `scan/service.go`) — not via the `AnalysisEnricher` hook, because refs are not on `Analysis` (keeping that generic type ecosystem-neutral).
- **SHA / branch pins skip detection** and fall back to repo-level evaluation — deterministic, no false positives.
- **Seed scope is intentionally small** (3 action families at release): every entry carries a verifiable `ReferenceURL` to the GitHub announcement; tests enforce URL validity and that the `Reason` mentions the `EOLDate`.

Full rationale and rejected alternatives in [ADR-0016](docs/adr/0016-action-pin-version-eol-detection.md).

## What's out of scope

- SHA → tag resolution via GitHub API (deferred; repo-level verdict still applies).
- The `--file .github/workflows/ci.yml` path (still uses the URL-only parser; tracked separately).
- Auto-fetch of deprecation announcements (YAGNI — 2-3 events/year, static catalog is auditable in review).

## Test plan

- [x] `ParseWorkflowAllWithRefs` preserves `@ref` across standard, multi-pin, and SHA-pinned fixtures
- [x] Catalog invariants: valid `ReferenceURL`, suggested version not self-deprecated, reason contains EOL date
- [x] `applyActionPinCatalog` flips deprecated pin → `VerdictReplace` with `ActionPinCatalog` evidence
- [x] Current pin (v4) untouched; SHA pin untouched; branch pin untouched; non-action source untouched
- [x] Mixed pins (v2 + v4) flip on any deprecated ref
- [x] CSV/JSON expose `eol_reason` + `action_refs`
- [x] All pre-existing tests still pass (`go test ./...`), `go vet ./...` clean

## Validation on real OSS (2026-04-20)

Rescanned the 5 Tier-1 candidates with the PR build (`uzomuzo scan <url> --include-actions --format json`). All 5 returned `replace: 0`, for two distinct and expected reasons:

| Repo | Total | OK | Caution | Replace | Tag refs | SHA refs | Branch refs | Why catalog silent |
|---|---:|---:|---:|---:|---:|---:|---:|---|
| `goreleaser/goreleaser` | 38 | 34 | 3 | 0 | 0 | 37 | 0 | SHA pins (deterministic fallback to repo-level) |
| `gitleaks/gitleaks` | 9 | 8 | 1 | 0 | 0 | 8 | 0 | SHA pins |
| `pallets/flask` | 10 | 10 | 0 | 0 | 0 | 9 | 0 | SHA pins |
| `JabRef/jabref` | 49 | 40 | 9 | 0 | 41 | 2 | 3 | Tag pins on **current** majors only (`checkout@v6`, `upload-artifact@v6`/`v7`, `download-artifact@v8`) — none in `DeprecatedMajors` |
| `axios/axios` | 11 | 11 | 0 | 0 | 0 | 10 | 0 | SHA pins |

Catalog-covered actions discovered across all 5 repos (checkout / upload-artifact / download-artifact): every usage is either a SHA (4 of 5 repos) or a current-major tag (JabRef). Zero catalog hits on any — the catalog stays silent exactly where it should.

### Interpretation

1. **No false positives on best-practice repos.** 4 of 5 Tier-1 repos follow Scorecard-recommended SHA pinning; the 5th uses tag pins but only on current majors. The catalog correctly abstains in both cases.
2. **ADR-0016 §Consequences validated in the field.** "SHA-pinned actions remain invisible" is now observable data, not just a design note.
3. **Catalog value lies outside Tier 1.** The positive path — flipping `checkout@v2` or `upload-artifact@v3` to `VerdictReplace` — is covered by unit tests and will trip on the long tail of repos that pin by tag but haven't migrated to `@v4`.

### Implication for follow-up work

- The SHA → tag resolver deferred in ADR-0016 §Alternative E is what closes the Tier-1 gap; prioritize it if the PR-outreach initiative targets SHA-pinning repos.
- For outreach-ready findings now, candidate targets are repos that still tag-pin to `checkout@v1/v2`, `upload-artifact@v1-v3`, `download-artifact@v1-v3`. A broader dogfood sweep (Tier 2/3 + long tail) is the next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
