### PR TITLE
refactor: reuse JoinMavenName/JoinNpmName at duplicate sites

### DIFF
--- a/internal/infrastructure/integration/populate.go
+++ b/internal/infrastructure/integration/populate.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/future-architect/uzomuzo-oss/internal/common"
+	commonlinks "github.com/future-architect/uzomuzo-oss/internal/common/links"
 	"github.com/future-architect/uzomuzo-oss/internal/common/purl"
 	domain "github.com/future-architect/uzomuzo-oss/internal/domain/analysis"
 	"github.com/future-architect/uzomuzo-oss/internal/infrastructure/depsdev"
@@ -40,8 +41,10 @@ func (s *IntegrationService) populateAnalysisFromBatchResult(analysis *domain.An
 			if group != "" {
 				switch strings.ToLower(strings.TrimSpace(analysis.Package.Ecosystem)) {
 				case "maven":
-					finalName = group + ":" + pkgName
-				case "packagist", "composer", "npm":
+					finalName = commonlinks.JoinMavenName(group, pkgName)
+				case "npm":
+					finalName = commonlinks.JoinNpmName(group, pkgName)
+				case "packagist", "composer":
 					finalName = group + "/" + pkgName
 				}
 			}

--- a/internal/infrastructure/integration/populate_project.go
+++ b/internal/infrastructure/integration/populate_project.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/future-architect/uzomuzo-oss/internal/common"
+	commonlinks "github.com/future-architect/uzomuzo-oss/internal/common/links"
 	"github.com/future-architect/uzomuzo-oss/internal/common/purl"
 	domain "github.com/future-architect/uzomuzo-oss/internal/domain/analysis"
 	"github.com/future-architect/uzomuzo-oss/internal/infrastructure/depsdev"
@@ -147,8 +148,10 @@ func (s *IntegrationService) populateReleaseInfo(analysis *domain.Analysis, batc
 			if group != "" {
 				switch strings.ToLower(strings.TrimSpace(analysis.Package.Ecosystem)) {
 				case "maven":
-					finalName = group + ":" + pkgName
-				case "packagist", "composer", "npm":
+					finalName = commonlinks.JoinMavenName(group, pkgName)
+				case "npm":
+					finalName = commonlinks.JoinNpmName(group, pkgName)
+				case "packagist", "composer":
 					finalName = group + "/" + pkgName
 				}
 			}

--- a/internal/infrastructure/integration/service.go
+++ b/internal/infrastructure/integration/service.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/future-architect/uzomuzo-oss/internal/common"
+	commonlinks "github.com/future-architect/uzomuzo-oss/internal/common/links"
 	"github.com/future-architect/uzomuzo-oss/internal/common/purl"
 	domain "github.com/future-architect/uzomuzo-oss/internal/domain/analysis"
 	"github.com/future-architect/uzomuzo-oss/internal/domain/config"
@@ -182,8 +183,10 @@ func (s *IntegrationService) buildVersionDetail(src *depsdev.Version, analysis *
 			if group != "" {
 				switch strings.ToLower(strings.TrimSpace(analysis.Package.Ecosystem)) {
 				case "maven":
-					finalName = group + ":" + pkgName
-				case "packagist", "composer", "npm":
+					finalName = commonlinks.JoinMavenName(group, pkgName)
+				case "npm":
+					finalName = commonlinks.JoinNpmName(group, pkgName)
+				case "packagist", "composer":
 					finalName = group + "/" + pkgName
 				}
 			}

--- a/internal/infrastructure/npmjs/client.go
+++ b/internal/infrastructure/npmjs/client.go
@@ -278,8 +278,7 @@ func (c *Client) GetDeprecation(ctx context.Context, namespace, name, version st
 				info.Message = msg
 				if succ := extractNpmSuccessor(msg); succ != "" {
 					// Self-reference suppression: compare normalized tokens ignoring case.
-					fullName := links.JoinNpmName(ns, pkg)
-					if !strings.EqualFold(succ, pkg) && !strings.EqualFold(succ, fullName) {
+					if !strings.EqualFold(succ, pkg) && !strings.EqualFold(succ, full) {
 						info.Successor = succ
 					}
 				}

--- a/internal/infrastructure/npmjs/client.go
+++ b/internal/infrastructure/npmjs/client.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/future-architect/uzomuzo-oss/internal/common"
+	"github.com/future-architect/uzomuzo-oss/internal/common/links"
 	"github.com/future-architect/uzomuzo-oss/internal/infrastructure/httpclient"
 )
 
@@ -75,13 +76,7 @@ func (c *Client) GetRepoURL(ctx context.Context, namespace, name, version string
 	if pkg == "" {
 		return "", nil
 	}
-	if ns != "" && !strings.HasPrefix(ns, "@") {
-		ns = "@" + ns
-	}
-	full := pkg
-	if ns != "" {
-		full = ns + "/" + pkg
-	}
+	full := links.JoinNpmName(ns, pkg)
 	endpoint := fmt.Sprintf("%s/%s", c.baseURL, url.PathEscape(full))
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
@@ -246,13 +241,7 @@ func (c *Client) GetDeprecation(ctx context.Context, namespace, name, version st
 	if pkg == "" {
 		return nil, false, nil
 	}
-	if ns != "" && !strings.HasPrefix(ns, "@") {
-		ns = "@" + ns
-	}
-	full := pkg
-	if ns != "" {
-		full = ns + "/" + pkg
-	}
+	full := links.JoinNpmName(ns, pkg)
 	endpoint := fmt.Sprintf("%s/%s", c.baseURL, url.PathEscape(full))
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
@@ -289,10 +278,7 @@ func (c *Client) GetDeprecation(ctx context.Context, namespace, name, version st
 				info.Message = msg
 				if succ := extractNpmSuccessor(msg); succ != "" {
 					// Self-reference suppression: compare normalized tokens ignoring case.
-					fullName := pkg
-					if ns != "" {
-						fullName = ns + "/" + pkg
-					}
+					fullName := links.JoinNpmName(ns, pkg)
 					if !strings.EqualFold(succ, pkg) && !strings.EqualFold(succ, fullName) {
 						info.Successor = succ
 					}


### PR DESCRIPTION
## Summary

Closes #343.

Migrate six call sites that built canonical Maven/npm names by hand to delegate to the shared helpers introduced in #340 (`links.JoinMavenName` / `links.JoinNpmName`). Tightens the single-source-of-truth guarantee for `:`-joining (Maven) and `@scope/`-joining (npm).

### Changes

- **`internal/infrastructure/npmjs/client.go`** (3 sites): `GetRepoURL`, `GetDeprecation`, and the in-function `fullName` recomputation in `GetDeprecation` now use `links.JoinNpmName`. The helper is idempotent on the leading `@` so callers stay safe whether they pass `"@vue"` or `"vue"`.
- **`internal/infrastructure/integration/{populate,populate_project,service}.go`** (3 sites): split the maven/packagist/composer/npm switch arm so the maven and npm branches delegate to `commonlinks.{JoinMavenName,JoinNpmName}`. `packagist`/`composer` keep their inline `group + "/" + name` form (different semantics — those ecosystems do not prefix `@scope`).

### Behavior

Preserved. The only observable difference is in one debug log line in `npmjs.GetRepoURL` where `namespace` is now logged in its raw input form rather than the `@`-normalized form (the resolved `endpoint` URL still shows the canonical path, so the log remains debuggable).

## Test plan

- [x] `GOWORK=off go build ./...`
- [x] `GOWORK=off go test ./...` — all packages pass
- [x] `GOWORK=off go vet ./...`
- [x] `GOWORK=off goimports -l <changed files>` — clean
- [x] `GOWORK=off golangci-lint run ./internal/infrastructure/npmjs/... ./internal/infrastructure/integration/...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)