### PR TITLE
ci: take control of Copilot review lifecycle (re-review on push + clean label)

### DIFF
--- a/.claude/rules/copilot-learned-coding.md
+++ b/.claude/rules/copilot-learned-coding.md
@@ -152,10 +152,9 @@ pending_patterns:
 ```
 
 <!-- Promotion history (kept for audit trail):
-  # defensive-coding: promoted to copilot-learned-coding.instructions.md (PRs #324, #338 — u.Hostname() for port-safe host comparison + go-import prefix matching + CI trigger path constraint enforcement + generous pagination page sizes)
+  # defensive-coding: promoted to copilot-learned-coding.instructions.md (PRs #324, #338 — u.Hostname() for port-safe host comparison + go-import prefix matching per Go module spec)
+  # defensive-coding: newly authored in copilot-learned-coding.instructions.md (PR #338 — Enforce Access Constraints on All CI Trigger Paths + generous pagination page sizes in verification queries)
   # security: promoted to security.instructions.md (PRs #276, #324 — normalize hostnames in SSRF denylists/cache keys: strip trailing dots + lowercase + IPv6 zone IDs before denylist checks and cache-key construction)
-  # defensive-coding (PR #324): pending — u.Hostname() vs u.Host for port-safe host comparison (first occurrence, flagged twice in same PR: resolve_vanity.go and resolve.go)
-  # defensive-coding (PR #324): pending — go-import prefix matching per Go module spec for multi-entry vanity pages (first occurrence)
   # comment-doc-drift (PR #324): already covered by promoted rule — dedup comment overstated resolver cache normalization scope (trailing slash/path casing)
   # defensive-coding: promoted to copilot-learned-coding.instructions.md (PRs #318, #324 — enforce HTTP client hardening on all code paths: CheckRedirect on injected clients, transient 408/429 classification, redirect off-by-one)
   # defensive-coding (PR #324): already covered by "Use Case-Insensitive Comparison for URL Components" — hostOf used case-sensitive HasPrefix for scheme detection

--- a/.claude/rules/copilot-learned-coding.md
+++ b/.claude/rules/copilot-learned-coding.md
@@ -109,6 +109,11 @@ pending_patterns:
     pr: 318
     file: "internal/infrastructure/integration/populate_project_test.go"
     date: "2026-04-20"
+  - category: "defensive-coding"
+    summary: "Sanitize shell variables before embedding in GitHub Actions ::warning:: workflow commands — multi-line content or :: sequences break command parsing and can inject accidental workflow commands; emit a short single-line warning and log the full payload separately"
+    pr: 338
+    file: ".github/workflows/copilot-clean-label.yml"
+    date: "2026-04-28"
   - category: "comment-doc-drift"
     summary: "graphqlEndpoint comment claimed BaseURL controls 'both REST and GraphQL paths' but FetchRepoLanguages still hardcodes api.github.com — scope claims to the APIs that actually honor the knob"
     pr: 318

--- a/.claude/rules/copilot-learned-coding.md
+++ b/.claude/rules/copilot-learned-coding.md
@@ -15,6 +15,7 @@ Rules extracted from recurring Copilot review patterns on coding-standards topic
 - **Reject Flags That Silently Have No Effect**: When a CLI flag only applies to a specific input mode (e.g., `--sample` for PURL list files), explicitly reject it with a clear error when the input is a different mode (e.g., go.mod or SBOM). Do not silently ignore the flag — users assume their flags take effect.
 - **Deduplicate Inputs Before Batch API Calls**: When accepting user-provided input lists (PURLs, URLs) that feed into batch API calls, deduplicate them while preserving first-seen order before processing. Duplicates cause redundant external calls, skew logging/counts, and waste resources.
 - **Normalize User-Provided Enum Values**: When accepting string values for format selectors, mode switches, or other enums from CLI flags, normalize with `strings.TrimSpace(strings.ToLower(...))` before validation. Case-sensitive matching rejects common inputs like `--format JSON` or `--format "json "`.
+- **Enforce Access Constraints on All CI Trigger Paths**: When a CI workflow guards against cross-repository or fork PRs on the `pull_request` trigger (e.g., `head.repo.full_name == github.repository`), enforce the same constraint in code paths reachable by other triggers (`schedule`, `workflow_dispatch`) that bypass the trigger-level guard. Unguarded paths can fire privileged operations (e.g., GraphQL mutations with a PAT) on fork PRs, causing auth failures or unintended side effects. Similarly, use generous page sizes (e.g., `first:100` instead of `first:20`) in paginated API verification queries to avoid false negatives that trigger unnecessary retries.
 - **Interface Contract Documentation Must Match Signature Semantics**: When documenting an interface method, the doc comment must accurately reflect the method's full signature — including error returns, nil semantics, and parameter constraints. If the signature returns `(T, error)`, do not document it as "returns nil/empty on failure" — state that errors may be returned and describe the caller's expected handling (e.g., non-fatal/graceful degradation). Mismatched contract documentation misleads implementers and callers.
 - **GitHub Actions `||` Treats Empty as Falsy**: When a workflow input documents "empty = X behavior", do not use `${{ inputs.foo || 'default' }}` — the `||` operator treats empty string as falsy and applies the default, preventing users from intentionally selecting the empty option. Instead, pass the raw input via an env var and apply defaults conditionally (e.g., only for scheduled triggers).
 - **Guard Downstream Jobs Against Missing Outputs**: When a CI job produces outputs that downstream jobs depend on (exit codes, flags), gate downstream jobs on `needs.<job>.outputs.<key> != ''` to prevent execution when the upstream job fails before setting outputs. Otherwise, empty values may be misinterpreted (e.g., empty exit code `""` compared with `!= "0"` evaluates to true, creating misleading reports).
@@ -47,6 +48,7 @@ Rules extracted from recurring Copilot review patterns on coding-standards topic
 - **Gate Fallback Logic on Error, Not Result Nilness**: When deciding whether to trigger fallback or retry logic, check the error value — not whether the result is nil. A nil result with nil error is a valid success case (e.g., zero matches found), and treating it as a failure triggers unnecessary retries or incorrect fallback paths.
 - **Minimize Allocations in Hot Paths**: In batch-processing or frequently-called functions, avoid unnecessary O(n) allocations when only a subset of data is needed. Cache results of expensive parsing calls when the same value is checked multiple times in a loop iteration, and iterate to a known cutoff point rather than materializing the full collection (e.g., iterate runes up to a count rather than converting the entire string to `[]rune`).
 - **Use Structured Parsers for Structured Identifier Properties**: When checking properties of structured identifiers (PURLs, URIs, import paths), use the appropriate parser rather than naive string operations (`strings.Contains`, `strings.Split`). For example, `strings.Contains(purl, "@")` misclassifies npm scoped packages like `pkg:npm/@scope/name` as versioned because `@` appears in the namespace. Use `packageurl.FromString(p).Version != ""` or an equivalent parser-based check.
+- **Use `u.Hostname()` for Port-Safe Host Comparison**: When comparing URL hostnames, use `u.Hostname()` instead of `u.Host`. The `Host` field includes the port component (e.g., `github.com:443`), so direct string comparison against a bare hostname fails silently, misclassifying URLs and triggering unnecessary fallback processing. Similarly, when parsing multi-entry `go-import`/`go-source` meta tags, select the entry whose import prefix most specifically matches the requested path per the Go module spec — blindly taking the first match can resolve to the wrong repository on monorepo vanity pages.
 - **Use Case-Insensitive Comparison for URL Components**: When comparing URL components (scheme, host), use case-insensitive comparison per RFC 3986 — schemes (`HTTP://`) and hosts (`GitHub.COM`) are case-insensitive. Normalize with `strings.ToLower` or `strings.EqualFold` before prefix checks or host matching to avoid double-prefixing or missed matches.
 - **Structured Logging Conventions**: When adding `slog` calls: use DEBUG level for routine per-item telemetry (reserve INFO for exceptional events); use `snake_case` for event names (not spaces) for consistency and filterability; choose field key names that accurately describe the data across all call sites (e.g., `"ref"` not `"purl"` when the function handles both PURLs and URLs).
 - **Match Validation Format Strings to Production Format Strings**: When a validation or check function mirrors a production function's output (e.g., marker validation vs. marker replacement), use the exact same format strings and delimiters. Mismatched formats allow invalid input to pass validation silently.
@@ -142,19 +144,15 @@ pending_patterns:
     pr: 140
     file: "internal/infrastructure/depparser/detect.go"
     date: "2026-04-05"
-  - category: "defensive-coding"
-    summary: "Use u.Hostname() instead of u.Host when comparing hostnames — u.Host includes the port component, so github.com:443 != github.com misclassifies URLs and triggers unnecessary processing"
-    pr: 324
-    file: "internal/infrastructure/integration/resolve_vanity.go"
-    date: "2026-04-21"
-  - category: "defensive-coding"
-    summary: "When parsing multi-entry go-import/go-source meta tags, select the most specific prefix matching the requested import path per the Go module spec — blindly taking the first match can resolve to the wrong repository on monorepo vanity pages"
-    pr: 324
-    file: "internal/infrastructure/govanityresolve/resolve.go"
-    date: "2026-04-21"
+  - category: "api-consistency"
+    summary: "Redundant gh pr view API call to fetch labels when pr_json from repos/.../pulls already contains label data — reuse already-fetched API response data instead of making redundant calls for a subset of the same information"
+    pr: 338
+    file: ".github/workflows/copilot-clean-label.yml"
+    date: "2026-04-27"
 ```
 
 <!-- Promotion history (kept for audit trail):
+  # defensive-coding: promoted to copilot-learned-coding.instructions.md (PRs #324, #338 — u.Hostname() for port-safe host comparison + go-import prefix matching + CI trigger path constraint enforcement + generous pagination page sizes)
   # security: promoted to security.instructions.md (PRs #276, #324 — normalize hostnames in SSRF denylists/cache keys: strip trailing dots + lowercase + IPv6 zone IDs before denylist checks and cache-key construction)
   # defensive-coding (PR #324): pending — u.Hostname() vs u.Host for port-safe host comparison (first occurrence, flagged twice in same PR: resolve_vanity.go and resolve.go)
   # defensive-coding (PR #324): pending — go-import prefix matching per Go module spec for multi-entry vanity pages (first occurrence)

--- a/.github/instructions/copilot-learned-coding.instructions.md
+++ b/.github/instructions/copilot-learned-coding.instructions.md
@@ -150,10 +150,9 @@ pending_patterns:
 ```
 
 <!-- Promotion history (kept for audit trail):
-  # defensive-coding: promoted to copilot-learned-coding.instructions.md (PRs #324, #338 — u.Hostname() for port-safe host comparison + go-import prefix matching + CI trigger path constraint enforcement + generous pagination page sizes)
+  # defensive-coding: promoted to copilot-learned-coding.instructions.md (PRs #324, #338 — u.Hostname() for port-safe host comparison + go-import prefix matching per Go module spec)
+  # defensive-coding: newly authored in copilot-learned-coding.instructions.md (PR #338 — Enforce Access Constraints on All CI Trigger Paths + generous pagination page sizes in verification queries)
   # security: promoted to security.instructions.md (PRs #276, #324 — normalize hostnames in SSRF denylists/cache keys: strip trailing dots + lowercase + IPv6 zone IDs before denylist checks and cache-key construction)
-  # defensive-coding (PR #324): pending — u.Hostname() vs u.Host for port-safe host comparison (first occurrence, flagged twice in same PR: resolve_vanity.go and resolve.go)
-  # defensive-coding (PR #324): pending — go-import prefix matching per Go module spec for multi-entry vanity pages (first occurrence)
   # comment-doc-drift (PR #324): already covered by promoted rule — dedup comment overstated resolver cache normalization scope (trailing slash/path casing)
   # defensive-coding: promoted to copilot-learned-coding.instructions.md (PRs #318, #324 — enforce HTTP client hardening on all code paths: CheckRedirect on injected clients, transient 408/429 classification, redirect off-by-one)
   # defensive-coding (PR #324): already covered by "Use Case-Insensitive Comparison for URL Components" — hostOf used case-sensitive HasPrefix for scheme detection

--- a/.github/instructions/copilot-learned-coding.instructions.md
+++ b/.github/instructions/copilot-learned-coding.instructions.md
@@ -107,6 +107,11 @@ pending_patterns:
     pr: 318
     file: "internal/infrastructure/integration/populate_project_test.go"
     date: "2026-04-20"
+  - category: "defensive-coding"
+    summary: "Sanitize shell variables before embedding in GitHub Actions ::warning:: workflow commands — multi-line content or :: sequences break command parsing and can inject accidental workflow commands; emit a short single-line warning and log the full payload separately"
+    pr: 338
+    file: ".github/workflows/copilot-clean-label.yml"
+    date: "2026-04-28"
   - category: "comment-doc-drift"
     summary: "graphqlEndpoint comment claimed BaseURL controls 'both REST and GraphQL paths' but FetchRepoLanguages still hardcodes api.github.com — scope claims to the APIs that actually honor the knob"
     pr: 318

--- a/.github/instructions/copilot-learned-coding.instructions.md
+++ b/.github/instructions/copilot-learned-coding.instructions.md
@@ -13,6 +13,7 @@ Rules extracted from recurring Copilot review patterns on coding-standards topic
 - **Reject Flags That Silently Have No Effect**: When a CLI flag only applies to a specific input mode (e.g., `--sample` for PURL list files), explicitly reject it with a clear error when the input is a different mode (e.g., go.mod or SBOM). Do not silently ignore the flag — users assume their flags take effect.
 - **Deduplicate Inputs Before Batch API Calls**: When accepting user-provided input lists (PURLs, URLs) that feed into batch API calls, deduplicate them while preserving first-seen order before processing. Duplicates cause redundant external calls, skew logging/counts, and waste resources.
 - **Normalize User-Provided Enum Values**: When accepting string values for format selectors, mode switches, or other enums from CLI flags, normalize with `strings.TrimSpace(strings.ToLower(...))` before validation. Case-sensitive matching rejects common inputs like `--format JSON` or `--format "json "`.
+- **Enforce Access Constraints on All CI Trigger Paths**: When a CI workflow guards against cross-repository or fork PRs on the `pull_request` trigger (e.g., `head.repo.full_name == github.repository`), enforce the same constraint in code paths reachable by other triggers (`schedule`, `workflow_dispatch`) that bypass the trigger-level guard. Unguarded paths can fire privileged operations (e.g., GraphQL mutations with a PAT) on fork PRs, causing auth failures or unintended side effects. Similarly, use generous page sizes (e.g., `first:100` instead of `first:20`) in paginated API verification queries to avoid false negatives that trigger unnecessary retries.
 - **Interface Contract Documentation Must Match Signature Semantics**: When documenting an interface method, the doc comment must accurately reflect the method's full signature — including error returns, nil semantics, and parameter constraints. If the signature returns `(T, error)`, do not document it as "returns nil/empty on failure" — state that errors may be returned and describe the caller's expected handling (e.g., non-fatal/graceful degradation). Mismatched contract documentation misleads implementers and callers.
 - **GitHub Actions `||` Treats Empty as Falsy**: When a workflow input documents "empty = X behavior", do not use `${{ inputs.foo || 'default' }}` — the `||` operator treats empty string as falsy and applies the default, preventing users from intentionally selecting the empty option. Instead, pass the raw input via an env var and apply defaults conditionally (e.g., only for scheduled triggers).
 - **Guard Downstream Jobs Against Missing Outputs**: When a CI job produces outputs that downstream jobs depend on (exit codes, flags), gate downstream jobs on `needs.<job>.outputs.<key> != ''` to prevent execution when the upstream job fails before setting outputs. Otherwise, empty values may be misinterpreted (e.g., empty exit code `""` compared with `!= "0"` evaluates to true, creating misleading reports).
@@ -45,6 +46,7 @@ Rules extracted from recurring Copilot review patterns on coding-standards topic
 - **Gate Fallback Logic on Error, Not Result Nilness**: When deciding whether to trigger fallback or retry logic, check the error value — not whether the result is nil. A nil result with nil error is a valid success case (e.g., zero matches found), and treating it as a failure triggers unnecessary retries or incorrect fallback paths.
 - **Minimize Allocations in Hot Paths**: In batch-processing or frequently-called functions, avoid unnecessary O(n) allocations when only a subset of data is needed. Cache results of expensive parsing calls when the same value is checked multiple times in a loop iteration, and iterate to a known cutoff point rather than materializing the full collection (e.g., iterate runes up to a count rather than converting the entire string to `[]rune`).
 - **Use Structured Parsers for Structured Identifier Properties**: When checking properties of structured identifiers (PURLs, URIs, import paths), use the appropriate parser rather than naive string operations (`strings.Contains`, `strings.Split`). For example, `strings.Contains(purl, "@")` misclassifies npm scoped packages like `pkg:npm/@scope/name` as versioned because `@` appears in the namespace. Use `packageurl.FromString(p).Version != ""` or an equivalent parser-based check.
+- **Use `u.Hostname()` for Port-Safe Host Comparison**: When comparing URL hostnames, use `u.Hostname()` instead of `u.Host`. The `Host` field includes the port component (e.g., `github.com:443`), so direct string comparison against a bare hostname fails silently, misclassifying URLs and triggering unnecessary fallback processing. Similarly, when parsing multi-entry `go-import`/`go-source` meta tags, select the entry whose import prefix most specifically matches the requested path per the Go module spec — blindly taking the first match can resolve to the wrong repository on monorepo vanity pages.
 - **Use Case-Insensitive Comparison for URL Components**: When comparing URL components (scheme, host), use case-insensitive comparison per RFC 3986 — schemes (`HTTP://`) and hosts (`GitHub.COM`) are case-insensitive. Normalize with `strings.ToLower` or `strings.EqualFold` before prefix checks or host matching to avoid double-prefixing or missed matches.
 - **Structured Logging Conventions**: When adding `slog` calls: use DEBUG level for routine per-item telemetry (reserve INFO for exceptional events); use `snake_case` for event names (not spaces) for consistency and filterability; choose field key names that accurately describe the data across all call sites (e.g., `"ref"` not `"purl"` when the function handles both PURLs and URLs).
 - **Match Validation Format Strings to Production Format Strings**: When a validation or check function mirrors a production function's output (e.g., marker validation vs. marker replacement), use the exact same format strings and delimiters. Mismatched formats allow invalid input to pass validation silently.
@@ -140,19 +142,15 @@ pending_patterns:
     pr: 140
     file: "internal/infrastructure/depparser/detect.go"
     date: "2026-04-05"
-  - category: "defensive-coding"
-    summary: "Use u.Hostname() instead of u.Host when comparing hostnames — u.Host includes the port component, so github.com:443 != github.com misclassifies URLs and triggers unnecessary processing"
-    pr: 324
-    file: "internal/infrastructure/integration/resolve_vanity.go"
-    date: "2026-04-21"
-  - category: "defensive-coding"
-    summary: "When parsing multi-entry go-import/go-source meta tags, select the most specific prefix matching the requested import path per the Go module spec — blindly taking the first match can resolve to the wrong repository on monorepo vanity pages"
-    pr: 324
-    file: "internal/infrastructure/govanityresolve/resolve.go"
-    date: "2026-04-21"
+  - category: "api-consistency"
+    summary: "Redundant gh pr view API call to fetch labels when pr_json from repos/.../pulls already contains label data — reuse already-fetched API response data instead of making redundant calls for a subset of the same information"
+    pr: 338
+    file: ".github/workflows/copilot-clean-label.yml"
+    date: "2026-04-27"
 ```
 
 <!-- Promotion history (kept for audit trail):
+  # defensive-coding: promoted to copilot-learned-coding.instructions.md (PRs #324, #338 — u.Hostname() for port-safe host comparison + go-import prefix matching + CI trigger path constraint enforcement + generous pagination page sizes)
   # security: promoted to security.instructions.md (PRs #276, #324 — normalize hostnames in SSRF denylists/cache keys: strip trailing dots + lowercase + IPv6 zone IDs before denylist checks and cache-key construction)
   # defensive-coding (PR #324): pending — u.Hostname() vs u.Host for port-safe host comparison (first occurrence, flagged twice in same PR: resolve_vanity.go and resolve.go)
   # defensive-coding (PR #324): pending — go-import prefix matching per Go module spec for multi-entry vanity pages (first occurrence)

--- a/.github/workflows/copilot-clean-label.yml
+++ b/.github/workflows/copilot-clean-label.yml
@@ -126,19 +126,26 @@ jobs:
             [ -z "$pr" ] && continue
             echo "::group::PR #$pr"
 
-            # Single fetch of PR metadata: author + head SHA in one call.
+            # Single fetch of PR metadata: author + head SHA + labels + node_id.
             if ! pr_json=$(gh api "repos/$REPO/pulls/$pr" 2>&1); then
-              echo "::warning::failed to fetch PR metadata: $pr_json"
+              echo "::warning::PR #$pr: failed to fetch PR metadata: $pr_json"
               echo "::endgroup::"
               continue
             fi
             author=$(printf '%s' "$pr_json" | jq -r '.user.login')
             head_sha=$(printf '%s' "$pr_json" | jq -r '.head.sha')
+            head_repo=$(printf '%s' "$pr_json" | jq -r '.head.repo.full_name // ""')
 
-            # Defensive author check — schedule/workflow_dispatch reach here
-            # without the job-level `if:` guard.
+            # Defensive author + same-repo check — schedule/workflow_dispatch
+            # reach here without the job-level `if:` guard. Fork PRs cannot
+            # access GH_ACTIONS_TOKEN, so we skip them to avoid spurious 401s.
             if [ "$author" != "kotakanbe" ]; then
               echo "skip: author=$author"
+              echo "::endgroup::"
+              continue
+            fi
+            if [ "$head_repo" != "$REPO" ]; then
+              echo "skip: head_repo=$head_repo (not same-repo)"
               echo "::endgroup::"
               continue
             fi
@@ -147,7 +154,7 @@ jobs:
             # `gh api --paginate --jq` evaluates per-page, which would return
             # the per-page last instead of the global last.
             if ! reviews_json=$(gh api --paginate "repos/$REPO/pulls/$pr/reviews" 2>&1); then
-              echo "::warning::failed to fetch reviews: $reviews_json"
+              echo "::warning::PR #$pr: failed to fetch reviews: $reviews_json"
               echo "::endgroup::"
               continue
             fi
@@ -172,11 +179,9 @@ jobs:
               fi
             fi
 
-            if ! current_labels=$(gh pr view "$pr" --repo "$REPO" --json labels --jq '.labels[].name' 2>&1); then
-              echo "::warning::failed to fetch labels: $current_labels"
-              echo "::endgroup::"
-              continue
-            fi
+            # Reuse the labels already returned by the pulls/$pr fetch above
+            # rather than making a second API call (gh pr view --json labels).
+            current_labels=$(printf '%s' "$pr_json" | jq -r '.labels[].name')
             has_label=0
             if printf '%s\n' "$current_labels" | grep -qFx "$LABEL"; then
               has_label=1
@@ -238,14 +243,28 @@ jobs:
                     | sort_by(.created_at) | last
                     | .created_at // ""
                   ')
+                  # Compute age in minutes; treat both "no event ever" and
+                  # "unparseable timestamp" as definitely-stuck. `date -d` is
+                  # split out so a parse failure does not kill the arithmetic
+                  # under `set -euo pipefail`.
+                  refire_stuck=0
                   if [ -z "$last_request" ]; then
-                    age_min=99999
+                    echo "stuck detector: no prior review_requested event for Copilot"
+                    refire_stuck=1
+                  elif ! last_epoch=$(date -d "$last_request" +%s 2>/dev/null); then
+                    echo "::warning::PR #$pr: cannot parse last_request timestamp '$last_request' — treating as stuck"
+                    refire_stuck=1
                   else
-                    age_min=$(( ($(date +%s) - $(date -d "$last_request" +%s)) / 60 ))
+                    age_min=$(( ($(date +%s) - last_epoch) / 60 ))
+                    if [ "$age_min" -ge "$STUCK_THRESHOLD_MIN" ]; then
+                      refire_stuck=1
+                    else
+                      echo "stuck detector: last review_requested was ${age_min}min ago (< ${STUCK_THRESHOLD_MIN}min) — skipping refire"
+                    fi
                   fi
-                  if [ "$age_min" -ge "$STUCK_THRESHOLD_MIN" ]; then
+                  if [ "$refire_stuck" = "1" ]; then
                     pr_node_id=$(printf '%s' "$pr_json" | jq -r '.node_id')
-                    echo "stuck detector: last review_requested was ${age_min}min ago — refiring requestReviews"
+                    echo "stuck detector: refiring requestReviews"
                     if ! refire=$(gh api graphql \
                       -f query='mutation($pr:ID!,$bot:ID!){requestReviews(input:{pullRequestId:$pr, botIds:[$bot]}){pullRequest{id}}}' \
                       -f pr="$pr_node_id" \
@@ -254,8 +273,6 @@ jobs:
                     else
                       echo "stuck detector: refire ok"
                     fi
-                  else
-                    echo "stuck detector: last review_requested was ${age_min}min ago (< ${STUCK_THRESHOLD_MIN}min) — skipping refire"
                   fi
                 fi
                 ;;

--- a/.github/workflows/copilot-clean-label.yml
+++ b/.github/workflows/copilot-clean-label.yml
@@ -1,0 +1,265 @@
+name: Copilot Clean Label
+
+# Apply the `copilot-clean` label to a PR when its latest Copilot review on the
+# current HEAD reports no (new) comments, matching `generated no( new)? comments`
+# (case-insensitive). Remove the label otherwise. Driven by cron (every 10 min)
+# because `pull_request_review` (submitted) does not fire for Copilot since the
+# 2026-03-05 agentic-architecture migration. The `synchronize` event handles
+# instant label removal on new commits.
+#
+# Labels owned by this workflow: `copilot-clean` (read+write).
+# Other Copilot-related labels (e.g. `copilot-review` consumed by
+# copilot-review-fix.yml) are NOT touched here.
+
+on:
+  schedule:
+    - cron: '*/10 * * * *'
+  pull_request:
+    types: [opened, reopened, synchronize]
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: 'PR number (optional; default: scan all open kotakanbe PRs)'
+        required: false
+        type: string
+
+permissions: {}
+
+# Per-PR groups let synchronize/cron run in parallel across different PRs.
+# Targeted workflow_dispatch (with `inputs.pr`) joins its own per-PR bucket so
+# manual single-PR runs aren't blocked by a global scan. Schedule and untargeted
+# dispatch share the `'cron'` bucket to serialize global scans against each
+# other (avoids racing label edits on the same PR set).
+concurrency:
+  group: copilot-clean-label-${{ github.event.pull_request.number || inputs.pr || 'cron' }}
+  cancel-in-progress: false
+
+jobs:
+  apply:
+    # Same-repo, kotakanbe-authored PRs only. Fork PRs cannot access
+    # `GH_ACTIONS_TOKEN`. Schedule and workflow_dispatch reach this job
+    # without a `pull_request` context — both are allowed.
+    if: >-
+      github.event_name == 'schedule'
+      || github.event_name == 'workflow_dispatch'
+      || (
+        github.event.pull_request.user.login == 'kotakanbe'
+        && github.event.pull_request.head.repo.full_name == github.repository
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      pull-requests: write
+    env:
+      # PAT (kotakanbe), not GITHUB_TOKEN: GraphQL `requestReviews` for the
+      # Copilot bot silently no-ops under GITHUB_TOKEN (200 OK with data, no
+      # `review_requested` event). The cron stuck detector below depends on
+      # the mutation actually taking effect. Same secret as copilot-review-fix.yml.
+      GH_TOKEN: ${{ secrets.GH_ACTIONS_TOKEN }}
+      REPO: ${{ github.repository }}
+      LABEL: copilot-clean
+      # The bot login as it appears in the REST `/pulls/.../reviews` payload.
+      # GitHub uses three different forms for the same Copilot bot across
+      # APIs and we MUST match each precisely:
+      #   REST review.user.login            = 'copilot-pull-request-reviewer[bot]'  (used here)
+      #   GraphQL Bot.login (node lookup)   = 'copilot-pull-request-reviewer'       (no [bot])
+      #   Timeline requested_reviewer.login = 'Copilot'                             (display form)
+      # Do not "unify" them — each form is correct only for its own API.
+      COPILOT_BOT: 'copilot-pull-request-reviewer[bot]'
+      # GraphQL node ID for the Copilot bot. Used by the stuck-PR detector
+      # below to re-fire requestReviews when the push-event mutation was
+      # deduped. See `copilot-rereview-on-push.yml` for full discovery context.
+      COPILOT_BOT_ID: 'BOT_kgDOCnlnWA'
+      # The exact Copilot summary phrases that mean "no findings" — both
+      # `generated no comments` (initial review) and `generated no new comments`
+      # (re-review). Case-insensitive in the matcher below as a safety net.
+      CLEAN_PHRASE_ERE: 'generated no( new)? comments'
+      # Stuck-PR detector threshold. If the latest `review_requested` event
+      # for Copilot is older than this (and HEAD has no Copilot review yet),
+      # re-fire the mutation. 5 min sits comfortably outside the observed
+      # short-lived dedup window when paired with the cron's 10 min period.
+      STUCK_THRESHOLD_MIN: '5'
+    steps:
+      - name: Resolve target PR list
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_PR: ${{ github.event.pull_request.number }}
+          INPUT_PR: ${{ inputs.pr }}
+        run: |
+          set -euo pipefail
+          case "$EVENT_NAME" in
+            pull_request)
+              printf '%s\n' "$EVENT_PR" > prs.txt
+              ;;
+            workflow_dispatch)
+              if [ -n "${INPUT_PR:-}" ]; then
+                # Reject non-numeric input to prevent path traversal in
+                # subsequent `gh api repos/.../pulls/$pr` calls.
+                case "$INPUT_PR" in
+                  ''|*[!0-9]*)
+                    echo "invalid pr input: '$INPUT_PR' (must be numeric)" >&2
+                    exit 1
+                    ;;
+                esac
+                printf '%s\n' "$INPUT_PR" > prs.txt
+              else
+                gh pr list --repo "$REPO" --state open --author kotakanbe \
+                  --json number --jq '.[].number' > prs.txt
+              fi
+              ;;
+            schedule)
+              gh pr list --repo "$REPO" --state open --author kotakanbe \
+                --json number --jq '.[].number' > prs.txt
+              ;;
+            *)
+              echo "unknown event: $EVENT_NAME" >&2
+              exit 1
+              ;;
+          esac
+          echo "Target PRs:"
+          cat prs.txt
+
+      - name: Apply or remove label
+        run: |
+          set -euo pipefail
+          while IFS= read -r pr; do
+            [ -z "$pr" ] && continue
+            echo "::group::PR #$pr"
+
+            # Single fetch of PR metadata: author + head SHA in one call.
+            if ! pr_json=$(gh api "repos/$REPO/pulls/$pr" 2>&1); then
+              echo "::warning::failed to fetch PR metadata: $pr_json"
+              echo "::endgroup::"
+              continue
+            fi
+            author=$(printf '%s' "$pr_json" | jq -r '.user.login')
+            head_sha=$(printf '%s' "$pr_json" | jq -r '.head.sha')
+
+            # Defensive author check — schedule/workflow_dispatch reach here
+            # without the job-level `if:` guard.
+            if [ "$author" != "kotakanbe" ]; then
+              echo "skip: author=$author"
+              echo "::endgroup::"
+              continue
+            fi
+
+            # Aggregate paginated reviews into one array, then sort+last.
+            # `gh api --paginate --jq` evaluates per-page, which would return
+            # the per-page last instead of the global last.
+            if ! reviews_json=$(gh api --paginate "repos/$REPO/pulls/$pr/reviews" 2>&1); then
+              echo "::warning::failed to fetch reviews: $reviews_json"
+              echo "::endgroup::"
+              continue
+            fi
+            latest=$(printf '%s' "$reviews_json" | jq -s --arg bot "$COPILOT_BOT" '
+              add | [.[] | select(.user.login == $bot)] | sort_by(.submitted_at) | last
+            ')
+
+            review_state="pending"  # pending / clean / dirty
+            if [ -n "$latest" ] && [ "$latest" != "null" ]; then
+              review_commit=$(printf '%s' "$latest" | jq -r '.commit_id // ""')
+              review_body=$(printf '%s' "$latest" | jq -r '.body // ""')
+              if [ "$review_commit" = "$head_sha" ]; then
+                if printf '%s' "$review_body" | grep -qiE "$CLEAN_PHRASE_ERE"; then
+                  review_state="clean"
+                else
+                  review_state="dirty"
+                  # Drift signal: review IS on HEAD but the phrase did not
+                  # match. Most often means Copilot found comments; could also
+                  # mean the summary phrasing changed.
+                  echo "::warning::PR #$pr: latest Copilot review on HEAD did not match clean phrase. Body head: $(printf '%s' "$review_body" | head -c 200)"
+                fi
+              fi
+            fi
+
+            if ! current_labels=$(gh pr view "$pr" --repo "$REPO" --json labels --jq '.labels[].name' 2>&1); then
+              echo "::warning::failed to fetch labels: $current_labels"
+              echo "::endgroup::"
+              continue
+            fi
+            has_label=0
+            if printf '%s\n' "$current_labels" | grep -qFx "$LABEL"; then
+              has_label=1
+            fi
+
+            # Label-edit failures are isolated per-PR: log a warning and
+            # continue so a single transient API error does not starve the
+            # remaining PRs in this run.
+            case "$review_state" in
+              clean)
+                if [ "$has_label" = "0" ]; then
+                  echo "ADD label '$LABEL' (review.commit_id == HEAD, body matched clean phrase)"
+                  if ! gh pr edit "$pr" --repo "$REPO" --add-label "$LABEL" 2>&1; then
+                    echo "::warning::PR #$pr: failed to add label '$LABEL'"
+                  fi
+                else
+                  echo "no change (already labeled clean)"
+                fi
+                ;;
+              dirty)
+                if [ "$has_label" = "1" ]; then
+                  echo "REMOVE label '$LABEL' (review on HEAD has comments)"
+                  if ! gh pr edit "$pr" --repo "$REPO" --remove-label "$LABEL" 2>&1; then
+                    echo "::warning::PR #$pr: failed to remove label '$LABEL'"
+                  fi
+                else
+                  echo "no change (already unlabeled, review has comments)"
+                fi
+                ;;
+              pending)
+                # No review yet, or latest review is for an older HEAD.
+                # We still strip the label because a stale clean signal must
+                # not survive a new commit; Copilot is expected to re-review
+                # (forced by copilot-rereview-on-push.yml).
+                if [ "$has_label" = "1" ]; then
+                  echo "REMOVE label '$LABEL' (review pending for current HEAD)"
+                  if ! gh pr edit "$pr" --repo "$REPO" --remove-label "$LABEL" 2>&1; then
+                    echo "::warning::PR #$pr: failed to remove label '$LABEL'"
+                  fi
+                else
+                  echo "no change (review pending, no stale label)"
+                fi
+
+                # Stuck-PR detector: re-fire requestReviews if Copilot was not
+                # pinged recently. Recovers from cases where the push-event
+                # mutation in copilot-rereview-on-push.yml was silently
+                # deduped (200 OK but no `review_requested` event).
+                if ! timeline=$(gh api --paginate "repos/$REPO/issues/$pr/timeline" 2>&1); then
+                  echo "::warning::PR #$pr: failed to fetch timeline for stuck detection: $timeline"
+                else
+                  # Note: timeline events use yet a third login form for Copilot
+                  # ("Copilot", capitalized) — distinct from REST's
+                  # `copilot-pull-request-reviewer[bot]` and GraphQL's
+                  # `copilot-pull-request-reviewer`.
+                  last_request=$(printf '%s' "$timeline" | jq -s -r '
+                    add
+                    | [.[] | select(.event == "review_requested"
+                        and .requested_reviewer.login == "Copilot")]
+                    | sort_by(.created_at) | last
+                    | .created_at // ""
+                  ')
+                  if [ -z "$last_request" ]; then
+                    age_min=99999
+                  else
+                    age_min=$(( ($(date +%s) - $(date -d "$last_request" +%s)) / 60 ))
+                  fi
+                  if [ "$age_min" -ge "$STUCK_THRESHOLD_MIN" ]; then
+                    pr_node_id=$(printf '%s' "$pr_json" | jq -r '.node_id')
+                    echo "stuck detector: last review_requested was ${age_min}min ago — refiring requestReviews"
+                    if ! refire=$(gh api graphql \
+                      -f query='mutation($pr:ID!,$bot:ID!){requestReviews(input:{pullRequestId:$pr, botIds:[$bot]}){pullRequest{id}}}' \
+                      -f pr="$pr_node_id" \
+                      -f bot="$COPILOT_BOT_ID" 2>&1); then
+                      echo "::warning::PR #$pr: stuck-detector refire failed: $refire"
+                    else
+                      echo "stuck detector: refire ok"
+                    fi
+                  else
+                    echo "stuck detector: last review_requested was ${age_min}min ago (< ${STUCK_THRESHOLD_MIN}min) — skipping refire"
+                  fi
+                fi
+                ;;
+            esac
+
+            echo "::endgroup::"
+          done < prs.txt

--- a/.github/workflows/copilot-rereview-on-push.yml
+++ b/.github/workflows/copilot-rereview-on-push.yml
@@ -1,0 +1,106 @@
+name: Copilot Re-review on Push
+
+# Force a Copilot re-review on every push to a PR. GitHub's auto-review-on-push
+# (the `copilot_code_review` ruleset rule) fires inconsistently in practice, so
+# we drive it explicitly. The standard `requested_reviewers` REST endpoint and
+# `gh pr edit --add-reviewer @copilot` only trigger an INITIAL request — once
+# Copilot has already reviewed, neither re-fires. The undocumented GraphQL
+# `requestReviews` mutation with `botIds` is the only call that re-triggers
+# Copilot after a previous review submission. See community discussion
+# github/community#186152.
+#
+# IMPORTANT — token choice: GITHUB_TOKEN can call this mutation and gets
+# `200 OK` back, but the mutation is **silently a no-op** for the Copilot
+# bot — the response carries valid data but no `review_requested` event
+# fires and Copilot never reviews. A user PAT (`GH_ACTIONS_TOKEN`) is
+# required for the mutation to actually take effect.
+#
+# When @claude pushes a fix immediately after Copilot has just submitted a
+# review, the mutation may also be silently deduped by Copilot's own
+# debouncing (mutation succeeds but no event). This workflow verifies the
+# mutation took effect and retries once with a 90s backoff. If both attempts
+# fail, the workflow emits a warning and exits successfully; the cron-based
+# stuck-PR detector in `copilot-clean-label.yml` will retry within ~10 min.
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions: {}
+
+concurrency:
+  group: copilot-rereview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  request:
+    # Same-repo PRs by the maintainer only. Fork PRs cannot access
+    # `GH_ACTIONS_TOKEN`, and only kotakanbe-authored PRs participate in
+    # the Copilot/@claude automation pipeline (matches `copilot-review-fix.yml`).
+    if: >-
+      github.event.pull_request.user.login == 'kotakanbe'
+      && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Request Copilot review via GraphQL
+        env:
+          # PAT (kotakanbe). See the workflow header for why GITHUB_TOKEN
+          # cannot be used here. Same secret as `copilot-review-fix.yml`.
+          GH_TOKEN: ${{ secrets.GH_ACTIONS_TOKEN }}
+          PR_NODE_ID: ${{ github.event.pull_request.node_id }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO_OWNER: ${{ github.repository_owner }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          # Copilot bot's GraphQL node ID. Globally stable; verified via
+          # `gh api graphql -f query='query{node(id:"BOT_kgDOCnlnWA"){__typename ... on Bot{login createdAt}}}'`
+          # (login: copilot-pull-request-reviewer, createdAt: 2024-07-16).
+          COPILOT_BOT_ID: BOT_kgDOCnlnWA
+        run: |
+          set -euo pipefail
+
+          echo "Requesting Copilot re-review for PR #$PR_NUMBER (node: $PR_NODE_ID)"
+
+          # Try up to 2 times with backoff. The first attempt fires immediately;
+          # if Copilot deduped (mutation returned OK but Copilot was not added
+          # to reviewRequests), wait 90s and try again to escape the dedup
+          # window. If the second attempt also fails, emit a warning and exit
+          # successfully — the cron detector will recover.
+          for attempt in 1 2; do
+            if ! response=$(gh api graphql \
+              -f query='mutation($pr:ID!,$bot:ID!){requestReviews(input:{pullRequestId:$pr, botIds:[$bot]}){pullRequest{id}}}' \
+              -f pr="$PR_NODE_ID" \
+              -f bot="$COPILOT_BOT_ID" 2>&1); then
+              echo "GraphQL requestReviews failed (attempt $attempt):"
+              echo "$response"
+              exit 1
+            fi
+            echo "attempt $attempt mutation response: $response"
+
+            # Allow propagation, then verify Copilot is actually pending review.
+            sleep 15
+            pending=$(gh api graphql \
+              -f query='query($o:String!,$n:String!,$pr:Int!){repository(owner:$o,name:$n){pullRequest(number:$pr){reviewRequests(first:20){nodes{requestedReviewer{__typename ... on Bot{login}}}}}}}' \
+              -f o="$REPO_OWNER" -f n="$REPO_NAME" -F pr="$PR_NUMBER" \
+              --jq '[.data.repository.pullRequest.reviewRequests.nodes[]?.requestedReviewer | select(.login == "copilot-pull-request-reviewer")] | length')
+
+            if [ "$pending" -gt 0 ]; then
+              echo "Verified: Copilot is in reviewRequests (attempt $attempt)."
+              exit 0
+            fi
+
+            echo "::warning::PR #$PR_NUMBER: mutation succeeded but Copilot not in reviewRequests (attempt $attempt) — likely dedup window"
+            if [ "$attempt" = "1" ]; then
+              echo "Waiting 90s before retry..."
+              sleep 90
+            fi
+          done
+
+          # Dedup detected on both attempts — emit a warning and exit 0.
+          # Marking the job as failed would put a permanent red X on the PR
+          # check list, which conflicts with the "fully automatic loop"
+          # contract. The cron detector in copilot-clean-label.yml is
+          # authoritative for recovery and will retry within ~10 min.
+          echo "::warning::PR #$PR_NUMBER: Copilot did not enter reviewRequests after 2 attempts (likely dedup window). The cron detector in copilot-clean-label.yml will retry within ~10 min."

--- a/.github/workflows/copilot-rereview-on-push.yml
+++ b/.github/workflows/copilot-rereview-on-push.yml
@@ -82,7 +82,7 @@ jobs:
             # Allow propagation, then verify Copilot is actually pending review.
             sleep 15
             pending=$(gh api graphql \
-              -f query='query($o:String!,$n:String!,$pr:Int!){repository(owner:$o,name:$n){pullRequest(number:$pr){reviewRequests(first:20){nodes{requestedReviewer{__typename ... on Bot{login}}}}}}}' \
+              -f query='query($o:String!,$n:String!,$pr:Int!){repository(owner:$o,name:$n){pullRequest(number:$pr){reviewRequests(first:100){nodes{requestedReviewer{__typename ... on Bot{login}}}}}}}' \
               -f o="$REPO_OWNER" -f n="$REPO_NAME" -F pr="$PR_NUMBER" \
               --jq '[.data.repository.pullRequest.reviewRequests.nodes[]?.requestedReviewer | select(.login == "copilot-pull-request-reviewer")] | length')
 


### PR DESCRIPTION
## Summary

Two CI workflows to drive the Copilot PR-review lifecycle deterministically:

- **`copilot-rereview-on-push.yml`** — on every `pull_request` `synchronize`/`opened`/`reopened`, fires the GraphQL `requestReviews` mutation with `botIds: [\"BOT_kgDOCnlnWA\"]` to force a Copilot re-review. The standard REST `requested_reviewers` endpoint and `gh pr edit --add-reviewer @copilot` only handle the **initial** request — once Copilot has already reviewed, neither re-fires (community#186152). The undocumented GraphQL `botIds` field is the only call that re-triggers Copilot.
- **`copilot-clean-label.yml`** — applies/removes the `copilot-clean` label based on whether the latest Copilot review is on the current HEAD and its body matches `generated no( new)? comments` (case-insensitive). Triggers:
  - `schedule` `*/10 * * * *` — Copilot's review submission does not fire `pull_request_review` since the 2026-03-05 agentic-architecture migration, so polling is required.
  - `pull_request` `synchronize`/`opened`/`reopened` — instant label removal on push.
  - `workflow_dispatch` (optional \`pr\` input) — manual / one-PR recovery.

Both workflows are scoped to:
- kotakanbe-authored PRs (matches existing \`copilot-review-fix.yml\` convention)
- same-repo PRs only (\`head.repo.full_name == github.repository\`) — fork PRs cannot access \`GH_ACTIONS_TOKEN\` and are skipped to avoid spurious 401 failures.

### Why a user PAT (`GH_ACTIONS_TOKEN`), not `GITHUB_TOKEN`

\`GITHUB_TOKEN\` can call the GraphQL \`requestReviews\` mutation and gets a \`200 OK\` response with valid data, but the mutation is **silently a no-op for the Copilot bot** — no \`review_requested\` event fires and Copilot never reviews. A user PAT is required for the mutation to actually take effect. Discovered via direct testing.

### Reliability story

- **Push-event path**: \`copilot-rereview-on-push.yml\` fires the mutation, sleeps 15s for propagation, and queries \`reviewRequests\` to verify Copilot was actually added. If not, it waits 90s (well outside the dedup window) and retries once. If both attempts fail, it emits a \`::warning::\` and exits 0 — the PR check list stays green.
- **Cron recovery**: \`copilot-clean-label.yml\`'s \`pending\`-state branch includes a stuck-PR detector. When the latest \`review_requested\` event for Copilot is older than \`STUCK_THRESHOLD_MIN\` (5 min), the cron re-fires the same mutation. Cron runs every 10 min, so a deduped push is recovered in at most ~15 min (cron tick + Copilot review time).

### Three login forms for Copilot

The Copilot bot has three distinct login strings across GitHub's APIs and each call site must use the form correct for its API:

| Surface | Login form | Used in |
| --- | --- | --- |
| REST \`/pulls/.../reviews\` \`user.login\` | \`copilot-pull-request-reviewer[bot]\` | clean-phrase matcher in clean-label.yml |
| GraphQL \`Bot.login\` (node lookup) | \`copilot-pull-request-reviewer\` | rereview-on-push.yml \`reviewRequests\` verify |
| Timeline \`requested_reviewer.login\` | \`Copilot\` | clean-label.yml stuck detector |

Do not \"unify\" these — each form is correct only for its own API.

### Required setup (already in place in this repo)

- \`GH_ACTIONS_TOKEN\` repository secret (PAT with \`repo\` scope; same secret already used by \`copilot-review-fix.yml\`). ✓
- \`copilot-clean\` label (color \`#0e8a16\`). ✓ Created out-of-band.
- Repository ruleset \`Copilot review for default branch\` should have \`copilot_code_review.review_on_push: false\` so that this workflow is the single source of trigger and does not fight the ruleset's own request. ✓ Already \`false\` in this repo.

### Verification (Copilot bot ID)

\`\`\`
gh api graphql -f query='query{node(id:\"BOT_kgDOCnlnWA\"){__typename ... on Bot{login createdAt}}}'
\`\`\`

Returns \`login: copilot-pull-request-reviewer\`, \`createdAt: 2024-07-16\` — confirming the bot ID is current.

## Test plan

- [ ] After merge, push a small commit to a kotakanbe-authored PR.
- [ ] Confirm \`Copilot Re-review on Push\` job fires, mutation logs \`Verified: Copilot is in reviewRequests\`, and a \`review_requested\` event appears in the PR timeline within seconds of the workflow run.
- [ ] Confirm Copilot submits a review within ~3 min.
- [ ] If review is clean (\`generated no new comments\`), confirm the next \`copilot-clean-label\` cron run (within 10 min) applies \`copilot-clean\`.
- [ ] Push a new commit to that clean-labeled PR → \`synchronize\` event removes the label within seconds.
- [ ] \`workflow_dispatch\` with a single PR number processes only that PR.

## Risks / fallbacks

- The GraphQL \`botIds\` field is undocumented. If GitHub changes the schema, the rereview workflow's mutation will fail; the \`if !\` wrapper exits the step with a clear error message. Revert the workflow until a new mechanism is identified.
- The \`copilot-clean\` label state can drift if the cron is disabled. Re-enabling reconciles within 10 min.
- Copilot's own \"accepted but never starts work\" hang (rare but observed) cannot be recovered from CI; manual re-firing of the mutation is the only known workaround.