### PR TITLE
feat(eolevaluator): detect yanked cargo/PyPI versions and deps.dev-deprecated stable versions

### DIFF
--- a/internal/domain/analysis/models.go
+++ b/internal/domain/analysis/models.go
@@ -123,7 +123,13 @@ type VersionDetail struct {
 	PublishedAt  time.Time
 	IsPrerelease bool
 	// IsDeprecated indicates the upstream has deprecated / retracted / yanked this specific version.
-	// This is metadata-only (no automatic lifecycle assessment effect) and is propagated from deps.dev API Version.IsDeprecated.
+	// Propagated from deps.dev API Version.IsDeprecated.
+	//
+	// Consumed as a fallback EOL signal by eolevaluator's applyDepsDevDeprecated rule
+	// for ecosystems without authoritative ecosystem-specific rules (golang, gem, pub,
+	// hex, conan). For ecosystems with authoritative rules (npm, NuGet, Packagist,
+	// Maven, PyPI, cargo), this field remains informational and the ecosystem-specific
+	// rule's verdict takes precedence via short-circuiting in the rule chain.
 	IsDeprecated bool
 	// RegistryURL points to the registry page specific to this version (flattened from former VersionLinks)
 	RegistryURL string

--- a/internal/infrastructure/crates/client.go
+++ b/internal/infrastructure/crates/client.go
@@ -1,0 +1,164 @@
+// Package crates provides a minimal crates.io metadata client used for
+// detecting yanked versions during EOL evaluation.
+//
+// DDD Layer: Infrastructure
+// Responsibility: External HTTP call to https://crates.io/api/v1/crates/<name>/<version>
+// with narrow field extraction (yanked flag) required by the EOL evaluator.
+package crates
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/future-architect/uzomuzo-oss/internal/infrastructure/httpclient"
+)
+
+// cratesUserAgent is the User-Agent sent on all crates.io HTTP requests.
+// crates.io rejects requests without a descriptive User-Agent (returns 403).
+const cratesUserAgent = "uzomuzo-crates-client/1.0 (+https://github.com/future-architect/uzomuzo-oss)"
+
+// maxJSONResponseSize caps the crates.io JSON API response body (1 MB).
+// crates.io version responses are typically <10 KB.
+const maxJSONResponseSize = 1 << 20
+
+// Client fetches crates.io version metadata.
+type Client struct {
+	http    *httpclient.Client
+	baseURL string
+
+	mu    sync.RWMutex
+	cache map[string]cacheEntry
+	ttl   time.Duration
+}
+
+type cacheEntry struct {
+	info *VersionInfo
+	ts   time.Time
+}
+
+// VersionInfo is the minimal subset of crates.io version metadata we need.
+type VersionInfo struct {
+	Name    string
+	Version string
+	Yanked  bool
+}
+
+// NewClient returns a crates.io client with sensible HTTP defaults.
+func NewClient() *Client {
+	hc := &http.Client{Timeout: 5 * time.Second}
+	return &Client{
+		http:    httpclient.NewClient(hc, httpclient.RetryConfig{MaxRetries: 2, BaseBackoff: 400 * time.Millisecond, MaxBackoff: 2 * time.Second, RetryOn5xx: true, RetryOnNetworkErr: true}),
+		baseURL: "https://crates.io",
+		cache:   make(map[string]cacheEntry),
+		ttl:     10 * time.Minute,
+	}
+}
+
+// SetHTTPClient overrides the underlying http.Client (tests).
+func (c *Client) SetHTTPClient(h *http.Client) {
+	if h == nil {
+		return
+	}
+	c.http = httpclient.NewClient(h, httpclient.RetryConfig{MaxRetries: 2, BaseBackoff: 400 * time.Millisecond, MaxBackoff: 2 * time.Second, RetryOn5xx: true, RetryOnNetworkErr: true})
+}
+
+// SetBaseURL overrides the base host (tests).
+func (c *Client) SetBaseURL(u string) { c.baseURL = strings.TrimRight(u, "/") }
+
+// SetCacheTTL sets the in-memory cache TTL (<=0 disables caching).
+func (c *Client) SetCacheTTL(d time.Duration) { c.ttl = d }
+
+// resolvedBaseURL returns the configured base URL or the default.
+func (c *Client) resolvedBaseURL() string {
+	if c.baseURL != "" {
+		return c.baseURL
+	}
+	return "https://crates.io"
+}
+
+func (c *Client) cacheKey(name, version string) string {
+	return strings.ToLower(name) + "@" + version
+}
+
+func (c *Client) getCached(key string) (*VersionInfo, bool) {
+	if c.ttl <= 0 {
+		return nil, false
+	}
+	c.mu.RLock()
+	ent, ok := c.cache[key]
+	c.mu.RUnlock()
+	if !ok {
+		return nil, false
+	}
+	if time.Since(ent.ts) > c.ttl {
+		return nil, false
+	}
+	return ent.info, true
+}
+
+func (c *Client) setCache(key string, info *VersionInfo) {
+	if c.ttl <= 0 || info == nil {
+		return
+	}
+	c.mu.Lock()
+	c.cache[key] = cacheEntry{info: info, ts: time.Now()}
+	c.mu.Unlock()
+}
+
+// GetVersion retrieves crate version metadata. Returns (info, found, err).
+// On 404 -> (nil, false, nil). Other non-200 -> error.
+func (c *Client) GetVersion(ctx context.Context, name, version string) (*VersionInfo, bool, error) {
+	n := strings.TrimSpace(name)
+	v := strings.TrimSpace(version)
+	if n == "" || v == "" {
+		return nil, false, nil
+	}
+	key := c.cacheKey(n, v)
+	if info, ok := c.getCached(key); ok {
+		slog.Debug("crates: cache hit", "name", n, "version", v)
+		return info, true, nil
+	}
+	apiURL := fmt.Sprintf("%s/api/v1/crates/%s/%s", c.resolvedBaseURL(), url.PathEscape(n), url.PathEscape(v))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
+	if err != nil {
+		return nil, false, fmt.Errorf("crates request build failed: %w", err)
+	}
+	req.Header.Set("User-Agent", cratesUserAgent)
+	req.Header.Set("Accept", "application/json")
+	resp, err := c.http.Do(ctx, req)
+	if err != nil {
+		return nil, false, fmt.Errorf("crates http failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, false, nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, false, fmt.Errorf("crates http status %d", resp.StatusCode)
+	}
+	var raw struct {
+		Version struct {
+			Crate  string `json:"crate"`
+			Num    string `json:"num"`
+			Yanked bool   `json:"yanked"`
+		} `json:"version"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxJSONResponseSize)).Decode(&raw); err != nil {
+		return nil, false, fmt.Errorf("crates decode failed: %w", err)
+	}
+	info := &VersionInfo{
+		Name:    raw.Version.Crate,
+		Version: raw.Version.Num,
+		Yanked:  raw.Version.Yanked,
+	}
+	c.setCache(key, info)
+	return info, true, nil
+}

--- a/internal/infrastructure/crates/client_test.go
+++ b/internal/infrastructure/crates/client_test.go
@@ -1,0 +1,189 @@
+package crates
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestGetVersion_Yanked(t *testing.T) {
+	t.Parallel()
+	var capturedPath atomic.Value
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath.Store(r.URL.Path)
+		_, _ = fmt.Fprintln(w, `{"version":{"crate":"openssl","num":"0.10.45","yanked":true}}`)
+	}))
+	defer srv.Close()
+
+	c := NewClient()
+	c.SetBaseURL(srv.URL)
+	c.SetCacheTTL(0)
+
+	info, found, err := c.GetVersion(context.Background(), "openssl", "0.10.45")
+	if err != nil {
+		t.Fatalf("GetVersion failed: %v", err)
+	}
+	if !found {
+		t.Fatalf("expected found=true")
+	}
+	if info == nil {
+		t.Fatalf("expected non-nil info")
+	}
+	if !info.Yanked {
+		t.Errorf("expected Yanked=true, got false")
+	}
+	if got := capturedPath.Load(); got != "/api/v1/crates/openssl/0.10.45" {
+		t.Errorf("unexpected request path: got %q, want /api/v1/crates/openssl/0.10.45", got)
+	}
+}
+
+func TestGetVersion_NotYanked(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprintln(w, `{"version":{"crate":"serde","num":"1.0.197","yanked":false}}`)
+	}))
+	defer srv.Close()
+
+	c := NewClient()
+	c.SetBaseURL(srv.URL)
+	c.SetCacheTTL(0)
+
+	info, found, err := c.GetVersion(context.Background(), "serde", "1.0.197")
+	if err != nil {
+		t.Fatalf("GetVersion failed: %v", err)
+	}
+	if !found {
+		t.Fatalf("expected found=true")
+	}
+	if info.Yanked {
+		t.Errorf("expected Yanked=false, got true")
+	}
+}
+
+func TestGetVersion_NotFound(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := NewClient()
+	c.SetBaseURL(srv.URL)
+	c.SetCacheTTL(0)
+
+	info, found, err := c.GetVersion(context.Background(), "nonexistent", "0.0.0")
+	if err != nil {
+		t.Fatalf("expected nil error on 404, got %v", err)
+	}
+	if found {
+		t.Errorf("expected found=false on 404")
+	}
+	if info != nil {
+		t.Errorf("expected nil info on 404, got %+v", info)
+	}
+}
+
+func TestGetVersion_EmptyArgs(t *testing.T) {
+	t.Parallel()
+	c := NewClient()
+	c.SetBaseURL("http://invalid.example.invalid") // would fail if hit
+
+	tests := []struct {
+		name, ver string
+	}{
+		{"", "1.0.0"},
+		{"foo", ""},
+		{"", ""},
+		{"   ", "1.0.0"},
+	}
+	for _, tc := range tests {
+		info, found, err := c.GetVersion(context.Background(), tc.name, tc.ver)
+		if err != nil || found || info != nil {
+			t.Errorf("expected (nil,false,nil) for empty args (%q,%q); got (%+v,%v,%v)", tc.name, tc.ver, info, found, err)
+		}
+	}
+}
+
+func TestGetVersion_Cache(t *testing.T) {
+	t.Parallel()
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		_, _ = fmt.Fprintln(w, `{"version":{"crate":"tokio","num":"1.0.0","yanked":false}}`)
+	}))
+	defer srv.Close()
+
+	c := NewClient()
+	c.SetBaseURL(srv.URL)
+	c.SetCacheTTL(5 * time.Minute)
+
+	ctx := context.Background()
+	if _, _, err := c.GetVersion(ctx, "tokio", "1.0.0"); err != nil {
+		t.Fatalf("first GetVersion failed: %v", err)
+	}
+	if got := atomic.LoadInt32(&hits); got != 1 {
+		t.Fatalf("expected 1 hit, got %d", got)
+	}
+
+	// Second call within TTL must hit cache.
+	if _, _, err := c.GetVersion(ctx, "tokio", "1.0.0"); err != nil {
+		t.Fatalf("second GetVersion failed: %v", err)
+	}
+	if got := atomic.LoadInt32(&hits); got != 1 {
+		t.Fatalf("expected cache hit (still 1 network call), got %d", got)
+	}
+
+	// Different version must miss cache.
+	if _, _, err := c.GetVersion(ctx, "tokio", "1.1.0"); err != nil {
+		t.Fatalf("third GetVersion failed: %v", err)
+	}
+	if got := atomic.LoadInt32(&hits); got != 2 {
+		t.Fatalf("expected cache miss for new version (2 calls), got %d", got)
+	}
+}
+
+func TestGetVersion_UserAgent(t *testing.T) {
+	t.Parallel()
+	var captured atomic.Value
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured.Store(r.Header.Get("User-Agent"))
+		_, _ = fmt.Fprintln(w, `{"version":{"crate":"x","num":"1.0.0","yanked":false}}`)
+	}))
+	defer srv.Close()
+
+	c := NewClient()
+	c.SetBaseURL(srv.URL)
+	c.SetCacheTTL(0)
+
+	if _, _, err := c.GetVersion(context.Background(), "x", "1.0.0"); err != nil {
+		t.Fatalf("GetVersion failed: %v", err)
+	}
+	got, _ := captured.Load().(string)
+	if got != cratesUserAgent {
+		t.Errorf("unexpected User-Agent: got %q, want %q", got, cratesUserAgent)
+	}
+}
+
+func TestGetVersion_HTTPError(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer srv.Close()
+
+	c := NewClient()
+	c.SetBaseURL(srv.URL)
+	c.SetCacheTTL(0)
+
+	_, found, err := c.GetVersion(context.Background(), "any", "1.0.0")
+	if err == nil {
+		t.Errorf("expected error on persistent 502, got nil")
+	}
+	if found {
+		t.Errorf("expected found=false on error")
+	}
+}

--- a/internal/infrastructure/eolevaluator/evaluator.go
+++ b/internal/infrastructure/eolevaluator/evaluator.go
@@ -9,6 +9,7 @@ import (
 
 	purl "github.com/future-architect/uzomuzo-oss/internal/common/purl"
 	domain "github.com/future-architect/uzomuzo-oss/internal/domain/analysis"
+	"github.com/future-architect/uzomuzo-oss/internal/infrastructure/crates"
 	"github.com/future-architect/uzomuzo-oss/internal/infrastructure/maven"
 	"github.com/future-architect/uzomuzo-oss/internal/infrastructure/npmjs"
 	"github.com/future-architect/uzomuzo-oss/internal/infrastructure/nuget"
@@ -34,11 +35,12 @@ type npmDeprecationClient interface {
 }
 
 type Evaluator struct {
-	pg   packagistAbandonedClient
-	ng   nugetDeprecationClient
-	mvn  mavenRelocationClient
-	npm  npmDeprecationClient
-	pypi *pypi.Client
+	pg     packagistAbandonedClient
+	ng     nugetDeprecationClient
+	mvn    mavenRelocationClient
+	npm    npmDeprecationClient
+	pypi   *pypi.Client
+	crates *crates.Client
 	// rule chain (rebuilt each EvaluateBatch)
 	rules      []eolRuleFunc
 	maxWorkers int
@@ -58,6 +60,7 @@ func NewEvaluator(pg *packagist.Client) *Evaluator {
 		mvn:        maven.NewClient(),
 		npm:        npmjs.NewClient(),
 		pypi:       pypi.NewClient(),
+		crates:     crates.NewClient(),
 		maxWorkers: 12,
 	}
 }
@@ -76,6 +79,9 @@ func (e *Evaluator) SetNpmClient(npm npmDeprecationClient) { e.npm = npm }
 
 // SetPyPIClient overrides the default PyPI client (useful for tests).
 func (e *Evaluator) SetPyPIClient(pc *pypi.Client) { e.pypi = pc }
+
+// SetCratesClient overrides the default crates.io client (useful for tests).
+func (e *Evaluator) SetCratesClient(cc *crates.Client) { e.crates = cc }
 
 // (Removed) suppressions support eliminated; heuristic-based evidence gathering removed.
 
@@ -99,8 +105,17 @@ func (e *Evaluator) ensureRuleChain() {
 		func(ctx context.Context, key string, a *domain.Analysis, st *domain.EOLStatus) bool { // PyPI classifier explicit inactivity
 			return e.applyPyPIClassifier(ctx, a, st)
 		},
+		func(ctx context.Context, key string, a *domain.Analysis, st *domain.EOLStatus) bool { // PyPI version yanked
+			return e.applyPyPIYanked(ctx, a, st)
+		},
+		func(ctx context.Context, key string, a *domain.Analysis, st *domain.EOLStatus) bool { // Cargo version yanked
+			return e.applyCargoYanked(ctx, a, st)
+		},
 		func(ctx context.Context, key string, a *domain.Analysis, st *domain.EOLStatus) bool {
 			return e.applyMavenRelocation(ctx, a, st)
+		},
+		func(ctx context.Context, key string, a *domain.Analysis, st *domain.EOLStatus) bool { // deps.dev IsDeprecated fallback (LAST: only fires when no authoritative rule fired)
+			return e.applyDepsDevDeprecated(ctx, a, st)
 		},
 	}
 }
@@ -349,6 +364,131 @@ func (e *Evaluator) applyPyPIClassifier(ctx context.Context, a *domain.Analysis,
 		return true
 	}
 	return false
+}
+
+// applyPyPIYanked checks if the PyPI stable version (or PURL version if stable
+// is unavailable) is yanked on PyPI and promotes to EOL on confirmation.
+// Yanked semantics: see pypi.Client.GetVersion (info.yanked OR all urls[].yanked).
+func (e *Evaluator) applyPyPIYanked(ctx context.Context, a *domain.Analysis, status *domain.EOLStatus) (done bool) {
+	if status.State == domain.EOLEndOfLife || a == nil || a.Package == nil || a.Package.PURL == "" || e.pypi == nil {
+		return false
+	}
+	pp := purl.NewParser()
+	parsed, err := pp.Parse(a.Package.PURL)
+	if err != nil || parsed.GetEcosystem() != "pypi" {
+		return false
+	}
+	name := strings.ToLower(parsed.Name())
+	version := ""
+	if a.ReleaseInfo != nil && a.ReleaseInfo.StableVersion != nil {
+		version = a.ReleaseInfo.StableVersion.Version
+	}
+	if version == "" {
+		version = parsed.Version()
+	}
+	if version == "" {
+		return false
+	}
+	info, found, err := e.pypi.GetVersion(ctx, name, version)
+	if err != nil {
+		slog.Error("eol: pypi version fetch failed", "name", name, "version", version, "error", err)
+		return false
+	}
+	if !found || info == nil || !info.Yanked {
+		return false
+	}
+	summary := "Version yanked on PyPI"
+	if info.YankedReason != "" {
+		summary = summary + ": " + info.YankedReason
+	}
+	status.State = domain.EOLEndOfLife
+	status.Evidences = append(status.Evidences, domain.EOLEvidence{
+		Source:     "PyPI",
+		Summary:    summary,
+		Reference:  "https://pypi.org/project/" + info.Name + "/" + info.Version + "/",
+		Confidence: 0.95,
+	})
+	slog.Debug("eol: pypi version yanked", "name", name, "version", version)
+	return true
+}
+
+// applyCargoYanked checks if the Cargo PURL version is yanked on crates.io.
+func (e *Evaluator) applyCargoYanked(ctx context.Context, a *domain.Analysis, status *domain.EOLStatus) (done bool) {
+	if status.State == domain.EOLEndOfLife || a == nil || a.Package == nil || a.Package.PURL == "" || e.crates == nil {
+		return false
+	}
+	pp := purl.NewParser()
+	parsed, err := pp.Parse(a.Package.PURL)
+	if err != nil || parsed.GetEcosystem() != "cargo" {
+		return false
+	}
+	name, version := parseCargoNameVersionFromPURL(a.Package.PURL)
+	if name == "" || version == "" {
+		return false
+	}
+	info, found, err := e.crates.GetVersion(ctx, name, version)
+	if err != nil {
+		slog.Error("eol: crates fetch failed", "name", name, "version", version, "error", err)
+		return false
+	}
+	if !found || info == nil || !info.Yanked {
+		return false
+	}
+	status.State = domain.EOLEndOfLife
+	status.Evidences = append(status.Evidences, domain.EOLEvidence{
+		Source:     "crates.io",
+		Summary:    "Version yanked on crates.io",
+		Reference:  "https://crates.io/crates/" + name + "/" + version,
+		Confidence: 1.0,
+	})
+	slog.Debug("eol: cargo version yanked", "name", name, "version", version)
+	return true
+}
+
+// depsDevFallbackEcosystems are the PURL ecosystems where deps.dev's
+// Version.IsDeprecated is the only EOL signal we currently consume.
+// Ecosystems with authoritative ecosystem-specific rules (npm, NuGet, Packagist,
+// Maven, PyPI, cargo) are intentionally excluded so that authoritative-vs-stale
+// discrepancies fall to the authoritative side.
+var depsDevFallbackEcosystems = map[string]struct{}{
+	"golang": {},
+	"gem":    {},
+	"pub":    {},
+	"hex":    {},
+	"conan":  {},
+}
+
+// applyDepsDevDeprecated is a fallback rule that promotes to EOL when deps.dev
+// reports Version.IsDeprecated for ecosystems lacking an authoritative
+// ecosystem-specific rule. deps.dev aggregates from each registry's upstream
+// metadata for these ecosystems, so confidence is set to 0.95 (authoritative
+// aggregator). Placed LAST in the rule chain so any ecosystem-specific rule
+// short-circuits before this fallback runs.
+func (e *Evaluator) applyDepsDevDeprecated(_ context.Context, a *domain.Analysis, status *domain.EOLStatus) (done bool) {
+	if status.State == domain.EOLEndOfLife || a == nil || a.Package == nil || a.Package.PURL == "" {
+		return false
+	}
+	if a.ReleaseInfo == nil || a.ReleaseInfo.StableVersion == nil || !a.ReleaseInfo.StableVersion.IsDeprecated {
+		return false
+	}
+	pp := purl.NewParser()
+	parsed, err := pp.Parse(a.Package.PURL)
+	if err != nil {
+		return false
+	}
+	eco := strings.ToLower(parsed.GetEcosystem())
+	if _, ok := depsDevFallbackEcosystems[eco]; !ok {
+		return false
+	}
+	status.State = domain.EOLEndOfLife
+	status.Evidences = append(status.Evidences, domain.EOLEvidence{
+		Source:     "deps.dev",
+		Summary:    "Marked deprecated in deps.dev",
+		Reference:  "https://deps.dev/" + eco + "/" + parsed.Name() + "/" + a.ReleaseInfo.StableVersion.Version,
+		Confidence: 0.95,
+	})
+	slog.Debug("eol: deps.dev deprecated fallback", "ecosystem", eco, "name", parsed.Name(), "version", a.ReleaseInfo.StableVersion.Version)
+	return true
 }
 
 // EvaluateBatch computes EOL status for the given analyses keyed by input key.

--- a/internal/infrastructure/eolevaluator/evaluator.go
+++ b/internal/infrastructure/eolevaluator/evaluator.go
@@ -3,10 +3,12 @@ package eolevaluator
 import (
 	"context"
 	"log/slog"
+	"net/url"
 	"reflect"
 	"strings"
 	"sync"
 
+	"github.com/future-architect/uzomuzo-oss/internal/common/links"
 	purl "github.com/future-architect/uzomuzo-oss/internal/common/purl"
 	domain "github.com/future-architect/uzomuzo-oss/internal/domain/analysis"
 	"github.com/future-architect/uzomuzo-oss/internal/infrastructure/crates"
@@ -366,8 +368,12 @@ func (e *Evaluator) applyPyPIClassifier(ctx context.Context, a *domain.Analysis,
 	return false
 }
 
-// applyPyPIYanked checks if the PyPI stable version (or PURL version if stable
-// is unavailable) is yanked on PyPI and promotes to EOL on confirmation.
+// applyPyPIYanked checks if the PyPI version requested by the user (PURL version,
+// falling back to StableVersion when PURL is unversioned) is yanked on PyPI and
+// promotes to EOL on confirmation. PURL version is preferred because yanking is a
+// version-specific signal — checking the latest stable version would silently miss
+// a user's pinned-to-yanked dependency.
+//
 // Yanked semantics: see pypi.Client.GetVersion (info.yanked OR all urls[].yanked).
 func (e *Evaluator) applyPyPIYanked(ctx context.Context, a *domain.Analysis, status *domain.EOLStatus) (done bool) {
 	if status.State == domain.EOLEndOfLife || a == nil || a.Package == nil || a.Package.PURL == "" || e.pypi == nil {
@@ -379,14 +385,11 @@ func (e *Evaluator) applyPyPIYanked(ctx context.Context, a *domain.Analysis, sta
 		return false
 	}
 	name := strings.ToLower(parsed.Name())
-	version := ""
-	if a.ReleaseInfo != nil && a.ReleaseInfo.StableVersion != nil {
+	version := parsed.Version()
+	if version == "" && a.ReleaseInfo != nil && a.ReleaseInfo.StableVersion != nil {
 		version = a.ReleaseInfo.StableVersion.Version
 	}
-	if version == "" {
-		version = parsed.Version()
-	}
-	if version == "" {
+	if name == "" || version == "" {
 		return false
 	}
 	info, found, err := e.pypi.GetVersion(ctx, name, version)
@@ -405,14 +408,17 @@ func (e *Evaluator) applyPyPIYanked(ctx context.Context, a *domain.Analysis, sta
 	status.Evidences = append(status.Evidences, domain.EOLEvidence{
 		Source:     "PyPI",
 		Summary:    summary,
-		Reference:  "https://pypi.org/project/" + info.Name + "/" + info.Version + "/",
+		Reference:  "https://pypi.org/project/" + url.PathEscape(info.Name) + "/" + url.PathEscape(info.Version) + "/",
 		Confidence: 0.95,
 	})
 	slog.Debug("eol: pypi version yanked", "name", name, "version", version)
 	return true
 }
 
-// applyCargoYanked checks if the Cargo PURL version is yanked on crates.io.
+// applyCargoYanked checks if the Cargo PURL version (falling back to StableVersion
+// when PURL is unversioned) is yanked on crates.io. Same precedence rationale as
+// applyPyPIYanked. crates.io yanks have no upstream successor, so status.Successor
+// is left untouched.
 func (e *Evaluator) applyCargoYanked(ctx context.Context, a *domain.Analysis, status *domain.EOLStatus) (done bool) {
 	if status.State == domain.EOLEndOfLife || a == nil || a.Package == nil || a.Package.PURL == "" || e.crates == nil {
 		return false
@@ -422,7 +428,11 @@ func (e *Evaluator) applyCargoYanked(ctx context.Context, a *domain.Analysis, st
 	if err != nil || parsed.GetEcosystem() != "cargo" {
 		return false
 	}
-	name, version := parseCargoNameVersionFromPURL(a.Package.PURL)
+	name := parsed.Name()
+	version := parsed.Version()
+	if version == "" && a.ReleaseInfo != nil && a.ReleaseInfo.StableVersion != nil {
+		version = a.ReleaseInfo.StableVersion.Version
+	}
 	if name == "" || version == "" {
 		return false
 	}
@@ -438,37 +448,47 @@ func (e *Evaluator) applyCargoYanked(ctx context.Context, a *domain.Analysis, st
 	status.Evidences = append(status.Evidences, domain.EOLEvidence{
 		Source:     "crates.io",
 		Summary:    "Version yanked on crates.io",
-		Reference:  "https://crates.io/crates/" + name + "/" + version,
+		Reference:  "https://crates.io/crates/" + url.PathEscape(name) + "/" + url.PathEscape(version),
 		Confidence: 1.0,
 	})
 	slog.Debug("eol: cargo version yanked", "name", name, "version", version)
 	return true
 }
 
-// depsDevFallbackEcosystems are the PURL ecosystems where deps.dev's
-// Version.IsDeprecated is the only EOL signal we currently consume.
-// Ecosystems with authoritative ecosystem-specific rules (npm, NuGet, Packagist,
-// Maven, PyPI, cargo) are intentionally excluded so that authoritative-vs-stale
-// discrepancies fall to the authoritative side.
-var depsDevFallbackEcosystems = map[string]struct{}{
-	"golang": {},
-	"gem":    {},
-	"pub":    {},
-	"hex":    {},
-	"conan":  {},
+// ecosystemsWithAuthoritativeRules enumerates PURL ecosystems for which an
+// ecosystem-specific terminal rule already runs earlier in the rule chain.
+// applyDepsDevDeprecated skips these ecosystems so deps.dev's aggregated signal
+// never overrides an authoritative source.
+//
+// IMPORTANT: When adding a new ecosystem-specific authoritative rule, add the
+// PURL ecosystem to this set so the deps.dev fallback yields to it.
+var ecosystemsWithAuthoritativeRules = map[string]struct{}{
+	"npm":       {}, // applyNpmStableDeprecation / applyNpmPURLDeprecation
+	"nuget":     {}, // applyNuGetDeprecation
+	"composer":  {}, // applyPackagistAbandoned
+	"packagist": {}, // applyPackagistAbandoned (alias)
+	"maven":     {}, // applyMavenRelocation
+	"pypi":      {}, // applyPyPIClassifier / applyPyPIYanked
+	"cargo":     {}, // applyCargoYanked
 }
 
 // applyDepsDevDeprecated is a fallback rule that promotes to EOL when deps.dev
-// reports Version.IsDeprecated for ecosystems lacking an authoritative
-// ecosystem-specific rule. deps.dev aggregates from each registry's upstream
-// metadata for these ecosystems, so confidence is set to 0.95 (authoritative
-// aggregator). Placed LAST in the rule chain so any ecosystem-specific rule
-// short-circuits before this fallback runs.
+// reports Version.IsDeprecated for ecosystems lacking an ecosystem-specific
+// authoritative rule. Confidence is 0.95 (deps.dev aggregates from each
+// registry's upstream metadata for ecosystems it hosts). Placed LAST in the
+// rule chain so any ecosystem-specific rule short-circuits before this runs.
+//
+// Fires only when:
+//  1. The ecosystem is NOT in ecosystemsWithAuthoritativeRules, AND
+//  2. deps.dev hosts the ecosystem (links.BuildDepsDevVersionURL returns a non-empty URL).
+//
+// In effect this currently means Go modules and RubyGems (deps.dev hosts both
+// without us having authoritative rules for them).
 func (e *Evaluator) applyDepsDevDeprecated(_ context.Context, a *domain.Analysis, status *domain.EOLStatus) (done bool) {
 	if status.State == domain.EOLEndOfLife || a == nil || a.Package == nil || a.Package.PURL == "" {
 		return false
 	}
-	if a.ReleaseInfo == nil || a.ReleaseInfo.StableVersion == nil || !a.ReleaseInfo.StableVersion.IsDeprecated {
+	if a.ReleaseInfo == nil || a.ReleaseInfo.StableVersion == nil || a.ReleaseInfo.StableVersion.Version == "" || !a.ReleaseInfo.StableVersion.IsDeprecated {
 		return false
 	}
 	pp := purl.NewParser()
@@ -477,14 +497,19 @@ func (e *Evaluator) applyDepsDevDeprecated(_ context.Context, a *domain.Analysis
 		return false
 	}
 	eco := strings.ToLower(parsed.GetEcosystem())
-	if _, ok := depsDevFallbackEcosystems[eco]; !ok {
+	if _, hasAuthRule := ecosystemsWithAuthoritativeRules[eco]; hasAuthRule {
+		return false
+	}
+	ref := links.BuildDepsDevVersionURL(eco, parsed.Name(), a.ReleaseInfo.StableVersion.Version)
+	if ref == "" {
+		// deps.dev does not host this ecosystem; no useful evidence URL to emit.
 		return false
 	}
 	status.State = domain.EOLEndOfLife
 	status.Evidences = append(status.Evidences, domain.EOLEvidence{
 		Source:     "deps.dev",
 		Summary:    "Marked deprecated in deps.dev",
-		Reference:  "https://deps.dev/" + eco + "/" + parsed.Name() + "/" + a.ReleaseInfo.StableVersion.Version,
+		Reference:  ref,
 		Confidence: 0.95,
 	})
 	slog.Debug("eol: deps.dev deprecated fallback", "ecosystem", eco, "name", parsed.Name(), "version", a.ReleaseInfo.StableVersion.Version)

--- a/internal/infrastructure/eolevaluator/evaluator_cargo_yanked_test.go
+++ b/internal/infrastructure/eolevaluator/evaluator_cargo_yanked_test.go
@@ -1,0 +1,97 @@
+package eolevaluator
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	domain "github.com/future-architect/uzomuzo-oss/internal/domain/analysis"
+	"github.com/future-architect/uzomuzo-oss/internal/infrastructure/crates"
+)
+
+func TestEvaluator_Cargo_Yanked(t *testing.T) {
+	var capturedPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"version":{"crate":"openssl","num":"0.10.45","yanked":true}}`))
+	}))
+	defer srv.Close()
+
+	cc := crates.NewClient()
+	cc.SetBaseURL(srv.URL)
+	cc.SetCacheTTL(0)
+
+	ev := NewEvaluator(nil)
+	ev.SetMaxWorkers(1)
+	ev.SetCratesClient(cc)
+
+	analysis := &domain.Analysis{Package: &domain.Package{PURL: "pkg:cargo/openssl@0.10.45", Ecosystem: "cargo"}}
+	out, err := ev.EvaluateBatch(context.Background(), map[string]*domain.Analysis{"k": analysis})
+	if err != nil {
+		t.Fatalf("EvaluateBatch failed: %v", err)
+	}
+	st := out["k"]
+	if st.State != domain.EOLEndOfLife {
+		t.Fatalf("expected EOLEndOfLife on yanked crate, got %v", st.State)
+	}
+	if capturedPath != "/api/v1/crates/openssl/0.10.45" {
+		t.Errorf("unexpected request path: got %q, want /api/v1/crates/openssl/0.10.45", capturedPath)
+	}
+	found := false
+	for _, evd := range st.Evidences {
+		if evd.Source == "crates.io" && evd.Confidence == 1.0 && evd.Reference == "https://crates.io/crates/openssl/0.10.45" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected crates.io yanked evidence, got %#v", st.Evidences)
+	}
+}
+
+func TestEvaluator_Cargo_NotYanked(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"version":{"crate":"serde","num":"1.0.197","yanked":false}}`))
+	}))
+	defer srv.Close()
+
+	cc := crates.NewClient()
+	cc.SetBaseURL(srv.URL)
+	cc.SetCacheTTL(0)
+
+	ev := NewEvaluator(nil)
+	ev.SetMaxWorkers(1)
+	ev.SetCratesClient(cc)
+
+	analysis := &domain.Analysis{Package: &domain.Package{PURL: "pkg:cargo/serde@1.0.197", Ecosystem: "cargo"}}
+	out, err := ev.EvaluateBatch(context.Background(), map[string]*domain.Analysis{"k": analysis})
+	if err != nil {
+		t.Fatalf("EvaluateBatch failed: %v", err)
+	}
+	if out["k"].State == domain.EOLEndOfLife {
+		t.Fatalf("expected non-EOL on healthy crate, got EOL")
+	}
+}
+
+func TestEvaluator_Cargo_NonCargoPURL_NoFetch(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Errorf("crates server should not be hit for non-cargo PURL")
+		w.WriteHeader(500)
+	}))
+	defer srv.Close()
+
+	cc := crates.NewClient()
+	cc.SetBaseURL(srv.URL)
+	cc.SetCacheTTL(0)
+
+	ev := NewEvaluator(nil)
+	ev.SetMaxWorkers(1)
+	ev.SetCratesClient(cc)
+
+	analysis := &domain.Analysis{Package: &domain.Package{PURL: "pkg:npm/foo@1.0.0", Ecosystem: "npm"}}
+	if _, err := ev.EvaluateBatch(context.Background(), map[string]*domain.Analysis{"k": analysis}); err != nil {
+		t.Fatalf("EvaluateBatch failed: %v", err)
+	}
+}

--- a/internal/infrastructure/eolevaluator/evaluator_depsdev_fallback_test.go
+++ b/internal/infrastructure/eolevaluator/evaluator_depsdev_fallback_test.go
@@ -2,24 +2,44 @@ package eolevaluator
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	domain "github.com/future-architect/uzomuzo-oss/internal/domain/analysis"
 )
 
-func TestEvaluator_DepsDevFallback_FiresOnAllowedEcosystem(t *testing.T) {
-	for _, eco := range []string{"golang", "gem", "pub", "hex", "conan"} {
-		t.Run(eco, func(t *testing.T) {
-			purlStr := "pkg:" + eco + "/example@1.0.0"
-			if eco == "golang" {
-				purlStr = "pkg:golang/example.com/foo@1.0.0"
-			}
+// fallbackCases enumerates ecosystems where deps.dev hosts data AND we have no
+// authoritative ecosystem-specific rule. Today this is golang (deps.dev "go")
+// and gem (deps.dev "rubygems").
+var fallbackCases = []struct {
+	purlEcosystem      string
+	purlStr            string
+	version            string
+	wantRefHasSegments []string // expected substrings in the Reference URL
+}{
+	{
+		purlEcosystem:      "golang",
+		purlStr:            "pkg:golang/example.com/foo@1.0.0",
+		version:            "1.0.0",
+		wantRefHasSegments: []string{"https://deps.dev/go/", "1.0.0"}, // ecosystem normalized to "go"
+	},
+	{
+		purlEcosystem:      "gem",
+		purlStr:            "pkg:gem/rails@7.0.0",
+		version:            "7.0.0",
+		wantRefHasSegments: []string{"https://deps.dev/rubygems/rails/7.0.0"}, // gem → rubygems
+	},
+}
+
+func TestEvaluator_DepsDevFallback_FiresOnSupportedEcosystem(t *testing.T) {
+	for _, tc := range fallbackCases {
+		t.Run(tc.purlEcosystem, func(t *testing.T) {
 			ev := NewEvaluator(nil)
 			ev.SetMaxWorkers(1)
 			analysis := &domain.Analysis{
-				Package: &domain.Package{PURL: purlStr, Ecosystem: eco},
+				Package: &domain.Package{PURL: tc.purlStr, Ecosystem: tc.purlEcosystem},
 				ReleaseInfo: &domain.ReleaseInfo{
-					StableVersion: &domain.VersionDetail{Version: "1.0.0", IsDeprecated: true},
+					StableVersion: &domain.VersionDetail{Version: tc.version, IsDeprecated: true},
 				},
 			}
 			out, err := ev.EvaluateBatch(context.Background(), map[string]*domain.Analysis{"k": analysis})
@@ -28,17 +48,25 @@ func TestEvaluator_DepsDevFallback_FiresOnAllowedEcosystem(t *testing.T) {
 			}
 			st := out["k"]
 			if st.State != domain.EOLEndOfLife {
-				t.Fatalf("[%s] expected EOLEndOfLife from deps.dev fallback, got %v", eco, st.State)
+				t.Fatalf("[%s] expected EOLEndOfLife from deps.dev fallback, got %v", tc.purlEcosystem, st.State)
 			}
-			found := false
-			for _, evd := range st.Evidences {
-				if evd.Source == "deps.dev" && evd.Confidence == 0.95 {
-					found = true
+			var ev0 *domain.EOLEvidence
+			for i := range st.Evidences {
+				if st.Evidences[i].Source == "deps.dev" {
+					ev0 = &st.Evidences[i]
 					break
 				}
 			}
-			if !found {
-				t.Fatalf("[%s] expected deps.dev evidence with confidence 0.95, got %#v", eco, st.Evidences)
+			if ev0 == nil {
+				t.Fatalf("[%s] expected deps.dev evidence, got %#v", tc.purlEcosystem, st.Evidences)
+			}
+			if ev0.Confidence != 0.95 {
+				t.Errorf("[%s] expected Confidence 0.95, got %v", tc.purlEcosystem, ev0.Confidence)
+			}
+			for _, seg := range tc.wantRefHasSegments {
+				if !strings.Contains(ev0.Reference, seg) {
+					t.Errorf("[%s] expected Reference to contain %q, got %q", tc.purlEcosystem, seg, ev0.Reference)
+				}
 			}
 		})
 	}
@@ -53,16 +81,19 @@ func TestEvaluator_DepsDevFallback_DoesNotFire_NotDeprecated(t *testing.T) {
 			StableVersion: &domain.VersionDetail{Version: "1.0.0", IsDeprecated: false},
 		},
 	}
-	out, _ := ev.EvaluateBatch(context.Background(), map[string]*domain.Analysis{"k": analysis})
+	out, err := ev.EvaluateBatch(context.Background(), map[string]*domain.Analysis{"k": analysis})
+	if err != nil {
+		t.Fatalf("EvaluateBatch failed: %v", err)
+	}
 	if out["k"].State == domain.EOLEndOfLife {
 		t.Fatalf("expected non-EOL when IsDeprecated=false, got EOL")
 	}
 }
 
-func TestEvaluator_DepsDevFallback_DoesNotFire_DisallowedEcosystem(t *testing.T) {
-	// npm/pypi/maven/nuget/composer/cargo are excluded from the deps.dev allow-list
-	// because authoritative ecosystem-specific rules cover them.
-	for _, eco := range []string{"npm", "pypi", "maven", "nuget", "composer", "cargo"} {
+func TestEvaluator_DepsDevFallback_DoesNotFire_AuthoritativeEcosystem(t *testing.T) {
+	// Ecosystems with ecosystem-specific authoritative rules must not be touched
+	// by the fallback even when deps.dev reports IsDeprecated=true.
+	for _, eco := range []string{"npm", "pypi", "maven", "nuget", "composer", "packagist", "cargo"} {
 		t.Run(eco, func(t *testing.T) {
 			purlStr := "pkg:" + eco + "/foo@1.0.0"
 			if eco == "maven" {
@@ -70,8 +101,10 @@ func TestEvaluator_DepsDevFallback_DoesNotFire_DisallowedEcosystem(t *testing.T)
 			}
 			ev := NewEvaluator(nil)
 			ev.SetMaxWorkers(1)
-			// Disable the ecosystem-specific clients to ensure the disallowed-ecosystem
-			// guard (not the chain short-circuit) is what blocks the fallback.
+			// Disable the ecosystem-specific clients so the authoritative rule
+			// returns false on fetch error and the chain progresses to the fallback.
+			// The fallback's allow-list (not the chain short-circuit) is what
+			// blocks the rule for these ecosystems.
 			ev.SetPyPIClient(nil)
 			ev.SetCratesClient(nil)
 			analysis := &domain.Analysis{
@@ -80,9 +113,36 @@ func TestEvaluator_DepsDevFallback_DoesNotFire_DisallowedEcosystem(t *testing.T)
 					StableVersion: &domain.VersionDetail{Version: "1.0.0", IsDeprecated: true},
 				},
 			}
-			out, _ := ev.EvaluateBatch(context.Background(), map[string]*domain.Analysis{"k": analysis})
+			out, err := ev.EvaluateBatch(context.Background(), map[string]*domain.Analysis{"k": analysis})
+			if err != nil {
+				t.Fatalf("[%s] EvaluateBatch failed: %v", eco, err)
+			}
 			if out["k"].State == domain.EOLEndOfLife {
-				t.Fatalf("[%s] expected non-EOL (ecosystem excluded from deps.dev fallback), got EOL", eco)
+				t.Fatalf("[%s] expected non-EOL (ecosystem covered by authoritative rule), got EOL", eco)
+			}
+		})
+	}
+}
+
+func TestEvaluator_DepsDevFallback_DoesNotFire_DepsDevUnsupportedEcosystem(t *testing.T) {
+	// deps.dev does not host pub / hex / conan; the fallback must skip these
+	// rather than emit an unreachable evidence URL.
+	for _, eco := range []string{"pub", "hex", "conan"} {
+		t.Run(eco, func(t *testing.T) {
+			ev := NewEvaluator(nil)
+			ev.SetMaxWorkers(1)
+			analysis := &domain.Analysis{
+				Package: &domain.Package{PURL: "pkg:" + eco + "/foo@1.0.0", Ecosystem: eco},
+				ReleaseInfo: &domain.ReleaseInfo{
+					StableVersion: &domain.VersionDetail{Version: "1.0.0", IsDeprecated: true},
+				},
+			}
+			out, err := ev.EvaluateBatch(context.Background(), map[string]*domain.Analysis{"k": analysis})
+			if err != nil {
+				t.Fatalf("[%s] EvaluateBatch failed: %v", eco, err)
+			}
+			if out["k"].State == domain.EOLEndOfLife {
+				t.Fatalf("[%s] expected non-EOL (deps.dev does not host this ecosystem), got EOL", eco)
 			}
 		})
 	}
@@ -93,7 +153,7 @@ func TestEvaluator_DepsDevFallback_DoesNotFire_NilReleaseInfo(t *testing.T) {
 	ev.SetMaxWorkers(1)
 	analysis := &domain.Analysis{
 		Package:     &domain.Package{PURL: "pkg:golang/example.com/foo@1.0.0", Ecosystem: "golang"},
-		ReleaseInfo: nil, // explicit nil
+		ReleaseInfo: nil,
 	}
 	out, err := ev.EvaluateBatch(context.Background(), map[string]*domain.Analysis{"k": analysis})
 	if err != nil {
@@ -101,5 +161,23 @@ func TestEvaluator_DepsDevFallback_DoesNotFire_NilReleaseInfo(t *testing.T) {
 	}
 	if out["k"].State == domain.EOLEndOfLife {
 		t.Fatalf("expected non-EOL when ReleaseInfo nil, got EOL")
+	}
+}
+
+func TestEvaluator_DepsDevFallback_DoesNotFire_EmptyVersion(t *testing.T) {
+	ev := NewEvaluator(nil)
+	ev.SetMaxWorkers(1)
+	analysis := &domain.Analysis{
+		Package: &domain.Package{PURL: "pkg:golang/example.com/foo@1.0.0", Ecosystem: "golang"},
+		ReleaseInfo: &domain.ReleaseInfo{
+			StableVersion: &domain.VersionDetail{Version: "", IsDeprecated: true},
+		},
+	}
+	out, err := ev.EvaluateBatch(context.Background(), map[string]*domain.Analysis{"k": analysis})
+	if err != nil {
+		t.Fatalf("EvaluateBatch failed: %v", err)
+	}
+	if out["k"].State == domain.EOLEndOfLife {
+		t.Fatalf("expected non-EOL when StableVersion.Version empty, got EOL")
 	}
 }

--- a/internal/infrastructure/eolevaluator/evaluator_depsdev_fallback_test.go
+++ b/internal/infrastructure/eolevaluator/evaluator_depsdev_fallback_test.go
@@ -1,0 +1,105 @@
+package eolevaluator
+
+import (
+	"context"
+	"testing"
+
+	domain "github.com/future-architect/uzomuzo-oss/internal/domain/analysis"
+)
+
+func TestEvaluator_DepsDevFallback_FiresOnAllowedEcosystem(t *testing.T) {
+	for _, eco := range []string{"golang", "gem", "pub", "hex", "conan"} {
+		t.Run(eco, func(t *testing.T) {
+			purlStr := "pkg:" + eco + "/example@1.0.0"
+			if eco == "golang" {
+				purlStr = "pkg:golang/example.com/foo@1.0.0"
+			}
+			ev := NewEvaluator(nil)
+			ev.SetMaxWorkers(1)
+			analysis := &domain.Analysis{
+				Package: &domain.Package{PURL: purlStr, Ecosystem: eco},
+				ReleaseInfo: &domain.ReleaseInfo{
+					StableVersion: &domain.VersionDetail{Version: "1.0.0", IsDeprecated: true},
+				},
+			}
+			out, err := ev.EvaluateBatch(context.Background(), map[string]*domain.Analysis{"k": analysis})
+			if err != nil {
+				t.Fatalf("EvaluateBatch failed: %v", err)
+			}
+			st := out["k"]
+			if st.State != domain.EOLEndOfLife {
+				t.Fatalf("[%s] expected EOLEndOfLife from deps.dev fallback, got %v", eco, st.State)
+			}
+			found := false
+			for _, evd := range st.Evidences {
+				if evd.Source == "deps.dev" && evd.Confidence == 0.95 {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Fatalf("[%s] expected deps.dev evidence with confidence 0.95, got %#v", eco, st.Evidences)
+			}
+		})
+	}
+}
+
+func TestEvaluator_DepsDevFallback_DoesNotFire_NotDeprecated(t *testing.T) {
+	ev := NewEvaluator(nil)
+	ev.SetMaxWorkers(1)
+	analysis := &domain.Analysis{
+		Package: &domain.Package{PURL: "pkg:golang/example.com/foo@1.0.0", Ecosystem: "golang"},
+		ReleaseInfo: &domain.ReleaseInfo{
+			StableVersion: &domain.VersionDetail{Version: "1.0.0", IsDeprecated: false},
+		},
+	}
+	out, _ := ev.EvaluateBatch(context.Background(), map[string]*domain.Analysis{"k": analysis})
+	if out["k"].State == domain.EOLEndOfLife {
+		t.Fatalf("expected non-EOL when IsDeprecated=false, got EOL")
+	}
+}
+
+func TestEvaluator_DepsDevFallback_DoesNotFire_DisallowedEcosystem(t *testing.T) {
+	// npm/pypi/maven/nuget/composer/cargo are excluded from the deps.dev allow-list
+	// because authoritative ecosystem-specific rules cover them.
+	for _, eco := range []string{"npm", "pypi", "maven", "nuget", "composer", "cargo"} {
+		t.Run(eco, func(t *testing.T) {
+			purlStr := "pkg:" + eco + "/foo@1.0.0"
+			if eco == "maven" {
+				purlStr = "pkg:maven/group/foo@1.0.0"
+			}
+			ev := NewEvaluator(nil)
+			ev.SetMaxWorkers(1)
+			// Disable the ecosystem-specific clients to ensure the disallowed-ecosystem
+			// guard (not the chain short-circuit) is what blocks the fallback.
+			ev.SetPyPIClient(nil)
+			ev.SetCratesClient(nil)
+			analysis := &domain.Analysis{
+				Package: &domain.Package{PURL: purlStr, Ecosystem: eco},
+				ReleaseInfo: &domain.ReleaseInfo{
+					StableVersion: &domain.VersionDetail{Version: "1.0.0", IsDeprecated: true},
+				},
+			}
+			out, _ := ev.EvaluateBatch(context.Background(), map[string]*domain.Analysis{"k": analysis})
+			if out["k"].State == domain.EOLEndOfLife {
+				t.Fatalf("[%s] expected non-EOL (ecosystem excluded from deps.dev fallback), got EOL", eco)
+			}
+		})
+	}
+}
+
+func TestEvaluator_DepsDevFallback_DoesNotFire_NilReleaseInfo(t *testing.T) {
+	ev := NewEvaluator(nil)
+	ev.SetMaxWorkers(1)
+	analysis := &domain.Analysis{
+		Package:     &domain.Package{PURL: "pkg:golang/example.com/foo@1.0.0", Ecosystem: "golang"},
+		ReleaseInfo: nil, // explicit nil
+	}
+	out, err := ev.EvaluateBatch(context.Background(), map[string]*domain.Analysis{"k": analysis})
+	if err != nil {
+		t.Fatalf("EvaluateBatch failed: %v", err)
+	}
+	if out["k"].State == domain.EOLEndOfLife {
+		t.Fatalf("expected non-EOL when ReleaseInfo nil, got EOL")
+	}
+}

--- a/internal/infrastructure/eolevaluator/evaluator_pypi_yanked_test.go
+++ b/internal/infrastructure/eolevaluator/evaluator_pypi_yanked_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 
 	domain "github.com/future-architect/uzomuzo-oss/internal/domain/analysis"
@@ -85,7 +86,10 @@ func TestEvaluator_PyPI_AllUrlsYanked(t *testing.T) {
 		Package:     &domain.Package{PURL: "pkg:pypi/pkg@1.0.0", Ecosystem: "pypi"},
 		ReleaseInfo: &domain.ReleaseInfo{StableVersion: &domain.VersionDetail{Version: "1.0.0"}},
 	}
-	out, _ := ev.EvaluateBatch(context.Background(), map[string]*domain.Analysis{"k": analysis})
+	out, err := ev.EvaluateBatch(context.Background(), map[string]*domain.Analysis{"k": analysis})
+	if err != nil {
+		t.Fatalf("EvaluateBatch failed: %v", err)
+	}
 	if out["k"].State != domain.EOLEndOfLife {
 		t.Fatalf("expected EOLEndOfLife when all urls yanked, got %v", out["k"].State)
 	}
@@ -113,8 +117,76 @@ func TestEvaluator_PyPI_NotYanked(t *testing.T) {
 		Package:     &domain.Package{PURL: "pkg:pypi/pkg@1.0.0", Ecosystem: "pypi"},
 		ReleaseInfo: &domain.ReleaseInfo{StableVersion: &domain.VersionDetail{Version: "1.0.0"}},
 	}
-	out, _ := ev.EvaluateBatch(context.Background(), map[string]*domain.Analysis{"k": analysis})
+	out, err := ev.EvaluateBatch(context.Background(), map[string]*domain.Analysis{"k": analysis})
+	if err != nil {
+		t.Fatalf("EvaluateBatch failed: %v", err)
+	}
 	if out["k"].State == domain.EOLEndOfLife {
 		t.Fatalf("expected non-EOL on healthy PyPI version, got EOL")
+	}
+}
+
+// TestEvaluator_PyPI_Yanked_PreferPURLVersionOverStable verifies that the rule
+// checks the PURL-pinned version (yanked) rather than the latest StableVersion
+// (healthy). Yanking is a version-specific signal — checking StableVersion
+// would silently miss a user pinned to a yanked release.
+func TestEvaluator_PyPI_Yanked_PreferPURLVersionOverStable(t *testing.T) {
+	var (
+		mu             sync.Mutex
+		requestedPaths []string
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requestedPaths = append(requestedPaths, r.URL.Path)
+		mu.Unlock()
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/2.30.0/json"):
+			// PURL-pinned version is yanked.
+			_, _ = w.Write([]byte(`{"info":{"name":"requests","version":"2.30.0","yanked":true},"urls":[{"yanked":true}]}`))
+		case strings.HasSuffix(r.URL.Path, "/2.31.0/json"):
+			// StableVersion is healthy.
+			_, _ = w.Write([]byte(`{"info":{"name":"requests","version":"2.31.0","yanked":false},"urls":[{"yanked":false}]}`))
+		default:
+			// project endpoint
+			_, _ = w.Write([]byte(`{"info":{"name":"requests","summary":"","description":"","classifiers":["Development Status :: 5 - Production/Stable"]}}`))
+		}
+	}))
+	defer srv.Close()
+
+	pc := pypi.NewClient()
+	pc.SetBaseURL(srv.URL)
+	pc.SetCacheTTL(0)
+
+	ev := NewEvaluator(nil)
+	ev.SetMaxWorkers(1)
+	ev.SetPyPIClient(pc)
+
+	analysis := &domain.Analysis{
+		Package: &domain.Package{PURL: "pkg:pypi/requests@2.30.0", Ecosystem: "pypi"},
+		ReleaseInfo: &domain.ReleaseInfo{
+			StableVersion: &domain.VersionDetail{Version: "2.31.0"}, // newer healthy version
+		},
+	}
+	out, err := ev.EvaluateBatch(context.Background(), map[string]*domain.Analysis{"k": analysis})
+	if err != nil {
+		t.Fatalf("EvaluateBatch failed: %v", err)
+	}
+	if out["k"].State != domain.EOLEndOfLife {
+		t.Fatalf("expected EOLEndOfLife on PURL-pinned yanked version, got %v", out["k"].State)
+	}
+	mu.Lock()
+	paths := append([]string(nil), requestedPaths...)
+	mu.Unlock()
+	queriedPURL := false
+	for _, p := range paths {
+		if strings.HasSuffix(p, "/2.30.0/json") {
+			queriedPURL = true
+		}
+		if strings.HasSuffix(p, "/2.31.0/json") {
+			t.Errorf("rule must not query StableVersion (2.31.0); got path %q", p)
+		}
+	}
+	if !queriedPURL {
+		t.Errorf("expected rule to query PURL version 2.30.0; paths=%v", paths)
 	}
 }

--- a/internal/infrastructure/eolevaluator/evaluator_pypi_yanked_test.go
+++ b/internal/infrastructure/eolevaluator/evaluator_pypi_yanked_test.go
@@ -1,0 +1,120 @@
+package eolevaluator
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	domain "github.com/future-architect/uzomuzo-oss/internal/domain/analysis"
+	"github.com/future-architect/uzomuzo-oss/internal/infrastructure/pypi"
+)
+
+func TestEvaluator_PyPI_InfoYanked(t *testing.T) {
+	var capturedPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		// Distinguish project (classifier) endpoint vs version endpoint.
+		if !strings.HasSuffix(r.URL.Path, "/2.30.0/json") {
+			// /pypi/{name}/json — return non-inactive classifier so applyPyPIClassifier doesn't fire.
+			_, _ = w.Write([]byte(`{"info":{"name":"requests","summary":"","description":"","classifiers":["Development Status :: 5 - Production/Stable"]}}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"info":{"name":"requests","version":"2.30.0","yanked":true,"yanked_reason":"CVE-2024-XXXX"},"urls":[{"yanked":true}]}`))
+	}))
+	defer srv.Close()
+
+	pc := pypi.NewClient()
+	pc.SetBaseURL(srv.URL)
+	pc.SetCacheTTL(0)
+
+	ev := NewEvaluator(nil)
+	ev.SetMaxWorkers(1)
+	ev.SetPyPIClient(pc)
+
+	analysis := &domain.Analysis{
+		Package: &domain.Package{PURL: "pkg:pypi/requests@2.30.0", Ecosystem: "pypi"},
+		ReleaseInfo: &domain.ReleaseInfo{
+			StableVersion: &domain.VersionDetail{Version: "2.30.0"},
+		},
+	}
+	out, err := ev.EvaluateBatch(context.Background(), map[string]*domain.Analysis{"k": analysis})
+	if err != nil {
+		t.Fatalf("EvaluateBatch failed: %v", err)
+	}
+	st := out["k"]
+	if st.State != domain.EOLEndOfLife {
+		t.Fatalf("expected EOLEndOfLife on yanked PyPI version, got %v", st.State)
+	}
+	if capturedPath != "/pypi/requests/2.30.0/json" {
+		t.Errorf("unexpected last path: got %q", capturedPath)
+	}
+	found := false
+	for _, evd := range st.Evidences {
+		if evd.Source == "PyPI" && evd.Confidence == 0.95 && strings.Contains(evd.Summary, "CVE-2024-XXXX") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected pypi yanked evidence with reason, got %#v", st.Evidences)
+	}
+}
+
+func TestEvaluator_PyPI_AllUrlsYanked(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/1.0.0/json") {
+			_, _ = w.Write([]byte(`{"info":{"name":"pkg","summary":"","description":"","classifiers":["Development Status :: 5 - Production/Stable"]}}`))
+			return
+		}
+		// info.yanked=false, but every distribution URL is yanked.
+		_, _ = w.Write([]byte(`{"info":{"name":"pkg","version":"1.0.0","yanked":false},"urls":[{"yanked":true},{"yanked":true}]}`))
+	}))
+	defer srv.Close()
+
+	pc := pypi.NewClient()
+	pc.SetBaseURL(srv.URL)
+	pc.SetCacheTTL(0)
+
+	ev := NewEvaluator(nil)
+	ev.SetMaxWorkers(1)
+	ev.SetPyPIClient(pc)
+
+	analysis := &domain.Analysis{
+		Package:     &domain.Package{PURL: "pkg:pypi/pkg@1.0.0", Ecosystem: "pypi"},
+		ReleaseInfo: &domain.ReleaseInfo{StableVersion: &domain.VersionDetail{Version: "1.0.0"}},
+	}
+	out, _ := ev.EvaluateBatch(context.Background(), map[string]*domain.Analysis{"k": analysis})
+	if out["k"].State != domain.EOLEndOfLife {
+		t.Fatalf("expected EOLEndOfLife when all urls yanked, got %v", out["k"].State)
+	}
+}
+
+func TestEvaluator_PyPI_NotYanked(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/1.0.0/json") {
+			_, _ = w.Write([]byte(`{"info":{"name":"pkg","summary":"","description":"","classifiers":["Development Status :: 5 - Production/Stable"]}}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"info":{"name":"pkg","version":"1.0.0","yanked":false},"urls":[{"yanked":false}]}`))
+	}))
+	defer srv.Close()
+
+	pc := pypi.NewClient()
+	pc.SetBaseURL(srv.URL)
+	pc.SetCacheTTL(0)
+
+	ev := NewEvaluator(nil)
+	ev.SetMaxWorkers(1)
+	ev.SetPyPIClient(pc)
+
+	analysis := &domain.Analysis{
+		Package:     &domain.Package{PURL: "pkg:pypi/pkg@1.0.0", Ecosystem: "pypi"},
+		ReleaseInfo: &domain.ReleaseInfo{StableVersion: &domain.VersionDetail{Version: "1.0.0"}},
+	}
+	out, _ := ev.EvaluateBatch(context.Background(), map[string]*domain.Analysis{"k": analysis})
+	if out["k"].State == domain.EOLEndOfLife {
+		t.Fatalf("expected non-EOL on healthy PyPI version, got EOL")
+	}
+}

--- a/internal/infrastructure/eolevaluator/helpers.go
+++ b/internal/infrastructure/eolevaluator/helpers.go
@@ -97,47 +97,6 @@ func parseNuGetIDFromPURL(purl string) string {
 	return id
 }
 
-// parseCargoNameVersionFromPURL extracts (name, version) from a Cargo PURL like:
-//
-//	pkg:cargo/serde@1.0.197
-//
-// Returns empty strings when not a Cargo PURL or when components are missing.
-func parseCargoNameVersionFromPURL(purl string) (string, string) {
-	s := strings.TrimSpace(purl)
-	if s == "" || !strings.HasPrefix(s, "pkg:") {
-		return "", ""
-	}
-	s = strings.TrimPrefix(s, "pkg:")
-	slash := strings.IndexByte(s, '/')
-	if slash < 0 {
-		return "", ""
-	}
-	typ := s[:slash]
-	rest := s[slash+1:]
-	if !strings.EqualFold(typ, "cargo") {
-		return "", ""
-	}
-	at := strings.IndexByte(rest, '@')
-	if at < 0 {
-		return "", ""
-	}
-	name := rest[:at]
-	verRest := rest[at+1:]
-	cut := len(verRest)
-	if i := strings.IndexByte(verRest, '?'); i >= 0 && i < cut {
-		cut = i
-	}
-	if i := strings.IndexByte(verRest, '#'); i >= 0 && i < cut {
-		cut = i
-	}
-	version := strings.TrimSpace(verRest[:cut])
-	name = strings.TrimSpace(name)
-	if name == "" || version == "" {
-		return "", ""
-	}
-	return name, version
-}
-
 // parseMavenFromPURL extracts (groupId, artifactId, version) from a PURL like:
 //
 //	pkg:maven/group.id/artifact-id@1.2.3

--- a/internal/infrastructure/eolevaluator/helpers.go
+++ b/internal/infrastructure/eolevaluator/helpers.go
@@ -97,6 +97,47 @@ func parseNuGetIDFromPURL(purl string) string {
 	return id
 }
 
+// parseCargoNameVersionFromPURL extracts (name, version) from a Cargo PURL like:
+//
+//	pkg:cargo/serde@1.0.197
+//
+// Returns empty strings when not a Cargo PURL or when components are missing.
+func parseCargoNameVersionFromPURL(purl string) (string, string) {
+	s := strings.TrimSpace(purl)
+	if s == "" || !strings.HasPrefix(s, "pkg:") {
+		return "", ""
+	}
+	s = strings.TrimPrefix(s, "pkg:")
+	slash := strings.IndexByte(s, '/')
+	if slash < 0 {
+		return "", ""
+	}
+	typ := s[:slash]
+	rest := s[slash+1:]
+	if !strings.EqualFold(typ, "cargo") {
+		return "", ""
+	}
+	at := strings.IndexByte(rest, '@')
+	if at < 0 {
+		return "", ""
+	}
+	name := rest[:at]
+	verRest := rest[at+1:]
+	cut := len(verRest)
+	if i := strings.IndexByte(verRest, '?'); i >= 0 && i < cut {
+		cut = i
+	}
+	if i := strings.IndexByte(verRest, '#'); i >= 0 && i < cut {
+		cut = i
+	}
+	version := strings.TrimSpace(verRest[:cut])
+	name = strings.TrimSpace(name)
+	if name == "" || version == "" {
+		return "", ""
+	}
+	return name, version
+}
+
 // parseMavenFromPURL extracts (groupId, artifactId, version) from a PURL like:
 //
 //	pkg:maven/group.id/artifact-id@1.2.3

--- a/internal/infrastructure/pypi/client.go
+++ b/internal/infrastructure/pypi/client.go
@@ -32,7 +32,11 @@ type Client struct {
 
 	mu    sync.RWMutex
 	cache map[string]cacheEntry
-	ttl   time.Duration
+
+	versionMu    sync.RWMutex
+	versionCache map[string]versionCacheEntry // key: "name@version" (lowercased name)
+
+	ttl time.Duration
 
 	importCacheFields // wheel-based import name cache (lazily initialised)
 }
@@ -42,14 +46,20 @@ type cacheEntry struct {
 	ts   time.Time
 }
 
+type versionCacheEntry struct {
+	info *VersionInfo
+	ts   time.Time
+}
+
 // NewClient returns a PyPI client with sensible HTTP defaults.
 func NewClient() *Client { // nolint: revive
 	hc := &http.Client{Timeout: 5 * time.Second}
 	return &Client{
-		http:    httpclient.NewClient(hc, httpclient.RetryConfig{MaxRetries: 2, BaseBackoff: 400 * time.Millisecond, MaxBackoff: 2 * time.Second, RetryOn5xx: true, RetryOnNetworkErr: true}),
-		baseURL: "https://pypi.org",
-		cache:   make(map[string]cacheEntry),
-		ttl:     10 * time.Minute,
+		http:         httpclient.NewClient(hc, httpclient.RetryConfig{MaxRetries: 2, BaseBackoff: 400 * time.Millisecond, MaxBackoff: 2 * time.Second, RetryOn5xx: true, RetryOnNetworkErr: true}),
+		baseURL:      "https://pypi.org",
+		cache:        make(map[string]cacheEntry),
+		versionCache: make(map[string]versionCacheEntry),
+		ttl:          10 * time.Minute,
 	}
 }
 
@@ -121,6 +131,110 @@ type ProjectInfo struct {
 	Classifiers []string
 	ProjectURLs map[string]string // e.g. "Repository" -> "https://github.com/..."
 	HomePage    string
+}
+
+// VersionInfo is the minimal subset of PyPI version-level metadata we need.
+// Currently used for yanked-version detection during EOL evaluation.
+type VersionInfo struct {
+	Name         string
+	Version      string
+	Yanked       bool
+	YankedReason string // info.yanked_reason; optional
+}
+
+func (c *Client) getVersionCached(key string) (*VersionInfo, bool) {
+	if c.ttl <= 0 {
+		return nil, false
+	}
+	c.versionMu.RLock()
+	ent, ok := c.versionCache[key]
+	c.versionMu.RUnlock()
+	if !ok {
+		return nil, false
+	}
+	if time.Since(ent.ts) > c.ttl {
+		return nil, false
+	}
+	return ent.info, true
+}
+
+func (c *Client) setVersionCache(key string, info *VersionInfo) {
+	if c.ttl <= 0 || info == nil {
+		return
+	}
+	c.versionMu.Lock()
+	c.versionCache[key] = versionCacheEntry{info: info, ts: time.Now()}
+	c.versionMu.Unlock()
+}
+
+// GetVersion retrieves PyPI version-level metadata. Returns (info, found, err).
+// On 404 -> (nil, false, nil). Other non-200 -> error.
+//
+// Yanked is true when info.yanked is true OR every entry in urls[] is yanked.
+// Partial yanks (some distributions yanked, others not) are not considered
+// project-level EOL and yield Yanked = false.
+func (c *Client) GetVersion(ctx context.Context, name, version string) (*VersionInfo, bool, error) {
+	n := strings.TrimSpace(name)
+	v := strings.TrimSpace(version)
+	if n == "" || v == "" {
+		return nil, false, nil
+	}
+	lower := strings.ToLower(n)
+	key := lower + "@" + v
+	if info, ok := c.getVersionCached(key); ok {
+		slog.Debug("pypi: version cache hit", "name", lower, "version", v)
+		return info, true, nil
+	}
+	apiURL := fmt.Sprintf("%s/pypi/%s/%s/json", c.resolvedBaseURL(), url.PathEscape(n), url.PathEscape(v))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
+	if err != nil {
+		return nil, false, fmt.Errorf("pypi version request build failed: %w", err)
+	}
+	req.Header.Set("User-Agent", pypiUserAgent)
+	resp, err := c.http.Do(ctx, req)
+	if err != nil {
+		return nil, false, fmt.Errorf("pypi version http failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, false, nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, false, fmt.Errorf("pypi version http status %d", resp.StatusCode)
+	}
+	var raw struct {
+		Info struct {
+			Name         string `json:"name"`
+			Version      string `json:"version"`
+			Yanked       bool   `json:"yanked"`
+			YankedReason string `json:"yanked_reason"`
+		} `json:"info"`
+		URLs []struct {
+			Yanked bool `json:"yanked"`
+		} `json:"urls"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxJSONResponseSize)).Decode(&raw); err != nil {
+		return nil, false, fmt.Errorf("pypi version decode failed: %w", err)
+	}
+	yanked := raw.Info.Yanked
+	if !yanked && len(raw.URLs) > 0 {
+		allYanked := true
+		for _, u := range raw.URLs {
+			if !u.Yanked {
+				allYanked = false
+				break
+			}
+		}
+		yanked = allYanked
+	}
+	info := &VersionInfo{
+		Name:         raw.Info.Name,
+		Version:      raw.Info.Version,
+		Yanked:       yanked,
+		YankedReason: raw.Info.YankedReason,
+	}
+	c.setVersionCache(key, info)
+	return info, true, nil
 }
 
 // GetProject retrieves project info. Returns (info, found, err).

--- a/internal/infrastructure/pypi/client_test.go
+++ b/internal/infrastructure/pypi/client_test.go
@@ -277,3 +277,145 @@ func TestExtractRepoURL(t *testing.T) {
 		})
 	}
 }
+
+func TestGetVersion_InfoYanked(t *testing.T) {
+	t.Parallel()
+	var capturedPath atomic.Value
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath.Store(r.URL.Path)
+		_, _ = fmt.Fprintln(w, `{"info":{"name":"requests","version":"2.30.0","yanked":true,"yanked_reason":"security"},"urls":[{"yanked":true}]}`)
+	}))
+	defer srv.Close()
+
+	c := NewClient()
+	c.SetBaseURL(srv.URL)
+	c.SetCacheTTL(0)
+
+	info, found, err := c.GetVersion(context.Background(), "requests", "2.30.0")
+	if err != nil {
+		t.Fatalf("GetVersion failed: %v", err)
+	}
+	if !found || info == nil {
+		t.Fatalf("expected found=true with non-nil info")
+	}
+	if !info.Yanked {
+		t.Errorf("expected Yanked=true (info.yanked)")
+	}
+	if info.YankedReason != "security" {
+		t.Errorf("expected YankedReason=security, got %q", info.YankedReason)
+	}
+	if got := capturedPath.Load(); got != "/pypi/requests/2.30.0/json" {
+		t.Errorf("unexpected path: got %q, want /pypi/requests/2.30.0/json", got)
+	}
+}
+
+func TestGetVersion_AllUrlsYanked(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// info.yanked is false, but every distribution URL is yanked.
+		_, _ = fmt.Fprintln(w, `{"info":{"name":"pkg","version":"1.0.0","yanked":false},"urls":[{"yanked":true},{"yanked":true}]}`)
+	}))
+	defer srv.Close()
+
+	c := NewClient()
+	c.SetBaseURL(srv.URL)
+	c.SetCacheTTL(0)
+
+	info, _, err := c.GetVersion(context.Background(), "pkg", "1.0.0")
+	if err != nil {
+		t.Fatalf("GetVersion failed: %v", err)
+	}
+	if !info.Yanked {
+		t.Errorf("expected Yanked=true when all urls[].yanked=true")
+	}
+}
+
+func TestGetVersion_PartialYank(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// One distribution yanked, others not. Project-level yanked=false expected.
+		_, _ = fmt.Fprintln(w, `{"info":{"name":"pkg","version":"1.0.0","yanked":false},"urls":[{"yanked":true},{"yanked":false}]}`)
+	}))
+	defer srv.Close()
+
+	c := NewClient()
+	c.SetBaseURL(srv.URL)
+	c.SetCacheTTL(0)
+
+	info, _, err := c.GetVersion(context.Background(), "pkg", "1.0.0")
+	if err != nil {
+		t.Fatalf("GetVersion failed: %v", err)
+	}
+	if info.Yanked {
+		t.Errorf("expected Yanked=false on partial yank (one of two distributions)")
+	}
+}
+
+func TestGetVersion_NotFound(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := NewClient()
+	c.SetBaseURL(srv.URL)
+	c.SetCacheTTL(0)
+
+	info, found, err := c.GetVersion(context.Background(), "nope", "9.9.9")
+	if err != nil {
+		t.Fatalf("expected nil err on 404, got %v", err)
+	}
+	if found || info != nil {
+		t.Errorf("expected (nil,false,nil) on 404")
+	}
+}
+
+func TestGetVersion_Cache(t *testing.T) {
+	t.Parallel()
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		_, _ = fmt.Fprintln(w, `{"info":{"name":"x","version":"1.0.0","yanked":false},"urls":[]}`)
+	}))
+	defer srv.Close()
+
+	c := NewClient()
+	c.SetBaseURL(srv.URL)
+	c.SetCacheTTL(5 * time.Minute)
+
+	ctx := context.Background()
+	if _, _, err := c.GetVersion(ctx, "x", "1.0.0"); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	if _, _, err := c.GetVersion(ctx, "x", "1.0.0"); err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+	if got := atomic.LoadInt32(&hits); got != 1 {
+		t.Errorf("expected single network hit, got %d", got)
+	}
+	// Different version → cache miss.
+	if _, _, err := c.GetVersion(ctx, "x", "2.0.0"); err != nil {
+		t.Fatalf("third call: %v", err)
+	}
+	if got := atomic.LoadInt32(&hits); got != 2 {
+		t.Errorf("expected new hit for different version, got %d", got)
+	}
+}
+
+func TestGetVersion_EmptyArgs(t *testing.T) {
+	t.Parallel()
+	c := NewClient()
+	c.SetBaseURL("http://invalid.example.invalid")
+
+	for _, tc := range []struct{ name, ver string }{
+		{"", "1.0.0"},
+		{"pkg", ""},
+		{"   ", "1.0.0"},
+	} {
+		info, found, err := c.GetVersion(context.Background(), tc.name, tc.ver)
+		if err != nil || found || info != nil {
+			t.Errorf("expected (nil,false,nil) for empty args (%q,%q); got (%+v,%v,%v)", tc.name, tc.ver, info, found, err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds three terminal EOL detection rules to the eolevaluator rule chain (closes #331):

- **`applyCargoYanked`** — queries `https://crates.io/api/v1/crates/{name}/{version}` and promotes to EOL when `yanked=true` (Confidence 1.0).
- **`applyPyPIYanked`** — queries `https://pypi.org/pypi/{name}/{version}/json` and promotes to EOL when `info.yanked=true` OR every entry in `urls[]` is yanked (Confidence 0.95). Partial yanks (some distributions yanked, others not) are intentionally NOT treated as project-level EOL.
- **`applyDepsDevDeprecated`** — fallback rule that consumes `ReleaseInfo.StableVersion.IsDeprecated` for ecosystems lacking authoritative ecosystem-specific rules. Currently fires for golang and gem (the deps.dev-hosted ecosystems we don't yet cover directly). Confidence 0.95 (deps.dev acts as canonical aggregator). Placed LAST in the chain so authoritative rules short-circuit first.

### Supporting changes

- New `internal/infrastructure/crates/` package, modeled after `internal/infrastructure/pypi/` (httpclient retry config, in-memory cache with 10-min TTL, base URL override for tests).
- New `pypi.Client.GetVersion` method + version-keyed cache (separate from the project cache so `ProjectInfo` consumers are unaffected).
- New `ecosystemsWithAuthoritativeRules` set in `evaluator.go` — single source of truth listing ecosystems whose authoritative rules must take precedence over the deps.dev fallback. Adding a new authoritative rule for an ecosystem requires adding the ecosystem to this set.
- Reuses `internal/common/links.BuildDepsDevVersionURL` for evidence URL construction (correct ecosystem normalization: `golang→go`, `gem→rubygems`; URL escapes path components).
- `domain.VersionDetail.IsDeprecated` godoc updated to reflect that the field is now consumed by `applyDepsDevDeprecated` for unprivileged ecosystems.

### Confidence rationale

- cargo / pypi yanked = registry-direct, explicit flag → high confidence
- deps.dev fallback = canonical aggregator querying the same upstream registries we'd query directly → 0.95 (same as Maven relocation)
- See architect discussion in the planning thread for why "EOL-Effective vs Confirmed" is collapsed in OSS (`EOLStatus.ScheduledAt` is catalog-only; `LabelEOLEffective` cannot be expressed without a domain change)

## End-to-end verification on real packages

### Cargo yanked (`pkg:cargo/bumpalo@3.15.0`)

```
$ uzomuzo scan pkg:cargo/bumpalo@3.15.0
STATUS     PURL                      LIFECYCLE      BUILD
🔴 replace  pkg:cargo/bumpalo@3.15.0  EOL-Confirmed  —

── pkg:cargo/bumpalo@3.15.0 ────────────────────────────────
│ 🔴 EOL-Confirmed: Version yanked on crates.io
├─ EOL ─────────────────────────────────────────────────────
│ Evidence (1):
│   [crates.io] Version yanked on crates.io (confidence 1.00)
│     ↳ https://crates.io/crates/bumpalo/3.15.0
├─ Releases ────────────────────────────────────────────────
│ Stable: 3.20.2 (2026-02-19)
│ Requested: 3.15.0 (2024-02-15) ⚠️ [DEPRECATED]
```

### PyPI yanked with `yanked_reason` (`pkg:pypi/setuptools@71.0.1`)

```
$ uzomuzo scan pkg:pypi/setuptools@71.0.1
STATUS     PURL                        LIFECYCLE      BUILD
🔴 replace  pkg:pypi/setuptools@71.0.1  EOL-Confirmed  —

── pkg:pypi/setuptools@71.0.1 ──────────────────────────────
│ 🔴 EOL-Confirmed: Version yanked on PyPI: https://github.com/pypa/setuptools/issues/4480
├─ EOL ─────────────────────────────────────────────────────
│ Evidence (1):
│   [PyPI] Version yanked on PyPI: https://github.com/pypa/setuptools/issues/4480 (confidence 0.95)
│     ↳ https://pypi.org/project/setuptools/71.0.1/
```

### No false positives on healthy versions

```
$ uzomuzo scan pkg:cargo/bumpalo@3.20.2 pkg:pypi/setuptools@82.0.1
STATUS  PURL                        LIFECYCLE  BUILD
✅ ok    pkg:cargo/bumpalo@3.20.2    Active     Moderate 4.9
✅ ok    pkg:pypi/setuptools@82.0.1  Active     Moderate 3.1
2 dependencies | ✅ 2 ok | ⚠️ 0 caution | 🔴 0 replace | 🔍 0 review
```

### deps.dev fallback — coverage caveat

The `applyDepsDevDeprecated` rule is wired and unit-tested, but **deps.dev's `Version.IsDeprecated` field is currently sparse for golang and rubygems** in practice. Sampling popular Go modules with known retract directives (`etcd-io/bbolt`, `google.golang.org/appengine`, `dgrijalva/jwt-go`) and the rubygems flagship `rails`, deps.dev returned `isDeprecated=false` across all versions. By contrast, cargo (e.g., `bumpalo` has 13 deprecated versions on deps.dev) and pypi do have populated data — but those go through the authoritative crates.io / PyPI rules.

Net effect: the fallback is in place for whenever deps.dev backfills the data, but no real-world fires are expected today. This matches the issue's "Medium priority" classification.

## Test plan

- [x] `go test ./... -race -count=1` (full suite green)
- [x] `golangci-lint run` (0 issues)
- [x] `evaluator_cargo_yanked_test.go` — yanked / not-yanked / non-cargo PURL skipped
- [x] `evaluator_pypi_yanked_test.go` — `info.yanked` / all `urls[]` yanked / not-yanked / **PURL version preferred over StableVersion** (regression test for the intended precedence)
- [x] `evaluator_depsdev_fallback_test.go` — fires on golang+gem with normalized deps.dev URLs / does not fire when not deprecated / does not fire on authoritative ecosystems / does not fire on deps.dev-unsupported ecosystems (pub/hex/conan) / does not fire on nil `ReleaseInfo` / does not fire on empty `Version`
- [x] `crates/client_test.go` — yanked / not-yanked / 404 / empty args / cache TTL / User-Agent header / persistent 5xx error
- [x] `pypi/client_test.go` — `GetVersion` `info.yanked` / all-urls-yanked / partial-yank → not-yanked / 404 / cache / empty args
- [x] **End-to-end binary smoke test** (see "End-to-end verification" above): cargo yanked, PyPI yanked with reason, healthy versions correctly classified as Active

Refs #331

🤖 Generated with [Claude Code](https://claude.com/claude-code)