### PR TITLE
feat(licenses): SPDX expression parser with AST for SBOM/legal compliance (#351)

### DIFF
--- a/internal/domain/licenses/expression.go
+++ b/internal/domain/licenses/expression.go
@@ -59,7 +59,8 @@ type ExprCompound struct {
 
 // ExpressionResult is the outcome of parsing an SPDX license expression.
 type ExpressionResult struct {
-	// Raw is the original input string, before any trimming.
+	// Raw is the input as passed to ParseExpression, stored verbatim
+	// (no trimming, no canonicalization).
 	Raw string
 	// Root is the parsed AST. Nil for empty / oversized / fully-malformed input.
 	Root *ExprNode
@@ -103,6 +104,13 @@ const maxExpressionLength = 64 * 1024
 //     dropped (matches v1 contract).
 //   - A Compound with fewer than 2 children after parsing collapses to its
 //     single child or to nil; never emits a degenerate compound.
+//   - "(A OR B) WITH X" — SPDX-strict grammar forbids WITH on a compound,
+//     but real-world Maven / ClearlyDefined data ships it. The parser
+//     distributes the exception to every leaf so the legally-significant
+//     clause is preserved on each operand.
+//   - WITH chain ("A WITH B WITH C"): the first exception attaches to A;
+//     subsequent WITHs are silently truncated because parseWith only
+//     consumes one exception per primary.
 //   - The parser never returns an error — consumers ingesting external data
 //     can treat a nil Root as "could not extract any license info" and fall
 //     back to their non-SPDX path.
@@ -132,10 +140,12 @@ func ParseExpression(raw string) ExpressionResult {
 // operator gets parens. The result satisfies the idempotence property:
 // re-parsing the rendered string and rendering again produces the same text.
 //
-// Panics on any zero-valued or nil-operand node — these can only arise from
-// hand-built ASTs (the parser itself never produces them) and are surfaced
-// as programmer errors so a misuse is caught at the first render rather than
-// silently producing malformed SPDX text.
+// Panics on any malformed AST shape — zero-valued node (neither License nor
+// Compound), nil operand inside a Compound, or Compound with fewer than two
+// operands. These can only arise from hand-built ASTs (the parser itself
+// never produces them) and are surfaced as programmer errors so a misuse is
+// caught at the first render rather than silently producing malformed SPDX
+// text.
 func (n *ExprNode) String() string {
 	if n == nil {
 		return ""
@@ -145,6 +155,9 @@ func (n *ExprNode) String() string {
 	}
 	if n.Compound == nil {
 		panic("licenses.ExprNode: zero-valued node (neither License nor Compound)")
+	}
+	if len(n.Compound.Operands) < 2 {
+		panic("licenses.ExprNode: Compound must have at least two operands")
 	}
 	parts := make([]string, len(n.Compound.Operands))
 	for i, child := range n.Compound.Operands {
@@ -181,9 +194,20 @@ func (l *ExprLicense) String() string {
 // Returns nil when Root is nil so callers using a sentinel-nil check can
 // distinguish "no license info parsed" from "empty result accidentally
 // produced". This is the convenience accessor for consumers that do not need
-// operator structure (e.g., simple license enumeration).
+// operator structure (e.g., simple license enumeration in a CSV column).
 //
-// Panics if the AST contains a zero-valued ExprNode (programmer error).
+// Two caller-side caveats:
+//
+//   - Operator semantics are lost. A leaf-level walk cannot distinguish
+//     "must comply with all" (AND) from "choose any one" (OR). Consumers
+//     making legal-policy decisions must instead walk Root via the
+//     License/Compound discriminator and respect Compound.Operator.
+//   - The returned pointers alias live AST nodes. Mutating a leaf (e.g.,
+//     overwriting Identifier) silently corrupts the parsed tree shared
+//     with any other caller. Treat the returned slice as read-only or
+//     copy out the fields you need.
+//
+// Panics if the AST contains a malformed shape (programmer error).
 func (r ExpressionResult) Leaves() []*ExprLicense {
 	if r.Root == nil {
 		return nil
@@ -205,8 +229,9 @@ func needsParens(child *ExprNode, parentOp string) bool {
 }
 
 // walkLeaves appends every ExprLicense leaf reachable from n to out, in
-// reading order. Mirrors String()'s panic invariants: zero-valued and
-// nil-operand nodes are programmer errors and surface immediately.
+// reading order. Mirrors String()'s panic invariants: zero-valued node,
+// nil operand, and Compound with fewer than two operands are all
+// programmer errors and surface immediately.
 func walkLeaves(n *ExprNode, out *[]*ExprLicense) {
 	if n == nil {
 		return
@@ -217,6 +242,9 @@ func walkLeaves(n *ExprNode, out *[]*ExprLicense) {
 	}
 	if n.Compound == nil {
 		panic("licenses.ExprNode: zero-valued node during AST walk")
+	}
+	if len(n.Compound.Operands) < 2 {
+		panic("licenses.ExprNode: Compound must have at least two operands during AST walk")
 	}
 	for _, c := range n.Compound.Operands {
 		if c == nil {
@@ -402,16 +430,22 @@ func (p *parser) parseAnd() *ExprNode {
 
 // parseWith: with_expr = primary (WITH ident)?
 //
-// Two recovery paths for malformed inputs:
+// Recovery paths for malformed inputs:
 //
-//   - WITH is not followed by an identifier (`Apache-2.0 WITH`): the WITH
-//     token is consumed but not applied; the primary is returned untouched.
-//   - WITH follows a Compound primary (`(A OR B) WITH X`): SPDX strict
-//     grammar forbids this, but real-world Maven / ClearlyDefined data ships
-//     it. We distribute the exception to every leaf reachable from the
+//   - WITH not followed by an identifier (`Apache-2.0 WITH`, or
+//     `Apache-2.0 WITH OR ...` where the next token is another operator):
+//     the WITH token is consumed but not applied; the primary is returned
+//     untouched. The surrounding operator stays in the token stream and is
+//     handled normally by parseExpression / parseAnd.
+//   - WITH on a Compound primary (`(A OR B) WITH X`): SPDX strict grammar
+//     forbids this, but real-world Maven / ClearlyDefined data ships it.
+//     We distribute the exception to every leaf reachable from the
 //     compound — set-equivalent to the most generous interpretation
-//     ("either license, both with the same exception"). Each leaf that
-//     already has its own exception is left untouched.
+//     ("either license, both with the same exception"). Leaves that already
+//     carry their own exception keep theirs.
+//   - WITH chain (`A WITH B WITH C`): only one WITH is consumed per primary,
+//     so subsequent WITHs and their identifiers fall through and are
+//     silently dropped at the top level. SPDX 2.1+ does not permit chains.
 func (p *parser) parseWith() *ExprNode {
 	primary := p.parsePrimary()
 	if !p.acceptKind(tokWITH) {
@@ -434,9 +468,14 @@ func (p *parser) parseWith() *ExprNode {
 }
 
 // attachException sets the exception on a leaf that does not yet have one,
-// updating Raw to include the WITH clause. A leaf that already carries an
-// exception (e.g., chained "A WITH B WITH C") keeps its first exception —
-// SPDX 2.1+ forbids chains so additional WITHs are silently dropped.
+// updating Raw to include the WITH clause. The early-return guard is the
+// invariant used by distributeException: when an outer WITH is distributed
+// onto a Compound, leaves that were already parsed with their own inner
+// WITH keep their original exception rather than being overwritten.
+//
+// Note: chained "A WITH B WITH C" inputs do NOT exercise this guard —
+// parseWith consumes only one WITH per primary, so the second exception
+// is dropped at the parser level before attachException would see it.
 func attachException(l *ExprLicense, exception string) {
 	if l.Exception != "" {
 		return

--- a/internal/domain/licenses/expression.go
+++ b/internal/domain/licenses/expression.go
@@ -11,7 +11,13 @@ import (
 // ExprNode is invalid and will panic in String / Leaves operations to surface
 // programmer errors early.
 type ExprNode struct {
-	License  *ExprLicense
+	// License is the leaf payload when this node represents a simple SPDX
+	// expression (license-id with optional "+" / WITH). Non-nil iff Compound
+	// is nil.
+	License *ExprLicense
+	// Compound is the operator-and-operands payload when this node represents
+	// "A OR B" / "A AND B" with two or more operands. Non-nil iff License is
+	// nil.
 	Compound *ExprCompound
 }
 

--- a/internal/domain/licenses/expression.go
+++ b/internal/domain/licenses/expression.go
@@ -1,0 +1,205 @@
+package licenses
+
+import (
+	"regexp"
+	"strings"
+)
+
+// ExpressionOperand represents one operand from a parsed SPDX license expression.
+//
+// For inputs like "Apache-2.0 OR MIT", two operands are produced (one per
+// license-id). For "Apache-2.0 WITH Classpath-exception-2.0", a single operand
+// is produced with the full text in Raw — WITH clauses bind to the preceding
+// license-id per SPDX spec and are not split out in v1. Normalization on a
+// WITH-bearing operand will not match SPDX (no exception table is present yet);
+// callers should keep Raw for downstream display in that case.
+type ExpressionOperand struct {
+	// Raw is the operand substring after structural parsing (whitespace trimmed).
+	Raw string
+	// Normalization is the result of running Normalize on Raw.
+	Normalization NormalizationResult
+}
+
+// ExpressionResult is the outcome of parsing an SPDX license expression.
+//
+// For a plain license-id input (e.g., "Apache-2.0"), Operands has length 1.
+// For empty / whitespace-only input, Operands is nil.
+type ExpressionResult struct {
+	// Raw is the original input string, before any trimming.
+	Raw string
+	// Operands is one entry per top-level OR/AND-separated operand, in the
+	// order they appear. Length 1 for non-compound input. Nil for empty input.
+	Operands []ExpressionOperand
+}
+
+// expressionSplitter matches SPDX OR/AND operators bounded by whitespace.
+// The (?i) flag makes the match case-insensitive per SPDX spec; \s+ on both
+// sides ensures literal substrings within identifiers are not split (e.g.,
+// no SPDX ID currently contains " OR " or " AND " as a substring).
+var expressionSplitter = regexp.MustCompile(`(?i)\s+(?:OR|AND)\s+`)
+
+// leadingEdgeOperator matches a stray OR/AND token at the start of a segment
+// (with any trailing whitespace), so that malformed inputs like "OR Apache-2.0"
+// or recursion segments like "OR MIT" (left over after splitting) yield a
+// clean operand.
+var leadingEdgeOperator = regexp.MustCompile(`(?i)^(?:OR|AND)\b\s*`)
+
+// trailingEdgeOperator matches a stray OR/AND token at the end of a segment.
+var trailingEdgeOperator = regexp.MustCompile(`(?i)\s*\b(?:OR|AND)$`)
+
+// ParseExpression parses an SPDX license expression and normalizes each operand.
+//
+// Algorithm (v1):
+//  1. Trim outer whitespace.
+//  2. Strip outer-paren wrapping repeatedly (handles "((MIT))" → "MIT") when the
+//     parens balance correctly across the entire string.
+//  3. Find OR/AND operator positions at paren depth 0.
+//  4. Split into segments; recurse on each segment to flatten nested expressions
+//     such as "EPL-1.0 OR (LGPL-2.1 OR LGPL-3.0)" into a single 3-operand list.
+//  5. For each operand, run Normalize.
+//
+// Limitations (v1):
+//   - Mixed AND/OR is flattened into a single operand list. Operator structure
+//     and precedence are not preserved (no AST). Consumers that need to
+//     distinguish AND vs OR semantics for legal compliance must not rely on
+//     this parser alone.
+//   - "WITH" clauses stay attached to the preceding license-id; the combined
+//     "license-id WITH exception-id" string is normalized as a unit and will
+//     typically be reported as non-SPDX since no exception table exists yet.
+//   - The "+" suffix on a license-id (e.g., "Apache-2.0+") is preserved in Raw;
+//     normalization falls through to the heuristic, so the result is non-SPDX.
+func ParseExpression(raw string) ExpressionResult {
+	res := ExpressionResult{Raw: raw}
+	parts := splitFlatten(raw)
+	if len(parts) == 0 {
+		return res
+	}
+	res.Operands = make([]ExpressionOperand, 0, len(parts))
+	for _, p := range parts {
+		res.Operands = append(res.Operands, ExpressionOperand{
+			Raw:           p,
+			Normalization: Normalize(p),
+		})
+	}
+	return res
+}
+
+// splitFlatten returns the flat list of operand strings produced by recursively
+// splitting s on top-level OR/AND operators. Outer parens are stripped before
+// splitting so that "(A OR B)" yields the same operands as "A OR B". Stray
+// OR/AND tokens at the start or end (whether from malformed input or from a
+// recursion segment) are trimmed so we never emit phantom "OR ..." operands.
+//
+// Returns nil for empty / whitespace-only input.
+func splitFlatten(s string) []string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil
+	}
+	for {
+		next := trimEdgeOperators(stripOuterParens(s))
+		if next == s {
+			break
+		}
+		s = next
+	}
+	if s == "" {
+		return nil
+	}
+
+	ops := findTopLevelOperators(s)
+	if len(ops) == 0 {
+		return []string{s}
+	}
+
+	out := make([]string, 0, len(ops)+1)
+	last := 0
+	for _, op := range ops {
+		out = append(out, splitFlatten(s[last:op[0]])...)
+		last = op[1]
+	}
+	out = append(out, splitFlatten(s[last:])...)
+	return out
+}
+
+// trimEdgeOperators repeatedly strips bare OR/AND tokens at the start or end
+// of s, removing the surrounding whitespace each pass. Idempotent: if the
+// input has no edge operator tokens, returns s unchanged.
+func trimEdgeOperators(s string) string {
+	for {
+		next := leadingEdgeOperator.ReplaceAllString(s, "")
+		next = trailingEdgeOperator.ReplaceAllString(next, "")
+		next = strings.TrimSpace(next)
+		if next == s {
+			return s
+		}
+		s = next
+	}
+}
+
+// findTopLevelOperators returns [start, end) byte index pairs for every
+// OR/AND operator match in s that occurs at paren depth 0. The end index is
+// exclusive, matching regexp.FindAllStringIndex semantics.
+func findTopLevelOperators(s string) [][2]int {
+	matches := expressionSplitter.FindAllStringIndex(s, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+	depthAt := computeDepth(s)
+	out := make([][2]int, 0, len(matches))
+	for _, m := range matches {
+		if depthAt[m[0]] != 0 {
+			continue
+		}
+		out = append(out, [2]int{m[0], m[1]})
+	}
+	return out
+}
+
+// computeDepth returns a slice such that depthAt[i] is the paren nesting depth
+// just before the byte at position i. Length is len(s)+1 so the trailing index
+// is also valid for end-of-string queries.
+func computeDepth(s string) []int {
+	depthAt := make([]int, len(s)+1)
+	depth := 0
+	for i := 0; i < len(s); i++ {
+		depthAt[i] = depth
+		switch s[i] {
+		case '(':
+			depth++
+		case ')':
+			if depth > 0 {
+				depth--
+			}
+		}
+	}
+	depthAt[len(s)] = depth
+	return depthAt
+}
+
+// stripOuterParens removes one outer-paren pair if and only if the parens
+// balance to zero exactly at the final character. For "(A OR B)" this returns
+// "A OR B"; for "(A) OR (B)" it returns the input unchanged because the first
+// "(" closes before the end of the string.
+func stripOuterParens(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) < 2 || s[0] != '(' || s[len(s)-1] != ')' {
+		return s
+	}
+	depth := 0
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 && i != len(s)-1 {
+				return s
+			}
+		}
+	}
+	if depth != 0 {
+		return s
+	}
+	return strings.TrimSpace(s[1 : len(s)-1])
+}

--- a/internal/domain/licenses/expression.go
+++ b/internal/domain/licenses/expression.go
@@ -20,11 +20,15 @@ type ExprNode struct {
 // clause, or a free-text license name normalized via Normalize.
 type ExprLicense struct {
 	// Raw is the source substring this leaf was built from, including any
-	// "+" suffix and WITH clause attached during parsing. When an outer WITH
-	// is distributed onto a Compound (recovery for "(A OR B) WITH X"), each
-	// leaf's Raw is rewritten to include the inherited exception — Raw thus
-	// reflects the leaf's effective form, not necessarily a verbatim slice
-	// of the original input.
+	// "+" suffix and WITH clause attached during parsing. Two transformations
+	// can make Raw differ from a verbatim slice of the input:
+	//   - When an outer WITH is distributed onto a Compound (recovery for
+	//     "(A OR B) WITH X"), each *bare* leaf's Raw is rewritten to include
+	//     the inherited exception. Leaves that already carry their own
+	//     exception retain their original Raw.
+	//   - The lexer collapses runs of whitespace between adjacent IDENT chunks
+	//     into a single space when merging them into a free-text license name
+	//     (so "Apache  License\t2.0" lands as "Apache License 2.0").
 	Raw string
 	// Identifier is the canonical SPDX ID of the base license, or "" when the
 	// base did not normalize to SPDX. The "+" suffix and WITH clause are NOT
@@ -111,6 +115,13 @@ const maxExpressionLength = 64 * 1024
 //   - WITH chain ("A WITH B WITH C"): the first exception attaches to A;
 //     subsequent WITHs are silently truncated because parseWith only
 //     consumes one exception per primary.
+//   - Tokens following a complete top-level expression are silently dropped
+//     ("(MIT) (Apache-2.0)" returns just MIT). Bare-identifier sequences
+//     without an operator like "MIT BSD" exercise a different path — the
+//     lexer merges adjacent IDENTs into a single free-text identifier
+//     ("MIT BSD"), see Tokenization above.
+//     Recovery is best-effort — callers that need to detect "extra junk"
+//     must compare Root.String() to Raw themselves.
 //   - The parser never returns an error — consumers ingesting external data
 //     can treat a nil Root as "could not extract any license info" and fall
 //     back to their non-SPDX path.
@@ -175,8 +186,12 @@ func (n *ExprNode) String() string {
 
 // String renders an ExprLicense leaf as "<id>[+][ WITH <exception>]". When
 // the base did not normalize to SPDX, Raw of the base portion is used as a
-// best-effort fallback.
+// best-effort fallback. Returns "" for a nil receiver, matching
+// (*ExprNode).String() so both Stringers are uniformly nil-safe.
 func (l *ExprLicense) String() string {
+	if l == nil {
+		return ""
+	}
 	base := l.Identifier
 	if base == "" {
 		base = l.baseRaw()

--- a/internal/domain/licenses/expression.go
+++ b/internal/domain/licenses/expression.go
@@ -32,45 +32,71 @@ type ExpressionResult struct {
 	Operands []ExpressionOperand
 }
 
-// expressionSplitter matches SPDX OR/AND operators bounded by whitespace.
-// The (?i) flag makes the match case-insensitive per SPDX spec; \s+ on both
-// sides ensures literal substrings within identifiers are not split (e.g.,
-// no SPDX ID currently contains " OR " or " AND " as a substring).
+// expressionSplitter matches SPDX OR/AND operators (case-insensitive) bounded
+// by ASCII whitespace on both sides. Identifiers without surrounding whitespace
+// are never split, so substrings like "FOR-MIT" or "LICENSE-OR-FREE" stay
+// intact. Unicode whitespace (e.g. NBSP) is not recognized as a separator —
+// SPDX expressions in practice use ASCII whitespace only.
 var expressionSplitter = regexp.MustCompile(`(?i)\s+(?:OR|AND)\s+`)
 
-// leadingEdgeOperator matches a stray OR/AND token at the start of a segment
-// (with any trailing whitespace), so that malformed inputs like "OR Apache-2.0"
-// or recursion segments like "OR MIT" (left over after splitting) yield a
-// clean operand.
-var leadingEdgeOperator = regexp.MustCompile(`(?i)^(?:OR|AND)\b\s*`)
+// leadingEdgeOperator matches a stray OR/AND token at the start of a segment,
+// requiring trailing whitespace or end-of-string after the operator so that
+// hyphenated identifiers like "OR-tools" or "AND-license" are not stripped.
+var leadingEdgeOperator = regexp.MustCompile(`(?i)^(?:OR|AND)(?:\s+|$)`)
 
-// trailingEdgeOperator matches a stray OR/AND token at the end of a segment.
-var trailingEdgeOperator = regexp.MustCompile(`(?i)\s*\b(?:OR|AND)$`)
+// trailingEdgeOperator matches a stray OR/AND token at the end of a segment,
+// requiring leading whitespace or start-of-string before the operator (mirror
+// of leadingEdgeOperator).
+var trailingEdgeOperator = regexp.MustCompile(`(?i)(?:^|\s+)(?:OR|AND)$`)
+
+// maxExpressionLength caps the input size accepted by ParseExpression. SPDX
+// license expressions in practice are at most a few hundred characters (the
+// longest common form is a 4-license dual/triple compound). Anything larger
+// is treated as untrusted input and returns no operands so that quadratic
+// recursion / regex passes cannot be amplified by adversarial metadata
+// (e.g., a malformed ClearlyDefined.io response).
+const maxExpressionLength = 64 * 1024
 
 // ParseExpression parses an SPDX license expression and normalizes each operand.
 //
 // Algorithm (v1):
-//  1. Trim outer whitespace.
-//  2. Strip outer-paren wrapping repeatedly (handles "((MIT))" → "MIT") when the
-//     parens balance correctly across the entire string.
-//  3. Find OR/AND operator positions at paren depth 0.
-//  4. Split into segments; recurse on each segment to flatten nested expressions
-//     such as "EPL-1.0 OR (LGPL-2.1 OR LGPL-3.0)" into a single 3-operand list.
+//  1. Reject inputs longer than maxExpressionLength: Operands is nil and Raw
+//     holds the original input verbatim. Callers that ingest untrusted data
+//     should treat the raw oversized payload accordingly (log truncated).
+//  2. Trim outer whitespace, then repeatedly strip outer-paren wrapping and
+//     trim stray edge OR/AND tokens until both reach a fixed point.
+//     "((MIT))" → "MIT"; "OR MIT" → "MIT".
+//  3. Find OR/AND operator matches via expressionSplitter, then keep only
+//     those whose start position is at paren depth 0.
+//  4. Split into segments at the surviving operator positions; recurse on
+//     each segment so nested expressions such as
+//     "EPL-1.0 OR (LGPL-2.1 OR LGPL-3.0)" flatten to a 3-operand list.
 //  5. For each operand, run Normalize.
+//
+// The order of returned operands matches the input. Future versions may add
+// operator-kind metadata as additional fields; existing callers will not
+// break.
 //
 // Limitations (v1):
 //   - Mixed AND/OR is flattened into a single operand list. Operator structure
 //     and precedence are not preserved (no AST). Consumers that need to
 //     distinguish AND vs OR semantics for legal compliance must not rely on
 //     this parser alone.
-//   - "WITH" clauses stay attached to the preceding license-id; the combined
-//     "license-id WITH exception-id" string is normalized as a unit and will
-//     typically be reported as non-SPDX since no exception table exists yet.
-//   - The "+" suffix on a license-id (e.g., "Apache-2.0+") is preserved in Raw;
-//     normalization resolves it to the base SPDX ID via the generated alias table
-//     (e.g., "Apache-2.0+" → "Apache-2.0").
+//   - "WITH" clauses currently stay attached to the preceding license-id; the
+//     combined "license-id WITH exception-id" string is normalized as a unit.
+//     SPDX matching of license/exception pairs is out of scope for v1.
+//   - The "+" suffix on a license-id is preserved in operand Raw. Whether the
+//     operand normalizes to SPDX depends on the generated SPDX table — e.g.,
+//     "Apache-2.0+" is mapped back to "Apache-2.0" while "GPL-2.0+" is itself
+//     a canonical SPDX ID. The parser does not interpret "+" as "or-later"
+//     semantically; consumers needing that semantic must inspect Raw.
+//   - Operator boundaries require ASCII whitespace; Unicode whitespace
+//     (NBSP, ideographic space) is not recognized as a separator.
 func ParseExpression(raw string) ExpressionResult {
 	res := ExpressionResult{Raw: raw}
+	if len(raw) > maxExpressionLength {
+		return res
+	}
 	parts := splitFlatten(raw)
 	if len(parts) == 0 {
 		return res

--- a/internal/domain/licenses/expression.go
+++ b/internal/domain/licenses/expression.go
@@ -1,232 +1,577 @@
 package licenses
 
 import (
-	"regexp"
+	"fmt"
 	"strings"
+	"unicode"
 )
 
-// ExpressionOperand represents one operand from a parsed SPDX license expression.
-//
-// For inputs like "Apache-2.0 OR MIT", two operands are produced (one per
-// license-id). For "Apache-2.0 WITH Classpath-exception-2.0", a single operand
-// is produced with the full text in Raw — WITH clauses bind to the preceding
-// license-id per SPDX spec and are not split out in v1. Normalization on a
-// WITH-bearing operand will not match SPDX (no exception table is present yet);
-// callers should keep Raw for downstream display in that case.
-type ExpressionOperand struct {
-	// Raw is the operand substring after structural parsing (whitespace trimmed).
+// ExprNode is a node in the parsed SPDX expression AST. It is a tagged union:
+// exactly one of License or Compound is non-nil for a valid node. A zero-valued
+// ExprNode is invalid and will panic in String / Leaves operations to surface
+// programmer errors early.
+type ExprNode struct {
+	License  *ExprLicense
+	Compound *ExprCompound
+}
+
+// ExprLicense is a leaf node — an SPDX simple-expression: a license-id with
+// an optional "+" (or-later) suffix and an optional " WITH <exception-id>"
+// clause, or a free-text license name normalized via Normalize.
+type ExprLicense struct {
+	// Raw is the source substring this leaf was built from, including any
+	// "+" suffix and WITH clause attached during parsing. When an outer WITH
+	// is distributed onto a Compound (recovery for "(A OR B) WITH X"), each
+	// leaf's Raw is rewritten to include the inherited exception — Raw thus
+	// reflects the leaf's effective form, not necessarily a verbatim slice
+	// of the original input.
 	Raw string
-	// Normalization is the result of running Normalize on Raw.
+	// Identifier is the canonical SPDX ID of the base license, or "" when the
+	// base did not normalize to SPDX. The "+" suffix and WITH clause are NOT
+	// part of Identifier.
+	Identifier string
+	// Normalization is the full normalization result for the base license
+	// (with "+" stripped and WITH clause removed before normalizing).
 	Normalization NormalizationResult
+	// OrLater is true when the base license-id had a trailing "+" indicating
+	// "this version or any later version" per SPDX §10.2.3. The parser does
+	// not interpret the semantics; consumers needing "or-later" handling
+	// must read this flag.
+	OrLater bool
+	// Exception is the verbatim exception-id following a WITH clause, or ""
+	// when no exception was present. The parser does NOT validate exceptions
+	// against any SPDX exceptions table — there is no such table loaded in
+	// this codebase yet. Future revisions will normalize this field.
+	Exception string
+}
+
+// ExprCompound combines two or more sibling nodes with the same operator.
+// Chains of the same operator at the same precedence level are flattened
+// into a single Compound: "A OR B OR C" produces one Compound with three
+// children, not two nested Compounds. This matches SPDX renderer convention
+// and is set-equivalent in legal terms.
+type ExprCompound struct {
+	// Operator is "OR" or "AND" (canonical uppercase).
+	Operator string
+	// Operands is the ordered list of children, always length ≥ 2.
+	Operands []*ExprNode
 }
 
 // ExpressionResult is the outcome of parsing an SPDX license expression.
-//
-// For a plain license-id input (e.g., "Apache-2.0"), Operands has length 1.
-// For empty / whitespace-only input, Operands is nil.
 type ExpressionResult struct {
 	// Raw is the original input string, before any trimming.
 	Raw string
-	// Operands is one entry per top-level OR/AND-separated operand, in the
-	// order they appear. Length 1 for non-compound input. Nil for empty input.
-	Operands []ExpressionOperand
+	// Root is the parsed AST. Nil for empty / oversized / fully-malformed input.
+	Root *ExprNode
 }
 
-// expressionSplitter matches SPDX OR/AND operators (case-insensitive) bounded
-// by ASCII whitespace on both sides. Identifiers without surrounding whitespace
-// are never split, so substrings like "FOR-MIT" or "LICENSE-OR-FREE" stay
-// intact. Unicode whitespace (e.g. NBSP) is not recognized as a separator —
-// SPDX expressions in practice use ASCII whitespace only.
-var expressionSplitter = regexp.MustCompile(`(?i)\s+(?:OR|AND)\s+`)
+// SPDX expression operator keywords.
+const (
+	opOR   = "OR"
+	opAND  = "AND"
+	opWITH = "WITH"
+)
 
-// leadingEdgeOperator matches a stray OR/AND token at the start of a segment,
-// requiring trailing whitespace or end-of-string after the operator so that
-// hyphenated identifiers like "OR-tools" or "AND-license" are not stripped.
-var leadingEdgeOperator = regexp.MustCompile(`(?i)^(?:OR|AND)(?:\s+|$)`)
-
-// trailingEdgeOperator matches a stray OR/AND token at the end of a segment,
-// requiring leading whitespace or start-of-string before the operator (mirror
-// of leadingEdgeOperator).
-var trailingEdgeOperator = regexp.MustCompile(`(?i)(?:^|\s+)(?:OR|AND)$`)
-
-// maxExpressionLength caps the input size accepted by ParseExpression. SPDX
-// license expressions in practice are at most a few hundred characters (the
-// longest common form is a 4-license dual/triple compound). Anything larger
-// is treated as untrusted input and returns no operands so that quadratic
-// recursion / regex passes cannot be amplified by adversarial metadata
-// (e.g., a malformed ClearlyDefined.io response).
+// maxExpressionLength caps the input size (in bytes) accepted by
+// ParseExpression. SPDX license expressions in practice are at most a few
+// hundred characters; the generous cap defends against adversarial metadata
+// (e.g. malformed ClearlyDefined.io responses) that would amplify regex /
+// recursion work. Counted in bytes via len(), not runes, because the goal is
+// memory-bound resource control, not user-visible width.
 const maxExpressionLength = 64 * 1024
 
-// ParseExpression parses an SPDX license expression and normalizes each operand.
+// ParseExpression parses an SPDX license expression and returns the AST.
 //
-// Algorithm (v1):
-//  1. Reject inputs longer than maxExpressionLength: Operands is nil and Raw
-//     holds the original input verbatim. Callers that ingest untrusted data
-//     should treat the raw oversized payload accordingly (log truncated).
-//  2. Trim outer whitespace, then repeatedly strip outer-paren wrapping and
-//     trim stray edge OR/AND tokens until both reach a fixed point.
-//     "((MIT))" → "MIT"; "OR MIT" → "MIT".
-//  3. Find OR/AND operator matches via expressionSplitter, then keep only
-//     those whose start position is at paren depth 0.
-//  4. Split into segments at the surviving operator positions; recurse on
-//     each segment so nested expressions such as
-//     "EPL-1.0 OR (LGPL-2.1 OR LGPL-3.0)" flatten to a 3-operand list.
-//  5. For each operand, run Normalize.
+// Grammar (recursive descent, precedence WITH > AND > OR per SPDX §10.2.3):
 //
-// The order of returned operands matches the input. Future versions may add
-// operator-kind metadata as additional fields; existing callers will not
-// break.
+//	expression = and_expr (OR and_expr)*
+//	and_expr   = with_expr (AND with_expr)*
+//	with_expr  = primary (WITH ident)?
+//	primary    = ident ['+'] | '(' expression ')'
 //
-// Limitations (v1):
-//   - Mixed AND/OR is flattened into a single operand list. Operator structure
-//     and precedence are not preserved (no AST). Consumers that need to
-//     distinguish AND vs OR semantics for legal compliance must not rely on
-//     this parser alone.
-//   - "WITH" clauses currently stay attached to the preceding license-id; the
-//     combined "license-id WITH exception-id" string is normalized as a unit.
-//     SPDX matching of license/exception pairs is out of scope for v1.
-//   - The "+" suffix on a license-id is preserved in operand Raw. Whether the
-//     operand normalizes to SPDX depends on the generated SPDX table — e.g.,
-//     "Apache-2.0+" is mapped back to "Apache-2.0" while "GPL-2.0+" is itself
-//     a canonical SPDX ID. The parser does not interpret "+" as "or-later"
-//     semantically; consumers needing that semantic must inspect Raw.
-//   - Operator boundaries require ASCII whitespace; Unicode whitespace
-//     (NBSP, ideographic space) is not recognized as a separator.
+// Tokenization:
+//   - "OR" / "AND" / "WITH" (case-insensitive) and "(" / ")" are reserved.
+//   - Adjacent non-reserved word tokens merge into a single license-id (single
+//     space joined), so free-text Maven POM "<name>" values like "Apache
+//     License 2.0" are treated as one identifier and normalized via the alias
+//     table. Substrings like "OR-tools" or "AND-license" stay as IDENTs (they
+//     don't equal-fold to the reserved words).
+//
+// Robustness:
+//   - Empty / whitespace-only / oversized input → Root is nil.
+//   - Stray edge operators ("OR Apache-2.0", "Apache-2.0 OR") are silently
+//     dropped (matches v1 contract).
+//   - A Compound with fewer than 2 children after parsing collapses to its
+//     single child or to nil; never emits a degenerate compound.
+//   - The parser never returns an error — consumers ingesting external data
+//     can treat a nil Root as "could not extract any license info" and fall
+//     back to their non-SPDX path.
+//
+// Limitations:
+//   - WITH exception-ids are kept verbatim in ExprLicense.Exception; no
+//     normalization against an SPDX exceptions table (none is loaded yet).
+//   - "+" suffix is recorded as ExprLicense.OrLater; the parser does not
+//     interpret it semantically.
 func ParseExpression(raw string) ExpressionResult {
 	res := ExpressionResult{Raw: raw}
 	if len(raw) > maxExpressionLength {
 		return res
 	}
-	parts := splitFlatten(raw)
-	if len(parts) == 0 {
+	tokens := lex(raw)
+	if len(tokens) == 0 {
 		return res
 	}
-	res.Operands = make([]ExpressionOperand, 0, len(parts))
-	for _, p := range parts {
-		res.Operands = append(res.Operands, ExpressionOperand{
-			Raw:           p,
-			Normalization: Normalize(p),
-		})
-	}
+	p := &parser{tokens: tokens}
+	res.Root = p.parseExpression()
 	return res
 }
 
-// splitFlatten returns the flat list of operand strings produced by recursively
-// splitting s on top-level OR/AND operators. Outer parens are stripped before
-// splitting so that "(A OR B)" yields the same operands as "A OR B". Stray
-// OR/AND tokens at the start or end (whether from malformed input or from a
-// recursion segment) are trimmed so we never emit phantom "OR ..." operands.
+// String renders the AST back to canonical SPDX expression syntax. Compound
+// children are parenthesized only when needed for precedence — a child of an
+// OR whose own operator is also OR renders bare; a child with a different
+// operator gets parens. The result satisfies the idempotence property:
+// re-parsing the rendered string and rendering again produces the same text.
 //
-// Returns nil for empty / whitespace-only input.
-func splitFlatten(s string) []string {
-	s = strings.TrimSpace(s)
-	if s == "" {
+// Panics on any zero-valued or nil-operand node — these can only arise from
+// hand-built ASTs (the parser itself never produces them) and are surfaced
+// as programmer errors so a misuse is caught at the first render rather than
+// silently producing malformed SPDX text.
+func (n *ExprNode) String() string {
+	if n == nil {
+		return ""
+	}
+	if n.License != nil {
+		return n.License.String()
+	}
+	if n.Compound == nil {
+		panic("licenses.ExprNode: zero-valued node (neither License nor Compound)")
+	}
+	parts := make([]string, len(n.Compound.Operands))
+	for i, child := range n.Compound.Operands {
+		if child == nil {
+			panic("licenses.ExprNode: nil operand in Compound")
+		}
+		s := child.String()
+		if needsParens(child, n.Compound.Operator) {
+			s = "(" + s + ")"
+		}
+		parts[i] = s
+	}
+	return strings.Join(parts, " "+n.Compound.Operator+" ")
+}
+
+// String renders an ExprLicense leaf as "<id>[+][ WITH <exception>]". When
+// the base did not normalize to SPDX, Raw of the base portion is used as a
+// best-effort fallback.
+func (l *ExprLicense) String() string {
+	base := l.Identifier
+	if base == "" {
+		base = l.baseRaw()
+	}
+	if l.OrLater {
+		base += "+"
+	}
+	if l.Exception != "" {
+		return base + " " + opWITH + " " + l.Exception
+	}
+	return base
+}
+
+// Leaves walks the AST and returns leaf ExprLicense pointers in reading order.
+// Returns nil when Root is nil so callers using a sentinel-nil check can
+// distinguish "no license info parsed" from "empty result accidentally
+// produced". This is the convenience accessor for consumers that do not need
+// operator structure (e.g., simple license enumeration).
+//
+// Panics if the AST contains a zero-valued ExprNode (programmer error).
+func (r ExpressionResult) Leaves() []*ExprLicense {
+	if r.Root == nil {
 		return nil
 	}
+	var out []*ExprLicense
+	walkLeaves(r.Root, &out)
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// needsParens decides whether a child node needs to be parenthesized when
+// rendered inside a parent compound with the given operator. Rule: a Compound
+// child needs parens iff its operator differs from the parent's. Leaves never
+// need parens — WITH binds tighter than AND/OR per SPDX precedence.
+func needsParens(child *ExprNode, parentOp string) bool {
+	return child != nil && child.Compound != nil && child.Compound.Operator != parentOp
+}
+
+// walkLeaves appends every ExprLicense leaf reachable from n to out, in
+// reading order. Mirrors String()'s panic invariants: zero-valued and
+// nil-operand nodes are programmer errors and surface immediately.
+func walkLeaves(n *ExprNode, out *[]*ExprLicense) {
+	if n == nil {
+		return
+	}
+	if n.License != nil {
+		*out = append(*out, n.License)
+		return
+	}
+	if n.Compound == nil {
+		panic("licenses.ExprNode: zero-valued node during AST walk")
+	}
+	for _, c := range n.Compound.Operands {
+		if c == nil {
+			panic("licenses.ExprNode: nil operand in Compound during AST walk")
+		}
+		walkLeaves(c, out)
+	}
+}
+
+// baseRaw returns the substring of Raw before any "+" suffix and " WITH "
+// clause — useful as a String() fallback when normalization failed. Uses the
+// already-parsed Exception field rather than re-scanning Raw for "WITH",
+// avoiding duplicate parsing logic that could drift from lex().
+func (l *ExprLicense) baseRaw() string {
+	s := l.Raw
+	if l.Exception != "" {
+		suffix := " " + opWITH + " " + l.Exception
+		s = strings.TrimSuffix(s, suffix)
+	}
+	if isOrLaterSuffix(s) {
+		s = s[:len(s)-1]
+	}
+	return s
+}
+
+// --- Lexer -----------------------------------------------------------------
+
+type tokenKind int
+
+const (
+	tokIdent tokenKind = iota
+	tokOR
+	tokAND
+	tokWITH
+	tokLParen
+	tokRParen
+)
+
+type token struct {
+	kind tokenKind
+	text string // for tokIdent only; canonical form (single-spaced, original case)
+}
+
+// lex tokenizes the input. Whitespace separates raw chunks; "(" and ")" are
+// always their own chunks. Each non-paren chunk that case-folds to "OR" /
+// "AND" / "WITH" becomes a reserved token; everything else accumulates into
+// IDENT tokens, with adjacent IDENTs merged into a single IDENT separated by
+// one space (so free-text license names like "Apache License 2.0" survive as
+// one identifier).
+func lex(s string) []token {
+	chunks := splitChunks(s)
+	if len(chunks) == 0 {
+		return nil
+	}
+
+	var out []token
+	var pending strings.Builder
+	flushIdent := func() {
+		if pending.Len() > 0 {
+			out = append(out, token{kind: tokIdent, text: pending.String()})
+			pending.Reset()
+		}
+	}
+	for _, c := range chunks {
+		switch {
+		case c == "(":
+			flushIdent()
+			out = append(out, token{kind: tokLParen})
+		case c == ")":
+			flushIdent()
+			out = append(out, token{kind: tokRParen})
+		case strings.EqualFold(c, opOR):
+			flushIdent()
+			out = append(out, token{kind: tokOR})
+		case strings.EqualFold(c, opAND):
+			flushIdent()
+			out = append(out, token{kind: tokAND})
+		case strings.EqualFold(c, opWITH):
+			flushIdent()
+			out = append(out, token{kind: tokWITH})
+		default:
+			if pending.Len() > 0 {
+				pending.WriteByte(' ')
+			}
+			pending.WriteString(c)
+		}
+	}
+	flushIdent()
+	return out
+}
+
+// splitChunks splits s on whitespace, treating "(" and ")" as their own chunks
+// even when adjacent to non-whitespace characters. Empty results are dropped.
+func splitChunks(s string) []string {
+	var out []string
+	var cur strings.Builder
+	flush := func() {
+		if cur.Len() > 0 {
+			out = append(out, cur.String())
+			cur.Reset()
+		}
+	}
+	for _, r := range s {
+		switch {
+		case r == '(' || r == ')':
+			flush()
+			out = append(out, string(r))
+		case unicode.IsSpace(r):
+			flush()
+		default:
+			cur.WriteRune(r)
+		}
+	}
+	flush()
+	return out
+}
+
+// --- Parser ---------------------------------------------------------------
+
+type parser struct {
+	tokens []token
+	pos    int
+}
+
+func (p *parser) peek() (token, bool) {
+	if p.pos >= len(p.tokens) {
+		return token{}, false
+	}
+	return p.tokens[p.pos], true
+}
+
+func (p *parser) consume() (token, bool) {
+	t, ok := p.peek()
+	if ok {
+		p.pos++
+	}
+	return t, ok
+}
+
+// parseExpression: expression = and_expr (OR and_expr)*
+func (p *parser) parseExpression() *ExprNode {
+	left := p.parseAnd()
+	if !p.acceptKind(tokOR) {
+		return left
+	}
+	operands := []*ExprNode{}
+	if left != nil {
+		operands = append(operands, left)
+	}
 	for {
-		next := trimEdgeOperators(stripOuterParens(s))
-		if next == s {
+		right := p.parseAnd()
+		if right != nil {
+			operands = append(operands, right)
+		}
+		if !p.acceptKind(tokOR) {
 			break
 		}
-		s = next
 	}
-	if s == "" {
-		return nil
-	}
-
-	ops := findTopLevelOperators(s)
-	if len(ops) == 0 {
-		return []string{s}
-	}
-
-	out := make([]string, 0, len(ops)+1)
-	last := 0
-	for _, op := range ops {
-		out = append(out, splitFlatten(s[last:op[0]])...)
-		last = op[1]
-	}
-	out = append(out, splitFlatten(s[last:])...)
-	return out
+	return finalizeCompound(opOR, operands)
 }
 
-// trimEdgeOperators repeatedly strips bare OR/AND tokens at the start or end
-// of s, removing the surrounding whitespace each pass. Idempotent: if the
-// input has no edge operator tokens, returns s unchanged.
-func trimEdgeOperators(s string) string {
+// parseAnd: and_expr = with_expr (AND with_expr)*
+func (p *parser) parseAnd() *ExprNode {
+	left := p.parseWith()
+	if !p.acceptKind(tokAND) {
+		return left
+	}
+	operands := []*ExprNode{}
+	if left != nil {
+		operands = append(operands, left)
+	}
 	for {
-		next := leadingEdgeOperator.ReplaceAllString(s, "")
-		next = trailingEdgeOperator.ReplaceAllString(next, "")
-		next = strings.TrimSpace(next)
-		if next == s {
-			return s
+		right := p.parseWith()
+		if right != nil {
+			operands = append(operands, right)
 		}
-		s = next
+		if !p.acceptKind(tokAND) {
+			break
+		}
+	}
+	return finalizeCompound(opAND, operands)
+}
+
+// parseWith: with_expr = primary (WITH ident)?
+//
+// Two recovery paths for malformed inputs:
+//
+//   - WITH is not followed by an identifier (`Apache-2.0 WITH`): the WITH
+//     token is consumed but not applied; the primary is returned untouched.
+//   - WITH follows a Compound primary (`(A OR B) WITH X`): SPDX strict
+//     grammar forbids this, but real-world Maven / ClearlyDefined data ships
+//     it. We distribute the exception to every leaf reachable from the
+//     compound — set-equivalent to the most generous interpretation
+//     ("either license, both with the same exception"). Each leaf that
+//     already has its own exception is left untouched.
+func (p *parser) parseWith() *ExprNode {
+	primary := p.parsePrimary()
+	if !p.acceptKind(tokWITH) {
+		return primary
+	}
+	exceptionTok, ok := p.peek()
+	if !ok || exceptionTok.kind != tokIdent {
+		return primary
+	}
+	p.consume()
+	if primary == nil {
+		return nil
+	}
+	if primary.License != nil {
+		attachException(primary.License, exceptionTok.text)
+		return primary
+	}
+	distributeException(primary, exceptionTok.text)
+	return primary
+}
+
+// attachException sets the exception on a leaf that does not yet have one,
+// updating Raw to include the WITH clause. A leaf that already carries an
+// exception (e.g., chained "A WITH B WITH C") keeps its first exception —
+// SPDX 2.1+ forbids chains so additional WITHs are silently dropped.
+func attachException(l *ExprLicense, exception string) {
+	if l.Exception != "" {
+		return
+	}
+	l.Exception = exception
+	l.Raw = l.Raw + " " + opWITH + " " + exception
+}
+
+// distributeException applies the exception to every leaf reachable from n.
+// Used when a WITH clause attaches to a Compound primary; mathematically
+// equivalent to wrapping each leaf with its own WITH clause. Leaves that
+// already carry an exception retain theirs.
+func distributeException(n *ExprNode, exception string) {
+	if n == nil {
+		return
+	}
+	if n.License != nil {
+		attachException(n.License, exception)
+		return
+	}
+	if n.Compound == nil {
+		return
+	}
+	for _, c := range n.Compound.Operands {
+		distributeException(c, exception)
 	}
 }
 
-// findTopLevelOperators returns [start, end) byte index pairs for every
-// OR/AND operator match in s that occurs at paren depth 0. The end index is
-// exclusive, matching regexp.FindAllStringIndex semantics.
-func findTopLevelOperators(s string) [][2]int {
-	matches := expressionSplitter.FindAllStringIndex(s, -1)
-	if len(matches) == 0 {
-		return nil
+// parsePrimary: primary = ident ['+'] | '(' expression ')'
+//
+// Stray operator tokens (OR / AND / WITH) at the primary position are silently
+// skipped — this preserves the v1 contract that malformed edge-operator inputs
+// like "OR Apache-2.0", "Apache-2.0 OR", and "Apache-2.0 OR OR MIT" still
+// yield as much information as the parser can recover.
+func (p *parser) parsePrimary() *ExprNode {
+	for {
+		t, ok := p.peek()
+		if !ok {
+			return nil
+		}
+		switch t.kind {
+		case tokLParen:
+			p.consume()
+			inner := p.parseExpression()
+			_ = p.acceptKind(tokRParen) // tolerate missing RPAREN
+			return inner
+		case tokIdent:
+			p.consume()
+			return makeLeaf(t.text)
+		case tokOR, tokAND, tokWITH:
+			p.consume()
+			continue
+		default: // tokRParen — let the surrounding LParen handler consume it
+			return nil
+		}
 	}
-	depthAt := computeDepth(s)
-	out := make([][2]int, 0, len(matches))
-	for _, m := range matches {
-		if depthAt[m[0]] != 0 {
+}
+
+func (p *parser) acceptKind(kind tokenKind) bool {
+	t, ok := p.peek()
+	if !ok || t.kind != kind {
+		return false
+	}
+	p.pos++
+	return true
+}
+
+// finalizeCompound returns a normalized compound node, flattening same-
+// operator children into the parent so "A OR B OR C" — and equivalently
+// "A OR (B OR C)" via paren grouping — both produce a single Compound with
+// three operands. Set-equivalent in legal terms; matches SPDX renderer
+// convention.
+//
+//   - 0 operands → nil
+//   - 1 operand → that operand directly (collapse degenerate compound)
+//   - 2+ operands → ExprCompound{Operator: op, Operands: flattened}
+func finalizeCompound(op string, operands []*ExprNode) *ExprNode {
+	flat := make([]*ExprNode, 0, len(operands))
+	for _, o := range operands {
+		if o == nil {
 			continue
 		}
-		out = append(out, [2]int{m[0], m[1]})
+		if o.Compound != nil && o.Compound.Operator == op {
+			flat = append(flat, o.Compound.Operands...)
+			continue
+		}
+		flat = append(flat, o)
 	}
-	return out
+	switch len(flat) {
+	case 0:
+		return nil
+	case 1:
+		return flat[0]
+	default:
+		return &ExprNode{Compound: &ExprCompound{Operator: op, Operands: flat}}
+	}
 }
 
-// computeDepth returns a slice such that depthAt[i] is the paren nesting depth
-// just before the byte at position i. Length is len(s)+1 so the trailing index
-// is also valid for end-of-string queries.
-func computeDepth(s string) []int {
-	depthAt := make([]int, len(s)+1)
-	depth := 0
-	for i := 0; i < len(s); i++ {
-		depthAt[i] = depth
-		switch s[i] {
-		case '(':
-			depth++
-		case ')':
-			if depth > 0 {
-				depth--
-			}
-		}
+// makeLeaf builds a leaf node from a license-id text. Recognises a trailing
+// "+" (or-later) suffix, but only when exactly one "+" terminates a non-empty
+// base — bare "+" and "++" are treated as part of the identifier and left to
+// fail normalization, since SPDX has no notion of such forms.
+func makeLeaf(raw string) *ExprNode {
+	base := raw
+	orLater := false
+	if isOrLaterSuffix(base) {
+		base = base[:len(base)-1]
+		orLater = true
 	}
-	depthAt[len(s)] = depth
-	return depthAt
+	norm := Normalize(base)
+	id := ""
+	if norm.SPDX {
+		id = norm.CanonicalID
+	}
+	return &ExprNode{License: &ExprLicense{
+		Raw:           raw,
+		Identifier:    id,
+		Normalization: norm,
+		OrLater:       orLater,
+	}}
 }
 
-// stripOuterParens removes one outer-paren pair if and only if the parens
-// balance to zero exactly at the final character. For "(A OR B)" this returns
-// "A OR B"; for "(A) OR (B)" it returns the input unchanged because the first
-// "(" closes before the end of the string.
-func stripOuterParens(s string) string {
-	s = strings.TrimSpace(s)
-	if len(s) < 2 || s[0] != '(' || s[len(s)-1] != ')' {
-		return s
+// isOrLaterSuffix reports whether s ends with exactly one "+" attached to a
+// non-empty base (e.g. "Apache-2.0+"). Returns false for bare "+", "++", or
+// the empty string.
+func isOrLaterSuffix(s string) bool {
+	n := len(s)
+	if n < 2 || s[n-1] != '+' {
+		return false
 	}
-	depth := 0
-	for i := 0; i < len(s); i++ {
-		switch s[i] {
-		case '(':
-			depth++
-		case ')':
-			depth--
-			if depth == 0 && i != len(s)-1 {
-				return s
-			}
-		}
-	}
-	if depth != 0 {
-		return s
-	}
-	return strings.TrimSpace(s[1 : len(s)-1])
+	return s[n-2] != '+'
 }
+
+// Compile-time guard that the package's public types remain stringer-
+// compatible. The fmt import is otherwise unused; this also catches the case
+// where a future refactor accidentally drops the String method receiver.
+var _ fmt.Stringer = (*ExprNode)(nil)
+var _ fmt.Stringer = (*ExprLicense)(nil)

--- a/internal/domain/licenses/expression.go
+++ b/internal/domain/licenses/expression.go
@@ -67,7 +67,8 @@ var trailingEdgeOperator = regexp.MustCompile(`(?i)\s*\b(?:OR|AND)$`)
 //     "license-id WITH exception-id" string is normalized as a unit and will
 //     typically be reported as non-SPDX since no exception table exists yet.
 //   - The "+" suffix on a license-id (e.g., "Apache-2.0+") is preserved in Raw;
-//     normalization falls through to the heuristic, so the result is non-SPDX.
+//     normalization resolves it to the base SPDX ID via the generated alias table
+//     (e.g., "Apache-2.0+" → "Apache-2.0").
 func ParseExpression(raw string) ExpressionResult {
 	res := ExpressionResult{Raw: raw}
 	parts := splitFlatten(raw)

--- a/internal/domain/licenses/expression_test.go
+++ b/internal/domain/licenses/expression_test.go
@@ -333,6 +333,7 @@ func TestExprNode_StringIdempotent(t *testing.T) {
 		"(Apache-2.0 OR MIT) AND BSD-3-Clause",
 		"A OR B OR C",
 		"Apache-2.0+",
+		"Apache-2.0+ WITH Classpath-exception-2.0",
 		"NOASSERTION",
 	}
 	for _, in := range inputs {
@@ -447,6 +448,32 @@ func TestExprNode_StringPanicsOnNilOperand(t *testing.T) {
 	leaf := &ExprNode{License: &ExprLicense{Identifier: "MIT"}}
 	bad := &ExprNode{Compound: &ExprCompound{Operator: "OR", Operands: []*ExprNode{leaf, nil}}}
 	_ = bad.String()
+}
+
+// TestExprNode_StringPanicsOnUnderfilledCompound enforces the documented
+// "Operands always length ≥ 2" invariant uniformly with the other panic
+// paths. The parser cannot produce a 0/1-operand Compound (finalizeCompound
+// collapses), but a hand-built misuse must surface immediately rather than
+// rendering a malformed SPDX string.
+func TestExprNode_StringPanicsOnUnderfilledCompound(t *testing.T) {
+	tests := []struct {
+		name     string
+		operands []*ExprNode
+	}{
+		{name: "empty_operands", operands: nil},
+		{name: "single_operand", operands: []*ExprNode{{License: &ExprLicense{Identifier: "MIT"}}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r == nil {
+					t.Errorf("expected panic on Compound with %d operands", len(tt.operands))
+				}
+			}()
+			bad := &ExprNode{Compound: &ExprCompound{Operator: "OR", Operands: tt.operands}}
+			_ = bad.String()
+		})
+	}
 }
 
 // TestLeaves_PanicsOnZeroValue mirrors TestExprNode_StringPanicsOnZeroValue
@@ -620,6 +647,35 @@ func TestParseExpression_FreeTextAdjacentOperators(t *testing.T) {
 			got := summarize(ParseExpression(tt.input))
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("\n got %#v\nwant %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestParseExpression_AdjacentSimpleExpressions pins the silent-truncation
+// behavior for malformed inputs that juxtapose two simple-expressions with
+// no operator between them — e.g., `(MIT) (Apache-2.0)` from a buggy SBOM
+// exporter. The parser returns the first compound and stops; the trailing
+// tokens are left unconsumed. Locked-in to prevent silent regressions when
+// the parser's recovery policy is revised.
+func TestParseExpression_AdjacentSimpleExpressions(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []string // expected Identifier sequence from Leaves()
+	}{
+		{name: "adjacent_paren_groups", input: "(MIT) (Apache-2.0)", want: []string{"MIT"}},
+		{name: "adjacent_idents_merge_to_one", input: "MIT Apache-2.0", want: []string{""}}, // tokenizer merges to "MIT Apache-2.0", not SPDX
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			leaves := ParseExpression(tt.input).Leaves()
+			got := make([]string, 0, len(leaves))
+			for _, l := range leaves {
+				got = append(got, l.Identifier)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("got %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/internal/domain/licenses/expression_test.go
+++ b/internal/domain/licenses/expression_test.go
@@ -383,10 +383,12 @@ func TestParseExpression_LeafNormalization(t *testing.T) {
 	}
 }
 
-// TestParseExpression_TerminationGuards lock in non-amplification: a long
-// flat OR chain (1024 operands) and deeply nested parens (512 levels) must
-// both complete without panic. The cap test pins the strict-> comparison
-// against future "≥" regressions.
+// TestParseExpression_TerminationGuards verifies graceful handling at large
+// inputs: a long flat OR chain (1024 operands) and deeply nested parens
+// (512 levels) both complete without panic, and an input exactly at the
+// length cap is still accepted (pinning the strict ">" comparison against
+// future "≥" regressions). These are not hard caps — termination is bounded
+// by maxExpressionLength, not by an explicit recursion / chain limit.
 func TestParseExpression_TerminationGuards(t *testing.T) {
 	t.Run("long_flat_chain", func(t *testing.T) {
 		const operandCount = 1024
@@ -570,24 +572,48 @@ func TestParseExpression_WithChain(t *testing.T) {
 // OrLater. Bare "+" and "++" do NOT set OrLater — they are passed verbatim
 // to the SPDX normalizer, whose alias-key collapsing may still resolve some
 // to a canonical ID, but that is the table's call, not the parser's.
+//
+// The "Apache-2.0++" case also pins a silent input-data-loss path: the parser
+// preserves Raw verbatim but the rendered String() drops the second "+"
+// because Normalize() aliases "Apache-2.0++" → canonical "Apache-2.0". The
+// test asserts the rendered form so a future change cannot accidentally
+// promote double-plus to "or-later" semantics.
 func TestParseExpression_PlusEdgeCases(t *testing.T) {
 	tests := []struct {
-		name        string
-		input       string
-		wantOrLater bool
+		name           string
+		input          string
+		wantOrLater    bool
+		wantIdentifier string
+		wantRendered   string
 	}{
-		{name: "single_trailing_plus_sets_or_later", input: "Apache-2.0+", wantOrLater: true},
-		{name: "double_plus_does_not_set_or_later", input: "Apache-2.0++", wantOrLater: false},
-		{name: "bare_plus_does_not_set_or_later", input: "+", wantOrLater: false},
+		{
+			name: "single_trailing_plus_sets_or_later", input: "Apache-2.0+",
+			wantOrLater: true, wantIdentifier: "Apache-2.0", wantRendered: "Apache-2.0+",
+		},
+		{
+			name: "double_plus_does_not_set_or_later", input: "Apache-2.0++",
+			wantOrLater: false, wantIdentifier: "Apache-2.0", wantRendered: "Apache-2.0",
+		},
+		{
+			name: "bare_plus_does_not_set_or_later", input: "+",
+			wantOrLater: false, wantIdentifier: "", wantRendered: "+",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			leaves := ParseExpression(tt.input).Leaves()
+			res := ParseExpression(tt.input)
+			leaves := res.Leaves()
 			if len(leaves) != 1 {
 				t.Fatalf("expected 1 leaf, got %d", len(leaves))
 			}
 			if leaves[0].OrLater != tt.wantOrLater {
 				t.Errorf("OrLater = %v, want %v (raw=%q)", leaves[0].OrLater, tt.wantOrLater, leaves[0].Raw)
+			}
+			if leaves[0].Identifier != tt.wantIdentifier {
+				t.Errorf("Identifier = %q, want %q", leaves[0].Identifier, tt.wantIdentifier)
+			}
+			if got := res.Root.String(); got != tt.wantRendered {
+				t.Errorf("String() = %q, want %q", got, tt.wantRendered)
 			}
 		})
 	}
@@ -676,6 +702,45 @@ func TestParseExpression_AdjacentSimpleExpressions(t *testing.T) {
 			}
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestParseExpression_TrailingOperators pins recovery for inputs ending in a
+// dangling binary operator. The grammar requires a right-hand operand, but
+// real-world Maven POM and ClearlyDefined data occasionally truncate. The
+// parser drops the trailing operator and returns the left primary unchanged
+// — never produces a degenerate single-operand Compound. WITH at end-of-
+// input falls through to the same recovery path as "WITH not followed by an
+// identifier".
+func TestParseExpression_TrailingOperators(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []leafSummary
+	}{
+		{
+			name:  "or_at_end",
+			input: "Apache-2.0 OR ",
+			want:  []leafSummary{{Raw: "Apache-2.0", Identifier: "Apache-2.0"}},
+		},
+		{
+			name:  "and_at_end",
+			input: "Apache-2.0 AND ",
+			want:  []leafSummary{{Raw: "Apache-2.0", Identifier: "Apache-2.0"}},
+		},
+		{
+			name:  "with_at_end_no_exception",
+			input: "Apache-2.0 WITH ",
+			want:  []leafSummary{{Raw: "Apache-2.0", Identifier: "Apache-2.0"}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := summarize(ParseExpression(tt.input))
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("\n got %#v\nwant %#v", got, tt.want)
 			}
 		})
 	}

--- a/internal/domain/licenses/expression_test.go
+++ b/internal/domain/licenses/expression_test.go
@@ -1,0 +1,241 @@
+package licenses
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseExpression(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantRaws    []string
+		wantSPDXIDs []string // canonical SPDX ID per operand; empty string means non-SPDX
+	}{
+		{
+			name:        "empty",
+			input:       "",
+			wantRaws:    nil,
+			wantSPDXIDs: nil,
+		},
+		{
+			name:        "whitespace_only",
+			input:       "   \t\n",
+			wantRaws:    nil,
+			wantSPDXIDs: nil,
+		},
+		{
+			name:        "plain_spdx",
+			input:       "Apache-2.0",
+			wantRaws:    []string{"Apache-2.0"},
+			wantSPDXIDs: []string{"Apache-2.0"},
+		},
+		{
+			name:        "plain_alias_spaced",
+			input:       "Apache License 2.0",
+			wantRaws:    []string{"Apache License 2.0"},
+			wantSPDXIDs: []string{"Apache-2.0"},
+		},
+		{
+			name:        "or_two_spdx",
+			input:       "Apache-2.0 OR MIT",
+			wantRaws:    []string{"Apache-2.0", "MIT"},
+			wantSPDXIDs: []string{"Apache-2.0", "MIT"},
+		},
+		{
+			name:        "and_two_spdx",
+			input:       "Apache-2.0 AND MIT",
+			wantRaws:    []string{"Apache-2.0", "MIT"},
+			wantSPDXIDs: []string{"Apache-2.0", "MIT"},
+		},
+		{
+			name:        "or_lowercase",
+			input:       "MIT or Apache-2.0",
+			wantRaws:    []string{"MIT", "Apache-2.0"},
+			wantSPDXIDs: []string{"MIT", "Apache-2.0"},
+		},
+		{
+			name:        "and_mixed_case",
+			input:       "MIT And Apache-2.0",
+			wantRaws:    []string{"MIT", "Apache-2.0"},
+			wantSPDXIDs: []string{"MIT", "Apache-2.0"},
+		},
+		{
+			name:        "or_with_alias_operand",
+			input:       "MIT OR Apache License 2.0",
+			wantRaws:    []string{"MIT", "Apache License 2.0"},
+			wantSPDXIDs: []string{"MIT", "Apache-2.0"},
+		},
+		{
+			name:        "with_attached_single_operand",
+			input:       "Apache-2.0 WITH Classpath-exception-2.0",
+			wantRaws:    []string{"Apache-2.0 WITH Classpath-exception-2.0"},
+			wantSPDXIDs: []string{""},
+		},
+		{
+			name:        "or_with_in_second_operand",
+			input:       "CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0",
+			wantRaws:    []string{"CDDL-1.1", "GPL-2.0-only WITH Classpath-exception-2.0"},
+			wantSPDXIDs: []string{"CDDL-1.1", ""},
+		},
+		{
+			name:        "nested_paren_or_flattens",
+			input:       "EPL-1.0 OR (LGPL-2.1 OR LGPL-3.0)",
+			wantRaws:    []string{"EPL-1.0", "LGPL-2.1", "LGPL-3.0"},
+			wantSPDXIDs: []string{"EPL-1.0", "LGPL-2.1", "LGPL-3.0"},
+		},
+		{
+			name:        "outer_paren_wrap",
+			input:       "(MIT OR Apache-2.0)",
+			wantRaws:    []string{"MIT", "Apache-2.0"},
+			wantSPDXIDs: []string{"MIT", "Apache-2.0"},
+		},
+		{
+			name:        "double_outer_paren_wrap",
+			input:       "((MIT OR Apache-2.0))",
+			wantRaws:    []string{"MIT", "Apache-2.0"},
+			wantSPDXIDs: []string{"MIT", "Apache-2.0"},
+		},
+		{
+			name:        "noassertion_is_single_non_spdx",
+			input:       "NOASSERTION",
+			wantRaws:    []string{"NOASSERTION"},
+			wantSPDXIDs: []string{""},
+		},
+		{
+			// Apache-2.0+ is a deprecated SPDX form ("or later"). The generated
+			// SPDX table maps it back to Apache-2.0 as canonical.
+			name:        "plus_suffix_resolves_to_base_spdx",
+			input:       "Apache-2.0+",
+			wantRaws:    []string{"Apache-2.0+"},
+			wantSPDXIDs: []string{"Apache-2.0"},
+		},
+		{
+			name:        "leading_operator_yields_single_operand",
+			input:       " OR Apache-2.0",
+			wantRaws:    []string{"Apache-2.0"},
+			wantSPDXIDs: []string{"Apache-2.0"},
+		},
+		{
+			name:        "trailing_operator_yields_single_operand",
+			input:       "Apache-2.0 OR ",
+			wantRaws:    []string{"Apache-2.0"},
+			wantSPDXIDs: []string{"Apache-2.0"},
+		},
+		{
+			name:        "consecutive_operators_skip_empty_segments",
+			input:       "Apache-2.0 OR OR MIT",
+			wantRaws:    []string{"Apache-2.0", "MIT"},
+			wantSPDXIDs: []string{"Apache-2.0", "MIT"},
+		},
+		{
+			name:        "tabs_as_operator_whitespace",
+			input:       "Apache-2.0\tOR\tMIT",
+			wantRaws:    []string{"Apache-2.0", "MIT"},
+			wantSPDXIDs: []string{"Apache-2.0", "MIT"},
+		},
+		{
+			name:        "non_outer_paren_pair_left_intact",
+			input:       "(MIT) OR (Apache-2.0)",
+			wantRaws:    []string{"MIT", "Apache-2.0"},
+			wantSPDXIDs: []string{"MIT", "Apache-2.0"},
+		},
+		{
+			name:        "empty_parens_yields_no_operands",
+			input:       "()",
+			wantRaws:    nil,
+			wantSPDXIDs: nil,
+		},
+		{
+			name:        "three_way_or_chain",
+			input:       "MIT OR Apache-2.0 OR BSD-3-Clause",
+			wantRaws:    []string{"MIT", "Apache-2.0", "BSD-3-Clause"},
+			wantSPDXIDs: []string{"MIT", "Apache-2.0", "BSD-3-Clause"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParseExpression(tt.input)
+			if got.Raw != tt.input {
+				t.Errorf("Raw = %q, want %q", got.Raw, tt.input)
+			}
+			var gotRaws []string
+			var gotIDs []string
+			for _, op := range got.Operands {
+				gotRaws = append(gotRaws, op.Raw)
+				if op.Normalization.SPDX {
+					gotIDs = append(gotIDs, op.Normalization.CanonicalID)
+				} else {
+					gotIDs = append(gotIDs, "")
+				}
+			}
+			if !reflect.DeepEqual(gotRaws, tt.wantRaws) {
+				t.Errorf("operand Raws = %#v, want %#v", gotRaws, tt.wantRaws)
+			}
+			if !reflect.DeepEqual(gotIDs, tt.wantSPDXIDs) {
+				t.Errorf("operand SPDX IDs = %#v, want %#v", gotIDs, tt.wantSPDXIDs)
+			}
+		})
+	}
+}
+
+func TestParseExpression_NoassertionMatchType(t *testing.T) {
+	got := ParseExpression("NOASSERTION")
+	if len(got.Operands) != 1 {
+		t.Fatalf("expected 1 operand, got %d", len(got.Operands))
+	}
+	if got.Operands[0].Normalization.MatchType != MatchNoAssertion {
+		t.Errorf("MatchType = %v, want MatchNoAssertion", got.Operands[0].Normalization.MatchType)
+	}
+}
+
+func TestStripOuterParens(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "no_parens", in: "MIT", want: "MIT"},
+		{name: "balanced_outer", in: "(MIT)", want: "MIT"},
+		{name: "balanced_outer_with_inner", in: "(A OR (B AND C))", want: "A OR (B AND C)"},
+		{name: "non_outer_pair", in: "(A) OR (B)", want: "(A) OR (B)"},
+		{name: "unbalanced_extra_open", in: "((MIT)", want: "((MIT)"}, // depth never reaches 0 → unchanged
+		{name: "unbalanced_extra_close", in: "(MIT))", want: "(MIT))"},
+		{name: "double_wrap", in: "((MIT))", want: "(MIT)"}, // single pass; caller loops
+		{name: "empty_parens", in: "()", want: ""},
+		{name: "whitespace_inside", in: "(  MIT  )", want: "MIT"},
+		{name: "no_close", in: "(MIT", want: "(MIT"},
+		{name: "no_open", in: "MIT)", want: "MIT)"},
+		{name: "empty", in: "", want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := stripOuterParens(tt.in); got != tt.want {
+				t.Errorf("stripOuterParens(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFindTopLevelOperators(t *testing.T) {
+	tests := []struct {
+		name      string
+		in        string
+		wantCount int
+	}{
+		{name: "no_operators", in: "Apache-2.0", wantCount: 0},
+		{name: "one_top_level_or", in: "Apache-2.0 OR MIT", wantCount: 1},
+		{name: "two_top_level_or", in: "A OR B OR C", wantCount: 2},
+		{name: "operator_inside_parens_skipped", in: "A OR (B OR C)", wantCount: 1},
+		{name: "all_operators_inside_parens", in: "(B OR C)", wantCount: 0},
+		{name: "deeply_nested", in: "A OR ((B AND C) OR D)", wantCount: 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := findTopLevelOperators(tt.in)
+			if len(got) != tt.wantCount {
+				t.Errorf("findTopLevelOperators(%q) returned %d operators, want %d (got=%v)", tt.in, len(got), tt.wantCount, got)
+			}
+		})
+	}
+}

--- a/internal/domain/licenses/expression_test.go
+++ b/internal/domain/licenses/expression_test.go
@@ -6,352 +6,648 @@ import (
 	"testing"
 )
 
-func TestParseExpression(t *testing.T) {
+// leafSummary is a compact projection of an ExprLicense for table-driven
+// assertions. Captures Identifier, OrLater, Exception, and the Raw input —
+// the full Normalization surface is exercised in TestParseExpression_LeafNormalization.
+type leafSummary struct {
+	Raw        string
+	Identifier string
+	OrLater    bool
+	Exception  string
+}
+
+// summarize collects the leaves of result.Root in reading order.
+func summarize(r ExpressionResult) []leafSummary {
+	leaves := r.Leaves()
+	if leaves == nil {
+		return nil
+	}
+	out := make([]leafSummary, 0, len(leaves))
+	for _, l := range leaves {
+		out = append(out, leafSummary{
+			Raw:        l.Raw,
+			Identifier: l.Identifier,
+			OrLater:    l.OrLater,
+			Exception:  l.Exception,
+		})
+	}
+	return out
+}
+
+func TestParseExpression_Leaves(t *testing.T) {
 	tests := []struct {
-		name        string
-		input       string
-		wantRaws    []string
-		wantSPDXIDs []string // canonical SPDX ID per operand; empty string means non-SPDX
+		name  string
+		input string
+		want  []leafSummary
 	}{
+		{name: "empty", input: "", want: nil},
+		{name: "whitespace_only", input: "   \t\n", want: nil},
 		{
-			name:        "empty",
-			input:       "",
-			wantRaws:    nil,
-			wantSPDXIDs: nil,
+			name:  "plain_spdx",
+			input: "Apache-2.0",
+			want:  []leafSummary{{Raw: "Apache-2.0", Identifier: "Apache-2.0"}},
 		},
 		{
-			name:        "whitespace_only",
-			input:       "   \t\n",
-			wantRaws:    nil,
-			wantSPDXIDs: nil,
+			name:  "free_text_alias",
+			input: "Apache License 2.0",
+			want:  []leafSummary{{Raw: "Apache License 2.0", Identifier: "Apache-2.0"}},
 		},
 		{
-			name:        "plain_spdx",
-			input:       "Apache-2.0",
-			wantRaws:    []string{"Apache-2.0"},
-			wantSPDXIDs: []string{"Apache-2.0"},
+			name:  "or_two_spdx",
+			input: "Apache-2.0 OR MIT",
+			want: []leafSummary{
+				{Raw: "Apache-2.0", Identifier: "Apache-2.0"},
+				{Raw: "MIT", Identifier: "MIT"},
+			},
 		},
 		{
-			name:        "plain_alias_spaced",
-			input:       "Apache License 2.0",
-			wantRaws:    []string{"Apache License 2.0"},
-			wantSPDXIDs: []string{"Apache-2.0"},
+			name:  "and_two_spdx",
+			input: "Apache-2.0 AND MIT",
+			want: []leafSummary{
+				{Raw: "Apache-2.0", Identifier: "Apache-2.0"},
+				{Raw: "MIT", Identifier: "MIT"},
+			},
 		},
 		{
-			name:        "or_two_spdx",
-			input:       "Apache-2.0 OR MIT",
-			wantRaws:    []string{"Apache-2.0", "MIT"},
-			wantSPDXIDs: []string{"Apache-2.0", "MIT"},
+			name:  "or_lowercase",
+			input: "MIT or Apache-2.0",
+			want: []leafSummary{
+				{Raw: "MIT", Identifier: "MIT"},
+				{Raw: "Apache-2.0", Identifier: "Apache-2.0"},
+			},
 		},
 		{
-			name:        "and_two_spdx",
-			input:       "Apache-2.0 AND MIT",
-			wantRaws:    []string{"Apache-2.0", "MIT"},
-			wantSPDXIDs: []string{"Apache-2.0", "MIT"},
+			name:  "with_attached_single_leaf",
+			input: "Apache-2.0 WITH Classpath-exception-2.0",
+			want: []leafSummary{
+				{Raw: "Apache-2.0 WITH Classpath-exception-2.0", Identifier: "Apache-2.0", Exception: "Classpath-exception-2.0"},
+			},
 		},
 		{
-			name:        "or_lowercase",
-			input:       "MIT or Apache-2.0",
-			wantRaws:    []string{"MIT", "Apache-2.0"},
-			wantSPDXIDs: []string{"MIT", "Apache-2.0"},
+			name:  "or_with_in_second_operand",
+			input: "CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0",
+			want: []leafSummary{
+				{Raw: "CDDL-1.1", Identifier: "CDDL-1.1"},
+				{Raw: "GPL-2.0-only WITH Classpath-exception-2.0", Identifier: "GPL-2.0-only", Exception: "Classpath-exception-2.0"},
+			},
 		},
 		{
-			name:        "and_mixed_case",
-			input:       "MIT And Apache-2.0",
-			wantRaws:    []string{"MIT", "Apache-2.0"},
-			wantSPDXIDs: []string{"MIT", "Apache-2.0"},
+			name:  "free_text_with_exception",
+			input: "Apache License 2.0 WITH Classpath-exception-2.0",
+			want: []leafSummary{
+				{Raw: "Apache License 2.0 WITH Classpath-exception-2.0", Identifier: "Apache-2.0", Exception: "Classpath-exception-2.0"},
+			},
 		},
 		{
-			name:        "and_lowercase",
-			input:       "MIT and Apache-2.0",
-			wantRaws:    []string{"MIT", "Apache-2.0"},
-			wantSPDXIDs: []string{"MIT", "Apache-2.0"},
+			name:  "nested_paren_or_flattens",
+			input: "EPL-1.0 OR (LGPL-2.1 OR LGPL-3.0)",
+			want: []leafSummary{
+				{Raw: "EPL-1.0", Identifier: "EPL-1.0"},
+				{Raw: "LGPL-2.1", Identifier: "LGPL-2.1"},
+				{Raw: "LGPL-3.0", Identifier: "LGPL-3.0"},
+			},
 		},
 		{
-			name:        "multiple_spaces_around_operator",
-			input:       "MIT   OR   Apache-2.0",
-			wantRaws:    []string{"MIT", "Apache-2.0"},
-			wantSPDXIDs: []string{"MIT", "Apache-2.0"},
+			name:  "outer_paren_wrap",
+			input: "(MIT OR Apache-2.0)",
+			want: []leafSummary{
+				{Raw: "MIT", Identifier: "MIT"},
+				{Raw: "Apache-2.0", Identifier: "Apache-2.0"},
+			},
 		},
 		{
-			name:        "or_with_alias_operand",
-			input:       "MIT OR Apache License 2.0",
-			wantRaws:    []string{"MIT", "Apache License 2.0"},
-			wantSPDXIDs: []string{"MIT", "Apache-2.0"},
+			name:  "noassertion",
+			input: "NOASSERTION",
+			want: []leafSummary{
+				{Raw: "NOASSERTION", Identifier: ""},
+			},
 		},
 		{
-			name:        "with_attached_single_operand",
-			input:       "Apache-2.0 WITH Classpath-exception-2.0",
-			wantRaws:    []string{"Apache-2.0 WITH Classpath-exception-2.0"},
-			wantSPDXIDs: []string{""},
+			name:  "plus_suffix_or_later_flag",
+			input: "Apache-2.0+",
+			want: []leafSummary{
+				// Apache-2.0+ → SPDX alias to Apache-2.0; OrLater preserved.
+				{Raw: "Apache-2.0+", Identifier: "Apache-2.0", OrLater: true},
+			},
 		},
 		{
-			name:        "or_with_in_second_operand",
-			input:       "CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0",
-			wantRaws:    []string{"CDDL-1.1", "GPL-2.0-only WITH Classpath-exception-2.0"},
-			wantSPDXIDs: []string{"CDDL-1.1", ""},
+			name:  "leading_operator_dropped",
+			input: " OR Apache-2.0",
+			want: []leafSummary{{Raw: "Apache-2.0", Identifier: "Apache-2.0"}},
 		},
 		{
-			name:        "nested_paren_or_flattens",
-			input:       "EPL-1.0 OR (LGPL-2.1 OR LGPL-3.0)",
-			wantRaws:    []string{"EPL-1.0", "LGPL-2.1", "LGPL-3.0"},
-			wantSPDXIDs: []string{"EPL-1.0", "LGPL-2.1", "LGPL-3.0"},
+			name:  "trailing_operator_dropped",
+			input: "Apache-2.0 OR ",
+			want: []leafSummary{{Raw: "Apache-2.0", Identifier: "Apache-2.0"}},
 		},
 		{
-			name:        "outer_paren_wrap",
-			input:       "(MIT OR Apache-2.0)",
-			wantRaws:    []string{"MIT", "Apache-2.0"},
-			wantSPDXIDs: []string{"MIT", "Apache-2.0"},
+			name:  "consecutive_operators_skipped",
+			input: "Apache-2.0 OR OR MIT",
+			want: []leafSummary{
+				{Raw: "Apache-2.0", Identifier: "Apache-2.0"},
+				{Raw: "MIT", Identifier: "MIT"},
+			},
 		},
 		{
-			name:        "double_outer_paren_wrap",
-			input:       "((MIT OR Apache-2.0))",
-			wantRaws:    []string{"MIT", "Apache-2.0"},
-			wantSPDXIDs: []string{"MIT", "Apache-2.0"},
+			name:  "tabs_as_operator_whitespace",
+			input: "Apache-2.0\tOR\tMIT",
+			want: []leafSummary{
+				{Raw: "Apache-2.0", Identifier: "Apache-2.0"},
+				{Raw: "MIT", Identifier: "MIT"},
+			},
 		},
 		{
-			name:        "noassertion_is_single_non_spdx",
-			input:       "NOASSERTION",
-			wantRaws:    []string{"NOASSERTION"},
-			wantSPDXIDs: []string{""},
+			name:  "or_prefixed_identifier_not_split",
+			input: "OR-tools",
+			want:  []leafSummary{{Raw: "OR-tools", Identifier: ""}},
 		},
 		{
-			// Apache-2.0+ is a deprecated SPDX form ("or later"). The generated
-			// SPDX table maps it back to Apache-2.0 as canonical.
-			name:        "plus_suffix_resolves_to_base_spdx",
-			input:       "Apache-2.0+",
-			wantRaws:    []string{"Apache-2.0+"},
-			wantSPDXIDs: []string{"Apache-2.0"},
+			name:  "and_prefixed_identifier_not_split",
+			input: "AND-license",
+			want:  []leafSummary{{Raw: "AND-license", Identifier: ""}},
 		},
 		{
-			name:        "leading_operator_yields_single_operand",
-			input:       " OR Apache-2.0",
-			wantRaws:    []string{"Apache-2.0"},
-			wantSPDXIDs: []string{"Apache-2.0"},
+			name:  "oversized_input_yields_no_leaves",
+			input: strings.Repeat("X", maxExpressionLength+1),
+			want:  nil,
 		},
 		{
-			name:        "trailing_operator_yields_single_operand",
-			input:       "Apache-2.0 OR ",
-			wantRaws:    []string{"Apache-2.0"},
-			wantSPDXIDs: []string{"Apache-2.0"},
+			name:  "three_way_or_chain_flattens",
+			input: "MIT OR Apache-2.0 OR BSD-3-Clause",
+			want: []leafSummary{
+				{Raw: "MIT", Identifier: "MIT"},
+				{Raw: "Apache-2.0", Identifier: "Apache-2.0"},
+				{Raw: "BSD-3-Clause", Identifier: "BSD-3-Clause"},
+			},
 		},
 		{
-			// The first " OR " is the matched operator; the residual "OR MIT"
-			// segment then has its leading "OR " stripped by trimEdgeOperators.
-			name:        "operator_after_split_is_trimmed_as_edge",
-			input:       "Apache-2.0 OR OR MIT",
-			wantRaws:    []string{"Apache-2.0", "MIT"},
-			wantSPDXIDs: []string{"Apache-2.0", "MIT"},
+			name:  "empty_parens_yields_no_leaves",
+			input: "()",
+			want:  nil,
 		},
 		{
-			name:        "tabs_as_operator_whitespace",
-			input:       "Apache-2.0\tOR\tMIT",
-			wantRaws:    []string{"Apache-2.0", "MIT"},
-			wantSPDXIDs: []string{"Apache-2.0", "MIT"},
-		},
-		{
-			name:        "non_outer_paren_pair_left_intact",
-			input:       "(MIT) OR (Apache-2.0)",
-			wantRaws:    []string{"MIT", "Apache-2.0"},
-			wantSPDXIDs: []string{"MIT", "Apache-2.0"},
-		},
-		{
-			name:        "empty_parens_yields_no_operands",
-			input:       "()",
-			wantRaws:    nil,
-			wantSPDXIDs: nil,
-		},
-		{
-			name:        "three_way_or_chain",
-			input:       "MIT OR Apache-2.0 OR BSD-3-Clause",
-			wantRaws:    []string{"MIT", "Apache-2.0", "BSD-3-Clause"},
-			wantSPDXIDs: []string{"MIT", "Apache-2.0", "BSD-3-Clause"},
-		},
-		{
-			// Asymmetric handling pinned: open-only paren keeps the prefix
-			// attached because no top-level OR/AND can match at depth 0.
-			// Acceptable for v1; reconsider if real-world data shows demand.
-			name:        "unbalanced_open_paren_collapses_to_one_operand",
-			input:       "(MIT OR Apache-2.0",
-			wantRaws:    []string{"(MIT OR Apache-2.0"},
-			wantSPDXIDs: []string{""},
-		},
-		{
-			// Asymmetric handling pinned: close-only paren is treated as part
-			// of the trailing operand because depth never goes positive.
-			name:        "unbalanced_close_paren_kept_on_trailing_operand",
-			input:       "MIT OR Apache-2.0)",
-			wantRaws:    []string{"MIT", "Apache-2.0)"},
-			wantSPDXIDs: []string{"MIT", ""},
-		},
-		{
-			// Defensive: hyphenated identifiers starting with OR-/AND- must
-			// not be stripped by trimEdgeOperators. SPDX has no current entry
-			// like this, but a future custom alias could.
-			name:        "or_prefixed_identifier_not_stripped",
-			input:       "OR-tools",
-			wantRaws:    []string{"OR-tools"},
-			wantSPDXIDs: []string{""},
-		},
-		{
-			name:        "and_prefixed_identifier_not_stripped",
-			input:       "AND-license",
-			wantRaws:    []string{"AND-license"},
-			wantSPDXIDs: []string{""},
-		},
-		{
-			// Pathological input over the length cap returns no operands so
-			// recursion / regex passes cannot be amplified.
-			name:        "oversized_input_yields_no_operands",
-			input:       strings.Repeat("X", maxExpressionLength+1),
-			wantRaws:    nil,
-			wantSPDXIDs: nil,
-		},
-		{
-			// Boundary: input of exactly maxExpressionLength must still parse.
-			// Pads "MIT" to the cap so the parser produces a single operand
-			// (heuristic, non-SPDX) rather than tripping the guard. Locks in
-			// the strict ">" comparison against future "≥" regressions.
-			name:        "input_at_cap_is_accepted",
-			input:       "MIT" + strings.Repeat("X", maxExpressionLength-3),
-			wantRaws:    []string{"MIT" + strings.Repeat("X", maxExpressionLength-3)},
-			wantSPDXIDs: []string{""},
+			name:  "non_outer_paren_pair_left_intact",
+			input: "(MIT) OR (Apache-2.0)",
+			want: []leafSummary{
+				{Raw: "MIT", Identifier: "MIT"},
+				{Raw: "Apache-2.0", Identifier: "Apache-2.0"},
+			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := ParseExpression(tt.input)
-			if got.Raw != tt.input {
-				t.Errorf("Raw = %q, want %q", got.Raw, tt.input)
-			}
-			var gotRaws []string
-			var gotIDs []string
-			for _, op := range got.Operands {
-				gotRaws = append(gotRaws, op.Raw)
-				if op.Normalization.SPDX {
-					gotIDs = append(gotIDs, op.Normalization.CanonicalID)
-				} else {
-					gotIDs = append(gotIDs, "")
-				}
-			}
-			if !reflect.DeepEqual(gotRaws, tt.wantRaws) {
-				t.Errorf("operand Raws = %#v, want %#v", gotRaws, tt.wantRaws)
-			}
-			if !reflect.DeepEqual(gotIDs, tt.wantSPDXIDs) {
-				t.Errorf("operand SPDX IDs = %#v, want %#v", gotIDs, tt.wantSPDXIDs)
+			got := summarize(ParseExpression(tt.input))
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Leaves(%q) = %#v, want %#v", tt.input, got, tt.want)
 			}
 		})
 	}
 }
 
-func TestParseExpression_OperandMatchType(t *testing.T) {
+func TestParseExpression_Structure(t *testing.T) {
+	t.Run("flat_or_chain_is_single_compound", func(t *testing.T) {
+		root := ParseExpression("A OR B OR C").Root
+		if root == nil || root.Compound == nil {
+			t.Fatalf("expected a Compound root, got %+v", root)
+		}
+		if root.Compound.Operator != "OR" {
+			t.Errorf("Operator = %q, want OR", root.Compound.Operator)
+		}
+		if len(root.Compound.Operands) != 3 {
+			t.Errorf("Operands len = %d, want 3", len(root.Compound.Operands))
+		}
+		// All operands should be leaves at depth 1 (no nested OR Compound).
+		for i, op := range root.Compound.Operands {
+			if op.License == nil {
+				t.Errorf("operand[%d] is not a leaf: %+v", i, op)
+			}
+		}
+	})
+
+	t.Run("nested_paren_or_flattens_into_root_compound", func(t *testing.T) {
+		root := ParseExpression("A OR (B OR C)").Root
+		if root == nil || root.Compound == nil {
+			t.Fatalf("expected a Compound root, got %+v", root)
+		}
+		if len(root.Compound.Operands) != 3 {
+			t.Errorf("expected flattened 3 operands, got %d", len(root.Compound.Operands))
+		}
+	})
+
+	t.Run("mixed_or_and_respects_precedence", func(t *testing.T) {
+		// "A OR B AND C" must parse as "A OR (B AND C)" per SPDX precedence.
+		root := ParseExpression("Apache-2.0 OR MIT AND BSD-3-Clause").Root
+		if root == nil || root.Compound == nil || root.Compound.Operator != "OR" {
+			t.Fatalf("expected OR root, got %+v", root)
+		}
+		if len(root.Compound.Operands) != 2 {
+			t.Fatalf("expected 2 OR operands, got %d", len(root.Compound.Operands))
+		}
+		left := root.Compound.Operands[0]
+		right := root.Compound.Operands[1]
+		if left.License == nil || left.License.Identifier != "Apache-2.0" {
+			t.Errorf("left = %+v, want leaf(Apache-2.0)", left)
+		}
+		if right.Compound == nil || right.Compound.Operator != "AND" {
+			t.Errorf("right = %+v, want AND compound", right)
+		}
+		if got := len(right.Compound.Operands); got != 2 {
+			t.Errorf("right AND operands = %d, want 2", got)
+		}
+	})
+
+	t.Run("explicit_paren_overrides_precedence", func(t *testing.T) {
+		// "(A OR B) AND C" parses as AND root with OR child.
+		root := ParseExpression("(Apache-2.0 OR MIT) AND BSD-3-Clause").Root
+		if root == nil || root.Compound == nil || root.Compound.Operator != "AND" {
+			t.Fatalf("expected AND root, got %+v", root)
+		}
+		if len(root.Compound.Operands) != 2 {
+			t.Fatalf("expected 2 AND operands, got %d", len(root.Compound.Operands))
+		}
+		left := root.Compound.Operands[0]
+		if left.Compound == nil || left.Compound.Operator != "OR" {
+			t.Errorf("left = %+v, want OR compound", left)
+		}
+	})
+
+	t.Run("with_in_compound_attaches_to_correct_leaf", func(t *testing.T) {
+		root := ParseExpression("Apache-2.0 OR MIT WITH Classpath-exception-2.0").Root
+		if root == nil || root.Compound == nil {
+			t.Fatalf("expected Compound root, got %+v", root)
+		}
+		if len(root.Compound.Operands) != 2 {
+			t.Fatalf("expected 2 operands, got %d", len(root.Compound.Operands))
+		}
+		// First operand = leaf(Apache-2.0) with no exception.
+		if l := root.Compound.Operands[0].License; l == nil || l.Identifier != "Apache-2.0" || l.Exception != "" {
+			t.Errorf("first operand = %+v, want plain Apache-2.0 leaf", root.Compound.Operands[0])
+		}
+		// Second operand = leaf(MIT) WITH Classpath-exception-2.0.
+		if l := root.Compound.Operands[1].License; l == nil || l.Identifier != "MIT" || l.Exception != "Classpath-exception-2.0" {
+			t.Errorf("second operand = %+v, want MIT WITH Classpath-exception-2.0", root.Compound.Operands[1])
+		}
+	})
+}
+
+func TestExprNode_String(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "single_spdx", input: "Apache-2.0", want: "Apache-2.0"},
+		{name: "free_text_alias_canonicalized", input: "Apache License 2.0", want: "Apache-2.0"},
+		{name: "or_two", input: "Apache-2.0 OR MIT", want: "Apache-2.0 OR MIT"},
+		{name: "and_two", input: "Apache-2.0 AND MIT", want: "Apache-2.0 AND MIT"},
+		{name: "with_clause", input: "Apache-2.0 WITH Classpath-exception-2.0", want: "Apache-2.0 WITH Classpath-exception-2.0"},
+		{name: "plus_suffix", input: "Apache-2.0+", want: "Apache-2.0+"},
+		{name: "or_then_with", input: "CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0", want: "CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0"},
+		{name: "or_three_flattened", input: "A OR B OR C", want: "A OR B OR C"},
+		{name: "nested_or_flattens_in_render", input: "A OR (B OR C)", want: "A OR B OR C"},
+		{name: "or_of_and_canonicalizes_with_parens", input: "Apache-2.0 OR MIT AND BSD-3-Clause", want: "Apache-2.0 OR (MIT AND BSD-3-Clause)"},
+		{name: "explicit_or_in_and", input: "(Apache-2.0 OR MIT) AND BSD-3-Clause", want: "(Apache-2.0 OR MIT) AND BSD-3-Clause"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParseExpression(tt.input).Root.String()
+			if got != tt.want {
+				t.Errorf("String(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestExprNode_StringIdempotent verifies that re-parsing a rendered AST
+// produces an identical second render. This is the round-trip invariant for
+// SBOM serialization: once an expression is canonicalized, it stays stable.
+func TestExprNode_StringIdempotent(t *testing.T) {
+	inputs := []string{
+		"Apache-2.0",
+		"Apache License 2.0",
+		"Apache-2.0 OR MIT",
+		"Apache-2.0 AND MIT",
+		"Apache-2.0 WITH Classpath-exception-2.0",
+		"CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0",
+		"Apache-2.0 OR (MIT AND BSD-3-Clause)",
+		"(Apache-2.0 OR MIT) AND BSD-3-Clause",
+		"A OR B OR C",
+		"Apache-2.0+",
+		"NOASSERTION",
+	}
+	for _, in := range inputs {
+		t.Run(in, func(t *testing.T) {
+			first := ParseExpression(in).Root.String()
+			second := ParseExpression(first).Root.String()
+			if first != second {
+				t.Errorf("not idempotent: input=%q, first=%q, second=%q", in, first, second)
+			}
+		})
+	}
+}
+
+func TestParseExpression_LeafNormalization(t *testing.T) {
 	tests := []struct {
 		name      string
 		input     string
-		wantTypes []LicenseMatchType
+		wantType  LicenseMatchType
+		wantSPDX  bool
+		wantOrLat bool
 	}{
-		{name: "noassertion", input: "NOASSERTION", wantTypes: []LicenseMatchType{MatchNoAssertion}},
-		{name: "exact_canonical", input: "Apache-2.0", wantTypes: []LicenseMatchType{MatchCanonicalExact}},
-		{name: "casefold_canonical", input: "apache-2.0", wantTypes: []LicenseMatchType{MatchCanonicalCaseFold}},
-		{name: "alias_full_name", input: "Apache License 2.0", wantTypes: []LicenseMatchType{MatchAlias}},
-		{name: "heuristic_unknown_with_clause", input: "GPL-2.0-only WITH Classpath-exception-2.0", wantTypes: []LicenseMatchType{MatchHeuristic}},
-		{name: "compound_mixed_match_types", input: "Apache-2.0 OR Apache License 2.0", wantTypes: []LicenseMatchType{MatchCanonicalExact, MatchAlias}},
+		{name: "exact_canonical", input: "Apache-2.0", wantType: MatchCanonicalExact, wantSPDX: true},
+		{name: "casefold_canonical", input: "apache-2.0", wantType: MatchCanonicalCaseFold, wantSPDX: true},
+		{name: "alias_full_name", input: "Apache License 2.0", wantType: MatchAlias, wantSPDX: true},
+		{name: "noassertion", input: "NOASSERTION", wantType: MatchNoAssertion, wantSPDX: false},
+		{name: "heuristic_unknown", input: "Acme Internal", wantType: MatchHeuristic, wantSPDX: false},
+		// "+" is stripped before normalization so the base "Apache-2.0" matches exact.
+		{name: "or_later_flag", input: "Apache-2.0+", wantOrLat: true, wantSPDX: true, wantType: MatchCanonicalExact},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := ParseExpression(tt.input)
-			if len(got.Operands) != len(tt.wantTypes) {
-				t.Fatalf("operand count = %d, want %d (operands=%+v)", len(got.Operands), len(tt.wantTypes), got.Operands)
+			leaves := ParseExpression(tt.input).Leaves()
+			if len(leaves) != 1 {
+				t.Fatalf("got %d leaves, want 1", len(leaves))
 			}
-			for i, want := range tt.wantTypes {
-				if got.Operands[i].Normalization.MatchType != want {
-					t.Errorf("operand[%d].MatchType = %v, want %v", i, got.Operands[i].Normalization.MatchType, want)
-				}
+			l := leaves[0]
+			if l.Normalization.MatchType != tt.wantType {
+				t.Errorf("MatchType = %v, want %v", l.Normalization.MatchType, tt.wantType)
 			}
-		})
-	}
-}
-
-// TestParseExpression_LongChainTerminates locks in that a long flat OR chain
-// completes without panic and yields the expected operand count. Recursion
-// depth on a flat chain is shallow (operators are found in a single pass),
-// so this guards regex-pass work and operand accumulation rather than stack
-// growth from nesting.
-func TestParseExpression_LongChainTerminates(t *testing.T) {
-	const operandCount = 1024
-	parts := make([]string, operandCount)
-	for i := range parts {
-		parts[i] = "MIT"
-	}
-	got := ParseExpression(strings.Join(parts, " OR "))
-	if len(got.Operands) != operandCount {
-		t.Fatalf("operand count = %d, want %d", len(got.Operands), operandCount)
-	}
-}
-
-// TestParseExpression_DeepNestingTerminates drives the iterative paren-strip
-// loop inside splitFlatten with deeply nested but well-formed input. Each
-// loop pass peels one paren pair until the inner identifier is exposed; no
-// top-level operators are present, so this complements the flat-chain test
-// (which exercises operator-found recursion) rather than duplicating it.
-func TestParseExpression_DeepNestingTerminates(t *testing.T) {
-	const depth = 512
-	input := strings.Repeat("(", depth) + "MIT" + strings.Repeat(")", depth)
-	got := ParseExpression(input)
-	if len(got.Operands) != 1 {
-		t.Fatalf("operand count = %d, want 1 (operands=%+v)", len(got.Operands), got.Operands)
-	}
-	if got.Operands[0].Raw != "MIT" {
-		t.Errorf("operand[0].Raw = %q, want %q", got.Operands[0].Raw, "MIT")
-	}
-}
-
-func TestStripOuterParens(t *testing.T) {
-	tests := []struct {
-		name string
-		in   string
-		want string
-	}{
-		{name: "no_parens", in: "MIT", want: "MIT"},
-		{name: "balanced_outer", in: "(MIT)", want: "MIT"},
-		{name: "balanced_outer_with_inner", in: "(A OR (B AND C))", want: "A OR (B AND C)"},
-		{name: "non_outer_pair", in: "(A) OR (B)", want: "(A) OR (B)"},
-		{name: "unbalanced_extra_open", in: "((MIT)", want: "((MIT)"}, // depth never reaches 0 → unchanged
-		{name: "unbalanced_extra_close", in: "(MIT))", want: "(MIT))"},
-		{name: "double_wrap", in: "((MIT))", want: "(MIT)"}, // single pass; caller loops
-		{name: "empty_parens", in: "()", want: ""},
-		{name: "whitespace_inside", in: "(  MIT  )", want: "MIT"},
-		{name: "no_close", in: "(MIT", want: "(MIT"},
-		{name: "no_open", in: "MIT)", want: "MIT)"},
-		{name: "empty", in: "", want: ""},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := stripOuterParens(tt.in); got != tt.want {
-				t.Errorf("stripOuterParens(%q) = %q, want %q", tt.in, got, tt.want)
+			if l.Normalization.SPDX != tt.wantSPDX {
+				t.Errorf("SPDX = %v, want %v", l.Normalization.SPDX, tt.wantSPDX)
+			}
+			if l.OrLater != tt.wantOrLat {
+				t.Errorf("OrLater = %v, want %v", l.OrLater, tt.wantOrLat)
 			}
 		})
 	}
 }
 
-func TestFindTopLevelOperators(t *testing.T) {
+// TestParseExpression_TerminationGuards lock in non-amplification: a long
+// flat OR chain (1024 operands) and deeply nested parens (512 levels) must
+// both complete without panic. The cap test pins the strict-> comparison
+// against future "≥" regressions.
+func TestParseExpression_TerminationGuards(t *testing.T) {
+	t.Run("long_flat_chain", func(t *testing.T) {
+		const operandCount = 1024
+		parts := make([]string, operandCount)
+		for i := range parts {
+			parts[i] = "MIT"
+		}
+		root := ParseExpression(strings.Join(parts, " OR ")).Root
+		if root == nil || root.Compound == nil {
+			t.Fatalf("got %+v, want compound root", root)
+		}
+		if got := len(root.Compound.Operands); got != operandCount {
+			t.Errorf("operand count = %d, want %d", got, operandCount)
+		}
+	})
+
+	t.Run("deep_nested_parens", func(t *testing.T) {
+		const depth = 512
+		input := strings.Repeat("(", depth) + "MIT" + strings.Repeat(")", depth)
+		root := ParseExpression(input).Root
+		if root == nil || root.License == nil || root.License.Identifier != "MIT" {
+			t.Errorf("got %+v, want leaf(MIT)", root)
+		}
+	})
+
+	t.Run("input_at_cap_is_accepted", func(t *testing.T) {
+		input := "MIT" + strings.Repeat("X", maxExpressionLength-3)
+		got := ParseExpression(input)
+		if got.Root == nil {
+			t.Errorf("expected a non-nil root for input of length cap")
+		}
+	})
+}
+
+// TestExprNode_StringPanicsOnZeroValue verifies the invariant that a zero-
+// valued ExprNode (neither License nor Compound set) is treated as a
+// programmer error and surfaces immediately rather than silently producing
+// an empty string.
+func TestExprNode_StringPanicsOnZeroValue(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("expected panic on zero-valued ExprNode.String()")
+		}
+	}()
+	bad := &ExprNode{}
+	_ = bad.String()
+}
+
+// TestExprNode_StringPanicsOnNilOperand verifies that a Compound containing a
+// nil operand panics on render, locking the invariant that the AST shape is
+// uniformly enforced regardless of how a node was constructed (parser-built
+// or hand-built).
+func TestExprNode_StringPanicsOnNilOperand(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("expected panic on Compound with nil operand")
+		}
+	}()
+	leaf := &ExprNode{License: &ExprLicense{Identifier: "MIT"}}
+	bad := &ExprNode{Compound: &ExprCompound{Operator: "OR", Operands: []*ExprNode{leaf, nil}}}
+	_ = bad.String()
+}
+
+// TestLeaves_PanicsOnZeroValue mirrors TestExprNode_StringPanicsOnZeroValue
+// for the AST walk path; both readers must enforce the same invariant.
+func TestLeaves_PanicsOnZeroValue(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("expected panic on zero-valued ExprNode in Leaves()")
+		}
+	}()
+	r := ExpressionResult{Root: &ExprNode{}}
+	_ = r.Leaves()
+}
+
+// TestLeaves_PanicsOnNilOperand mirrors TestExprNode_StringPanicsOnNilOperand
+// for the walk path. Symmetry between the two reader entry points keeps the
+// AST contract uniformly enforced.
+func TestLeaves_PanicsOnNilOperand(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("expected panic on Compound with nil operand in Leaves()")
+		}
+	}()
+	leaf := &ExprNode{License: &ExprLicense{Identifier: "MIT"}}
+	r := ExpressionResult{Root: &ExprNode{Compound: &ExprCompound{Operator: "OR", Operands: []*ExprNode{leaf, nil}}}}
+	_ = r.Leaves()
+}
+
+// TestParseExpression_CompoundWithExceptionDistributes pins the documented
+// recovery for "(A OR B) WITH X" — SPDX-strict-grammar-illegal but real in
+// downstream data. The exception must propagate to every leaf so that
+// downstream legal-compliance consumers do not lose the legally significant
+// "WITH" clause.
+func TestParseExpression_CompoundWithExceptionDistributes(t *testing.T) {
 	tests := []struct {
-		name      string
-		in        string
-		wantCount int
+		name  string
+		input string
+		want  []leafSummary
 	}{
-		{name: "no_operators", in: "Apache-2.0", wantCount: 0},
-		{name: "one_top_level_or", in: "Apache-2.0 OR MIT", wantCount: 1},
-		{name: "two_top_level_or", in: "A OR B OR C", wantCount: 2},
-		{name: "operator_inside_parens_skipped", in: "A OR (B OR C)", wantCount: 1},
-		{name: "all_operators_inside_parens", in: "(B OR C)", wantCount: 0},
-		{name: "deeply_nested", in: "A OR ((B AND C) OR D)", wantCount: 1},
+		{
+			name:  "or_compound_distributes",
+			input: "(GPL-2.0-only OR Apache-2.0) WITH Classpath-exception-2.0",
+			want: []leafSummary{
+				{Raw: "GPL-2.0-only WITH Classpath-exception-2.0", Identifier: "GPL-2.0-only", Exception: "Classpath-exception-2.0"},
+				{Raw: "Apache-2.0 WITH Classpath-exception-2.0", Identifier: "Apache-2.0", Exception: "Classpath-exception-2.0"},
+			},
+		},
+		{
+			name:  "and_compound_distributes",
+			input: "(GPL-2.0-only AND Apache-2.0) WITH Classpath-exception-2.0",
+			want: []leafSummary{
+				{Raw: "GPL-2.0-only WITH Classpath-exception-2.0", Identifier: "GPL-2.0-only", Exception: "Classpath-exception-2.0"},
+				{Raw: "Apache-2.0 WITH Classpath-exception-2.0", Identifier: "Apache-2.0", Exception: "Classpath-exception-2.0"},
+			},
+		},
+		{
+			name:  "leaf_with_existing_exception_kept",
+			// The first leaf already has its own exception via the inner WITH;
+			// the outer WITH is distributed only to the second (bare) leaf.
+			input: "(MIT WITH Inner-Exception OR Apache-2.0) WITH Outer-Exception",
+			want: []leafSummary{
+				{Raw: "MIT WITH Inner-Exception", Identifier: "MIT", Exception: "Inner-Exception"},
+				{Raw: "Apache-2.0 WITH Outer-Exception", Identifier: "Apache-2.0", Exception: "Outer-Exception"},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := findTopLevelOperators(tt.in)
-			if len(got) != tt.wantCount {
-				t.Errorf("findTopLevelOperators(%q) returned %d operators, want %d (got=%v)", tt.in, len(got), tt.wantCount, got)
+			got := summarize(ParseExpression(tt.input))
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("\n got %#v\nwant %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestParseExpression_WithChain pins the truncation behavior for SPDX-illegal
+// chained WITH clauses ("A WITH B WITH C"). SPDX 2.1+ allows at most one
+// exception per simple-expression; we accept the first and silently truncate
+// subsequent WITH tokens. Documents the choice via test rather than letting a
+// future refactor accidentally change it.
+func TestParseExpression_WithChain(t *testing.T) {
+	got := summarize(ParseExpression("Apache-2.0 WITH Foo WITH Bar"))
+	want := []leafSummary{{
+		Raw: "Apache-2.0 WITH Foo", Identifier: "Apache-2.0", Exception: "Foo",
+	}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("\n got %#v\nwant %#v", got, want)
+	}
+}
+
+// TestParseExpression_PlusEdgeCases pins handling of "+" placement variants:
+// only an exact trailing-single-"+" attached to a non-empty base triggers
+// OrLater. Bare "+" and "++" do NOT set OrLater — they are passed verbatim
+// to the SPDX normalizer, whose alias-key collapsing may still resolve some
+// to a canonical ID, but that is the table's call, not the parser's.
+func TestParseExpression_PlusEdgeCases(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantOrLater bool
+	}{
+		{name: "single_trailing_plus_sets_or_later", input: "Apache-2.0+", wantOrLater: true},
+		{name: "double_plus_does_not_set_or_later", input: "Apache-2.0++", wantOrLater: false},
+		{name: "bare_plus_does_not_set_or_later", input: "+", wantOrLater: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			leaves := ParseExpression(tt.input).Leaves()
+			if len(leaves) != 1 {
+				t.Fatalf("expected 1 leaf, got %d", len(leaves))
+			}
+			if leaves[0].OrLater != tt.wantOrLater {
+				t.Errorf("OrLater = %v, want %v (raw=%q)", leaves[0].OrLater, tt.wantOrLater, leaves[0].Raw)
+			}
+		})
+	}
+}
+
+// TestParseExpression_PlusWithCombined pins the combined +/WITH form, which
+// is the natural SPDX way to express "Apache-2.0 or any later version, with
+// the Classpath exception".
+func TestParseExpression_PlusWithCombined(t *testing.T) {
+	got := summarize(ParseExpression("Apache-2.0+ WITH Classpath-exception-2.0"))
+	want := []leafSummary{{
+		Raw:        "Apache-2.0+ WITH Classpath-exception-2.0",
+		Identifier: "Apache-2.0",
+		OrLater:    true,
+		Exception:  "Classpath-exception-2.0",
+	}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("\n got %#v\nwant %#v", got, want)
+	}
+	// Round-trip via String() must preserve both flags.
+	rendered := ParseExpression("Apache-2.0+ WITH Classpath-exception-2.0").Root.String()
+	if rendered != "Apache-2.0+ WITH Classpath-exception-2.0" {
+		t.Errorf("String() = %q, want exact preservation", rendered)
+	}
+}
+
+// TestParseExpression_FreeTextAdjacentOperators verifies the tokenizer's
+// adjacent-IDENT-merge behavior: a multi-word license name like "Apache
+// License 2.0" stays as one IDENT even when followed by an operator and a
+// second license. Also pins the inverse case ("Apache OR Tools") where two
+// non-SPDX words happen to flank an OR keyword and should split.
+func TestParseExpression_FreeTextAdjacentOperators(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []leafSummary
+	}{
+		{
+			name:  "free_text_alias_then_or_then_spdx",
+			input: "Apache License 2.0 OR MIT",
+			want: []leafSummary{
+				{Raw: "Apache License 2.0", Identifier: "Apache-2.0"},
+				{Raw: "MIT", Identifier: "MIT"},
+			},
+		},
+		{
+			name:  "two_words_split_by_or",
+			input: "Apache OR Tools",
+			want: []leafSummary{
+				{Raw: "Apache", Identifier: ""},
+				{Raw: "Tools", Identifier: ""},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := summarize(ParseExpression(tt.input))
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("\n got %#v\nwant %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestParseExpression_UnbalancedParens pins the asymmetric handling of
+// unbalanced parens. v2 is more permissive than v1 because the recursive-
+// descent parser tolerates both unmatched open and unmatched close, but the
+// behavior is still asymmetric and worth locking in.
+func TestParseExpression_UnbalancedParens(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []string // expected Leaves() Identifier sequence
+	}{
+		{name: "open_only", input: "(MIT OR Apache-2.0", want: []string{"MIT", "Apache-2.0"}},
+		{name: "close_only", input: "MIT OR Apache-2.0)", want: []string{"MIT", "Apache-2.0"}},
+		{name: "mixed", input: "(MIT) OR (Apache-2.0)", want: []string{"MIT", "Apache-2.0"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			leaves := ParseExpression(tt.input).Leaves()
+			got := make([]string, 0, len(leaves))
+			for _, l := range leaves {
+				got = append(got, l.Identifier)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("got %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/internal/domain/licenses/expression_test.go
+++ b/internal/domain/licenses/expression_test.go
@@ -2,6 +2,7 @@ package licenses
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -57,6 +58,18 @@ func TestParseExpression(t *testing.T) {
 		{
 			name:        "and_mixed_case",
 			input:       "MIT And Apache-2.0",
+			wantRaws:    []string{"MIT", "Apache-2.0"},
+			wantSPDXIDs: []string{"MIT", "Apache-2.0"},
+		},
+		{
+			name:        "and_lowercase",
+			input:       "MIT and Apache-2.0",
+			wantRaws:    []string{"MIT", "Apache-2.0"},
+			wantSPDXIDs: []string{"MIT", "Apache-2.0"},
+		},
+		{
+			name:        "multiple_spaces_around_operator",
+			input:       "MIT   OR   Apache-2.0",
 			wantRaws:    []string{"MIT", "Apache-2.0"},
 			wantSPDXIDs: []string{"MIT", "Apache-2.0"},
 		},
@@ -123,7 +136,9 @@ func TestParseExpression(t *testing.T) {
 			wantSPDXIDs: []string{"Apache-2.0"},
 		},
 		{
-			name:        "consecutive_operators_skip_empty_segments",
+			// The first " OR " is the matched operator; the residual "OR MIT"
+			// segment then has its leading "OR " stripped by trimEdgeOperators.
+			name:        "operator_after_split_is_trimmed_as_edge",
 			input:       "Apache-2.0 OR OR MIT",
 			wantRaws:    []string{"Apache-2.0", "MIT"},
 			wantSPDXIDs: []string{"Apache-2.0", "MIT"},
@@ -152,6 +167,56 @@ func TestParseExpression(t *testing.T) {
 			wantRaws:    []string{"MIT", "Apache-2.0", "BSD-3-Clause"},
 			wantSPDXIDs: []string{"MIT", "Apache-2.0", "BSD-3-Clause"},
 		},
+		{
+			// Asymmetric handling pinned: open-only paren keeps the prefix
+			// attached because no top-level OR/AND can match at depth 0.
+			// Acceptable for v1; reconsider if real-world data shows demand.
+			name:        "unbalanced_open_paren_collapses_to_one_operand",
+			input:       "(MIT OR Apache-2.0",
+			wantRaws:    []string{"(MIT OR Apache-2.0"},
+			wantSPDXIDs: []string{""},
+		},
+		{
+			// Asymmetric handling pinned: close-only paren is treated as part
+			// of the trailing operand because depth never goes positive.
+			name:        "unbalanced_close_paren_kept_on_trailing_operand",
+			input:       "MIT OR Apache-2.0)",
+			wantRaws:    []string{"MIT", "Apache-2.0)"},
+			wantSPDXIDs: []string{"MIT", ""},
+		},
+		{
+			// Defensive: hyphenated identifiers starting with OR-/AND- must
+			// not be stripped by trimEdgeOperators. SPDX has no current entry
+			// like this, but a future custom alias could.
+			name:        "or_prefixed_identifier_not_stripped",
+			input:       "OR-tools",
+			wantRaws:    []string{"OR-tools"},
+			wantSPDXIDs: []string{""},
+		},
+		{
+			name:        "and_prefixed_identifier_not_stripped",
+			input:       "AND-license",
+			wantRaws:    []string{"AND-license"},
+			wantSPDXIDs: []string{""},
+		},
+		{
+			// Pathological input over the length cap returns no operands so
+			// recursion / regex passes cannot be amplified.
+			name:        "oversized_input_yields_no_operands",
+			input:       strings.Repeat("X", maxExpressionLength+1),
+			wantRaws:    nil,
+			wantSPDXIDs: nil,
+		},
+		{
+			// Boundary: input of exactly maxExpressionLength must still parse.
+			// Pads "MIT" to the cap so the parser produces a single operand
+			// (heuristic, non-SPDX) rather than tripping the guard. Locks in
+			// the strict ">" comparison against future "≥" regressions.
+			name:        "input_at_cap_is_accepted",
+			input:       "MIT" + strings.Repeat("X", maxExpressionLength-3),
+			wantRaws:    []string{"MIT" + strings.Repeat("X", maxExpressionLength-3)},
+			wantSPDXIDs: []string{""},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -179,13 +244,65 @@ func TestParseExpression(t *testing.T) {
 	}
 }
 
-func TestParseExpression_NoassertionMatchType(t *testing.T) {
-	got := ParseExpression("NOASSERTION")
-	if len(got.Operands) != 1 {
-		t.Fatalf("expected 1 operand, got %d", len(got.Operands))
+func TestParseExpression_OperandMatchType(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantTypes []LicenseMatchType
+	}{
+		{name: "noassertion", input: "NOASSERTION", wantTypes: []LicenseMatchType{MatchNoAssertion}},
+		{name: "exact_canonical", input: "Apache-2.0", wantTypes: []LicenseMatchType{MatchCanonicalExact}},
+		{name: "casefold_canonical", input: "apache-2.0", wantTypes: []LicenseMatchType{MatchCanonicalCaseFold}},
+		{name: "alias_full_name", input: "Apache License 2.0", wantTypes: []LicenseMatchType{MatchAlias}},
+		{name: "heuristic_unknown_with_clause", input: "GPL-2.0-only WITH Classpath-exception-2.0", wantTypes: []LicenseMatchType{MatchHeuristic}},
+		{name: "compound_mixed_match_types", input: "Apache-2.0 OR Apache License 2.0", wantTypes: []LicenseMatchType{MatchCanonicalExact, MatchAlias}},
 	}
-	if got.Operands[0].Normalization.MatchType != MatchNoAssertion {
-		t.Errorf("MatchType = %v, want MatchNoAssertion", got.Operands[0].Normalization.MatchType)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParseExpression(tt.input)
+			if len(got.Operands) != len(tt.wantTypes) {
+				t.Fatalf("operand count = %d, want %d (operands=%+v)", len(got.Operands), len(tt.wantTypes), got.Operands)
+			}
+			for i, want := range tt.wantTypes {
+				if got.Operands[i].Normalization.MatchType != want {
+					t.Errorf("operand[%d].MatchType = %v, want %v", i, got.Operands[i].Normalization.MatchType, want)
+				}
+			}
+		})
+	}
+}
+
+// TestParseExpression_LongChainTerminates locks in that a long flat OR chain
+// completes without panic and yields the expected operand count. Recursion
+// depth on a flat chain is shallow (operators are found in a single pass),
+// so this guards regex-pass work and operand accumulation rather than stack
+// growth from nesting.
+func TestParseExpression_LongChainTerminates(t *testing.T) {
+	const operandCount = 1024
+	parts := make([]string, operandCount)
+	for i := range parts {
+		parts[i] = "MIT"
+	}
+	got := ParseExpression(strings.Join(parts, " OR "))
+	if len(got.Operands) != operandCount {
+		t.Fatalf("operand count = %d, want %d", len(got.Operands), operandCount)
+	}
+}
+
+// TestParseExpression_DeepNestingTerminates drives the iterative paren-strip
+// loop inside splitFlatten with deeply nested but well-formed input. Each
+// loop pass peels one paren pair until the inner identifier is exposed; no
+// top-level operators are present, so this complements the flat-chain test
+// (which exercises operator-found recursion) rather than duplicating it.
+func TestParseExpression_DeepNestingTerminates(t *testing.T) {
+	const depth = 512
+	input := strings.Repeat("(", depth) + "MIT" + strings.Repeat(")", depth)
+	got := ParseExpression(input)
+	if len(got.Operands) != 1 {
+		t.Fatalf("operand count = %d, want 1 (operands=%+v)", len(got.Operands), got.Operands)
+	}
+	if got.Operands[0].Raw != "MIT" {
+		t.Errorf("operand[0].Raw = %q, want %q", got.Operands[0].Raw, "MIT")
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds a new domain-layer SPDX license expression parser at `internal/domain/licenses/expression.go`. **v2 redesign** preserves operator semantics (AND/OR/WITH/+) as a true AST, not a flat operand list — required for SBOM (CycloneDX/SPDX) round-trip output and legal-compliance use cases. Critical-path follow-up to PR #345 (Maven POM fallback) and a hard blocker for #354 (ClearlyDefined.io integration), which sees compound expressions in ~30% of `licensed.declared` responses.

## Public API

```go
type ExpressionResult struct { Raw string; Root *ExprNode }

type ExprNode struct { License *ExprLicense; Compound *ExprCompound }

type ExprLicense struct {
    Raw           string
    Identifier    string             // canonical SPDX, "" if non-SPDX
    Normalization NormalizationResult
    OrLater       bool               // "+" suffix
    Exception     string             // verbatim WITH operand
}

type ExprCompound struct { Operator string; Operands []*ExprNode }

func ParseExpression(raw string) ExpressionResult
func (n *ExprNode) String() string                  // canonical SPDX round-trip
func (r ExpressionResult) Leaves() []*ExprLicense   // flat enumeration
```

## Grammar (SPDX 2.3 precedence: WITH > AND > OR)

```
expression = and_expr (OR and_expr)*
and_expr   = with_expr (AND with_expr)*
with_expr  = primary (WITH ident)?
primary    = ident ['+'] | '(' expression ')'
```

Same-operator chains flatten ("A OR B OR C" and "A OR (B OR C)" both produce one Compound with three children — set-equivalent in legal terms, matches SPDX renderer convention).

## Examples

| Input | AST shape | `String()` |
|---|---|---|
| `Apache-2.0` | leaf | `Apache-2.0` |
| `Apache License 2.0` | leaf (alias→canonical) | `Apache-2.0` |
| `Apache-2.0 OR MIT` | Compound{OR, [A, M]} | `Apache-2.0 OR MIT` |
| `Apache-2.0 OR MIT AND BSD-3-Clause` | Compound{OR, [A, Compound{AND, [M, B]}]} | `Apache-2.0 OR (MIT AND BSD-3-Clause)` |
| `(Apache-2.0 OR MIT) AND BSD-3-Clause` | Compound{AND, [Compound{OR, [A, M]}, B]} | `(Apache-2.0 OR MIT) AND BSD-3-Clause` |
| `Apache-2.0+ WITH Classpath-exception-2.0` | leaf{OrLater, Exception} | `Apache-2.0+ WITH Classpath-exception-2.0` |
| `(GPL-2.0-only OR Apache-2.0) WITH Classpath-exception-2.0` | distributes exception to each leaf | `GPL-2.0-only WITH Classpath-exception-2.0 OR Apache-2.0 WITH Classpath-exception-2.0` |
| `EPL-1.0 OR (LGPL-2.1 OR LGPL-3.0)` | Compound{OR, [3 leaves]} | `EPL-1.0 OR LGPL-2.1 OR LGPL-3.0` |

## Robustness

- Empty / whitespace-only / oversized (>64KB) input → `Root` is nil
- Stray edge operators (`OR Apache-2.0`, `Apache-2.0 OR`, `OR OR MIT`) silently dropped per v1 contract
- `Compound` with fewer than 2 children collapses to single child or nil — never emits degenerate compound
- `(A OR B) WITH X` — SPDX-strict-illegal but real in Maven / ClearlyDefined data — distributes the exception to every leaf so the legally-significant clause is not lost
- Unbalanced parens tolerated; parser never returns errors

## Programmer-error invariants

`ExprNode.String()` and `ExpressionResult.Leaves()` panic on:
- Zero-valued `ExprNode` (neither License nor Compound)
- `nil` operand inside a `Compound`

These shapes can only arise from hand-built ASTs; the parser itself never produces them. Surfacing them as panics catches misuse at the first render rather than silently producing malformed SPDX text.

## Idempotence

`ParseExpression(s).Root.String()` is a fixed point under re-parsing:
re-parsing the rendered string and rendering again produces the same text (verified by `TestExprNode_StringIdempotent`). This is the contract SBOM serialization callers depend on.

## Test plan

- [x] AST shape: leaf, mixed-operator precedence, paren grouping, flattening
- [x] Round-trip idempotence on canonical and edge-case inputs
- [x] NOASSERTION / alias / casefold / heuristic / exact MatchType coverage
- [x] WITH chain truncation pinned (`A WITH B WITH C` → first only)
- [x] `(Compound) WITH X` distributes exception; pre-existing inner exception preserved
- [x] `+` placement: trailing single → OrLater; bare / `++` → not recognized
- [x] Combined +/WITH preserves both flags through round-trip
- [x] Free-text license name with adjacent operator (`Apache License 2.0 OR MIT`) splits correctly
- [x] Hyphenated identifiers (`OR-tools`, `AND-license`) not split
- [x] Length cap boundary (input == cap accepted; cap+1 rejected)
- [x] Deep nesting (512 paren levels) and long flat chains (1024 operands) terminate
- [x] Panic invariants for zero-valued and nil-operand nodes (in both `String()` and `Leaves()`)
- [x] Asymmetric unbalanced-paren handling pinned
- [x] `go vet`, `golangci-lint` clean; `go test ./...` clean under `-race`

Refs #327, refs #351 (this PR lands the parser primitive only; the per-operand `ResolvedLicense` emission and Maven POM dispatcher first-SPDX promotion that #351 ultimately requires are deferred to a follow-up wiring PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
