### PR TITLE
fix: populate Repository.Language from GitHub primaryLanguage (#326)

### DIFF
--- a/docs/data-flow.md
+++ b/docs/data-flow.md
@@ -90,8 +90,8 @@ Returns Project info for each projectKey (e.g., github.com/owner/repo):
 
 #### GitHub — GraphQL (POST https://api.github.com/graphql)
 
-- Query repository(owner, name) fields: `isArchived`, `isDisabled`, `isFork`, `stargazerCount`, `forkCount`, `description`, `homepageUrl`, `licenseInfo{spdxId, name}`, `repositoryTopics(first:20){nodes{topic{name}}}`, `defaultBranchRef{name, target{... on Commit { history(first:N){nodes{committedDate, author{user{login}}}}}}}`, `rateLimit{cost, remaining, resetAt}`
-- Purpose: Evaluate repository state (archived/disabled/fork), recent commit activity, and surface metadata (description → Repository.Summary, topics → Repository.Topics)
+- Query repository(owner, name) fields: `isArchived`, `isDisabled`, `isFork`, `stargazerCount`, `forkCount`, `description`, `homepageUrl`, `primaryLanguage{name}`, `licenseInfo{spdxId, name}`, `repositoryTopics(first:20){nodes{topic{name}}}`, `defaultBranchRef{name, target{... on Commit { history(first:N){nodes{committedDate, author{user{login}}}}}}}`, `rateLimit{cost, remaining, resetAt}`
+- Purpose: Evaluate repository state (archived/disabled/fork), recent commit activity, and surface metadata (description → Repository.Summary, topics → Repository.Topics, primaryLanguage → Repository.Language)
 - Code:
   - Basic info query: `Client.FetchBasicRepositoryInfo` (`internal/infrastructure/github/client.go`)
   - Batch orchestration: `Client.fetchRepositoryStatesBatch` (package-internal)

--- a/internal/infrastructure/github/client.go
+++ b/internal/infrastructure/github/client.go
@@ -49,6 +49,9 @@ type repoResult struct {
 	homepage      string
 	license       *LicenseInfo // newly captured licenseInfo (spdxId/name) to avoid extra query
 	defaultBranch string
+	// language is the GitHub-reported primary language (e.g., "Go", "Python").
+	// Empty when the repository has no detected language.
+	language string
 	// topics is non-nil (possibly empty) on a successful fetch. Stays nil when
 	// the result represents an error so downstream callers can distinguish
 	// "fetched, none" from "not fetched". See domain.Repository.Topics.
@@ -136,6 +139,7 @@ func (c *Client) FetchBasicRepositoryInfo(ctx context.Context, owner, repo strin
 		    forkCount
 		    description
 		    homepageUrl
+		    primaryLanguage { name }
 		    licenseInfo { spdxId name }
 		    repositoryTopics(first: 20) { nodes { topic { name } } }
 		    parent { nameWithOwner }
@@ -200,6 +204,7 @@ func (c *Client) FetchDetailedRepositoryInfo(ctx context.Context, owner, repo st
 		    forkCount
 		    description
 		    homepageUrl
+		    primaryLanguage { name }
 		    licenseInfo { spdxId name }
 		    repositoryTopics(first: 20) { nodes { topic { name } } }
 		    parent { nameWithOwner }
@@ -362,6 +367,9 @@ func (c *Client) FetchRepositoryStates(ctx context.Context, analyses map[string]
 			if analysis.Repository.DefaultBranch == "" && meta.defaultBranch != "" {
 				analysis.Repository.DefaultBranch = meta.defaultBranch
 			}
+			if analysis.Repository.Language == "" && meta.language != "" {
+				analysis.Repository.Language = meta.language
+			}
 			// License enrichment: fallback only (do not override canonical deps.dev SPDX values).
 			if meta.license != nil {
 				if updated, changed := enrichProjectLicenseFromGitHub(analysis.ProjectLicense, meta.license); changed {
@@ -478,6 +486,7 @@ func (c *Client) fetchRepositoryStatesBatch(ctx context.Context, repoURLs []stri
 				homepage:      result.homepage,
 				license:       result.license,
 				defaultBranch: result.defaultBranch,
+				language:      result.language,
 				topics:        result.topics,
 			}
 		}
@@ -637,6 +646,7 @@ func (c *Client) githubWorker(ctx context.Context, batchCancel context.CancelFun
 			homepage:      repoInfo.HomepageURL,
 			license:       repoInfo.LicenseInfo,
 			defaultBranch: repoInfo.DefaultBranchRef.Name,
+			language:      primaryLanguageName(repoInfo.PrimaryLanguage),
 			topics:        collectTopics(repoInfo.RepositoryTopics),
 		}
 
@@ -769,6 +779,16 @@ func collectTopics(c RepositoryTopicConnection) []string {
 		}
 	}
 	return topics
+}
+
+// primaryLanguageName returns the GitHub-reported primary language name, or "" when
+// the GraphQL primaryLanguage field is null (e.g. empty repos, docs-only repos) or
+// when the returned name is blank/whitespace-only.
+func primaryLanguageName(p *PrimaryLanguage) string {
+	if p == nil {
+		return ""
+	}
+	return strings.TrimSpace(p.Name)
 }
 
 // forkSourceFromRepoInfo extracts the parent repository name ("owner/repo") from a

--- a/internal/infrastructure/github/language_test.go
+++ b/internal/infrastructure/github/language_test.go
@@ -1,0 +1,120 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	domain "github.com/future-architect/uzomuzo-oss/internal/domain/analysis"
+)
+
+func TestPrimaryLanguageName(t *testing.T) {
+	tests := []struct {
+		name string
+		in   *PrimaryLanguage
+		want string
+	}{
+		{name: "nil_returns_empty", in: nil, want: ""},
+		{name: "blank_returns_empty", in: &PrimaryLanguage{Name: "  "}, want: ""},
+		{name: "trims_whitespace", in: &PrimaryLanguage{Name: " Go "}, want: "Go"},
+		{name: "passes_through", in: &PrimaryLanguage{Name: "Python"}, want: "Python"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := primaryLanguageName(tt.in); got != tt.want {
+				t.Errorf("primaryLanguageName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFetchRepositoryStates_PopulatesLanguageWhenPresent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprint(w, graphqlResponseBody(graphqlTestRepo{
+			Description:     "A library",
+			PrimaryLanguage: "Go",
+		}))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	repoURL := "https://github.com/owner/repo"
+	analyses := map[string]*domain.Analysis{
+		repoURL: {RepoURL: repoURL},
+	}
+
+	if err := c.FetchRepositoryStates(context.Background(), analyses); err != nil {
+		t.Fatalf("FetchRepositoryStates: %v", err)
+	}
+
+	got := analyses[repoURL].Repository
+	if got == nil {
+		t.Fatalf("expected Repository populated")
+	}
+	if got.Language != "Go" {
+		t.Errorf("Repository.Language = %q, want %q", got.Language, "Go")
+	}
+}
+
+// TestFetchRepositoryStates_LeavesLanguageEmptyWhenNull verifies that a null
+// primaryLanguage (e.g., empty repos, docs-only repos) leaves Language as "".
+func TestFetchRepositoryStates_LeavesLanguageEmptyWhenNull(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprint(w, graphqlResponseBody(graphqlTestRepo{
+			Description: "A docs-only repo",
+			// PrimaryLanguage left empty → serialized as null.
+		}))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	repoURL := "https://github.com/owner/docs"
+	analyses := map[string]*domain.Analysis{
+		repoURL: {RepoURL: repoURL},
+	}
+
+	if err := c.FetchRepositoryStates(context.Background(), analyses); err != nil {
+		t.Fatalf("FetchRepositoryStates: %v", err)
+	}
+
+	got := analyses[repoURL].Repository
+	if got == nil {
+		t.Fatalf("expected Repository populated")
+	}
+	if got.Language != "" {
+		t.Errorf("Repository.Language = %q, want empty when primaryLanguage is null", got.Language)
+	}
+}
+
+// TestFetchRepositoryStates_PreservesPreExistingLanguage ensures that an
+// already-set Language is not overwritten by GitHub enrichment, mirroring the
+// guard used for DefaultBranch and other Repository metadata fields.
+func TestFetchRepositoryStates_PreservesPreExistingLanguage(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprint(w, graphqlResponseBody(graphqlTestRepo{
+			Description:     "A library",
+			PrimaryLanguage: "Go",
+		}))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL)
+	repoURL := "https://github.com/owner/repo"
+	analyses := map[string]*domain.Analysis{
+		repoURL: {
+			RepoURL:    repoURL,
+			Repository: &domain.Repository{URL: repoURL, Language: "Rust"},
+		},
+	}
+
+	if err := c.FetchRepositoryStates(context.Background(), analyses); err != nil {
+		t.Fatalf("FetchRepositoryStates: %v", err)
+	}
+
+	got := analyses[repoURL].Repository
+	if got.Language != "Rust" {
+		t.Errorf("Repository.Language = %q, want %q (pre-existing value must not be overwritten)", got.Language, "Rust")
+	}
+}

--- a/internal/infrastructure/github/topics_test.go
+++ b/internal/infrastructure/github/topics_test.go
@@ -99,10 +99,11 @@ func newTestClient(t *testing.T, baseURL string) *Client {
 }
 
 // graphqlResponse encodes a minimal GraphQL response carrying the fields exercised
-// by the topics tests.
+// by the topics and language tests.
 type graphqlTestRepo struct {
-	Description string
-	Topics      []string
+	Description     string
+	Topics          []string
+	PrimaryLanguage string // empty string serializes the GraphQL field as null
 }
 
 func graphqlResponseBody(repo graphqlTestRepo) string {
@@ -112,6 +113,10 @@ func graphqlResponseBody(repo graphqlTestRepo) string {
 			topicNodes += ","
 		}
 		topicNodes += fmt.Sprintf(`{"topic":{"name":%q}}`, name)
+	}
+	primaryLanguage := "null"
+	if repo.PrimaryLanguage != "" {
+		primaryLanguage = fmt.Sprintf(`{"name":%q}`, repo.PrimaryLanguage)
 	}
 	return fmt.Sprintf(`{
 	  "data": {
@@ -123,6 +128,7 @@ func graphqlResponseBody(repo graphqlTestRepo) string {
 	      "forkCount": 1,
 	      "description": %q,
 	      "homepageUrl": "",
+	      "primaryLanguage": %s,
 	      "licenseInfo": null,
 	      "repositoryTopics": {"nodes": [%s]},
 	      "parent": null,
@@ -130,7 +136,7 @@ func graphqlResponseBody(repo graphqlTestRepo) string {
 	    },
 	    "rateLimit": {"cost":1,"remaining":4999,"resetAt":"2099-01-01T00:00:00Z"}
 	  }
-	}`, repo.Description, topicNodes)
+	}`, repo.Description, primaryLanguage, topicNodes)
 }
 
 func TestFetchRepositoryStates_PopulatesTopicsWhenPresent(t *testing.T) {

--- a/internal/infrastructure/github/types.go
+++ b/internal/infrastructure/github/types.go
@@ -31,9 +31,17 @@ type RepositoryInfo struct {
 	DependencyGraphManifests DependencyGraphManifests  `json:"dependencyGraphManifests"`
 	LicenseInfo              *LicenseInfo              `json:"licenseInfo"`
 	RepositoryTopics         RepositoryTopicConnection `json:"repositoryTopics"`
+	// PrimaryLanguage is GitHub's GraphQL repository.primaryLanguage. Nil when the
+	// repository has no detected language (e.g., empty repos or markdown-only docs).
+	PrimaryLanguage *PrimaryLanguage `json:"primaryLanguage,omitempty"`
 	// Parent is the immediate parent repository from which this repo was forked (GitHub GraphQL "parent" field).
 	// Nil when the repository is not a fork, or when the parent is private/inaccessible.
 	Parent *ParentInfo `json:"parent,omitempty"`
+}
+
+// PrimaryLanguage carries the GitHub-reported primary language for a repository.
+type PrimaryLanguage struct {
+	Name string `json:"name"`
 }
 
 // RepositoryTopicConnection mirrors the GraphQL repositoryTopics connection.
@@ -61,6 +69,7 @@ type repoMeta struct {
 	homepage      string
 	license       *LicenseInfo
 	defaultBranch string
+	language      string
 	topics        []string
 }
 

--- a/internal/infrastructure/github/types.go
+++ b/internal/infrastructure/github/types.go
@@ -41,6 +41,7 @@ type RepositoryInfo struct {
 
 // PrimaryLanguage carries the GitHub-reported primary language for a repository.
 type PrimaryLanguage struct {
+	// Name is the language display name as reported by GitHub (e.g., "Go", "Python").
 	Name string `json:"name"`
 }
 


### PR DESCRIPTION
## Summary

- Closes #326. `domain.Repository.Language` was defined but never populated by any production code, so consumers always observed `""`.
- Adds `repository.primaryLanguage { name }` to the existing GraphQL queries that already drive batch repo enrichment, and threads the value end-to-end through `RepositoryInfo → repoResult → repoMeta → analysis.Repository.Language` — mirroring the existing plumbing for `Topics`, `DefaultBranch`, etc.
- Chose GraphQL over the REST `/languages` endpoint already wrapped as `Client.FetchRepoLanguages`: zero extra GraphQL points (vs. N additional REST calls per batch), single-string semantics match the domain field, and the GHES/httptest base-URL knob flows naturally. `FetchRepoLanguages` is left intact since `inferPURLFromLanguages` still needs the byte-count map for ecosystem detection from URLs.

## Design

Discussed and validated with the architect agent before implementing. Pattern matches the existing `Topics`/`DefaultBranch` flow exactly. Change is fully scoped to `internal/infrastructure/github/`; domain/application/interfaces untouched.

## Test plan

- [x] `GOWORK=off go test ./...` — all green
- [x] `GOWORK=off go vet ./...` — clean
- [x] `GOWORK=off golangci-lint run ./internal/infrastructure/github/...` — 0 issues
- [x] New unit test `TestPrimaryLanguageName` covers nil / blank / trim / pass-through
- [x] New integration tests assert: language populated when present, empty when GraphQL `primaryLanguage` is null, pre-existing `Repository.Language` not overwritten
- [x] `docs/data-flow.md` updated to reflect the new GraphQL field and metadata mapping

🤖 Generated with [Claude Code](https://claude.com/claude-code)