### PR TITLE
feat(httpclient): honor Retry-After on HTTP 429 responses (#352)

### DIFF
--- a/.claude/rules/copilot-learned-coding.md
+++ b/.claude/rules/copilot-learned-coding.md
@@ -115,6 +115,11 @@ pending_patterns:
     file: "internal/infrastructure/treesitter/analyzer.go"
     date: "2026-04-29"
   - category: "testing"
+    summary: "When generating time-based test fixtures with coarse-grained formatters (e.g., http.TimeFormat at 1-second granularity), truncate to the format boundary and add enough offset (e.g., 2s) so the formatted value is deterministically in the expected range — sub-granularity offsets (50ms) can collapse to the current or past second"
+    pr: 359
+    file: "internal/infrastructure/httpclient/client_test.go"
+    date: "2026-04-29"
+  - category: "testing"
     summary: "Assert diagnostic context fields on typed error structs (e.g., ScorecardError.Context) in tests — checking only error type and call count misses regressions that silently strip diagnostic metadata"
     pr: 359
     file: "internal/infrastructure/httpclient/client_test.go"

--- a/.claude/rules/copilot-learned-coding.md
+++ b/.claude/rules/copilot-learned-coding.md
@@ -99,6 +99,11 @@ pending_patterns:
     pr: 140
     file: "internal/infrastructure/depparser/detect.go"
     date: "2026-04-05"
+  - category: "comment-doc-drift"
+    summary: "RetryConfig doc comment claimed DoWithRetryFunc could opt out of 429 retries via retryDecider, but 429 retry is hardcoded and retryDecider is not consulted — fix comment to match actual behavior"
+    pr: 359
+    file: "internal/infrastructure/httpclient/client.go"
+    date: "2026-04-29"
   - category: "defensive-coding"
     summary: "Guard time.Duration arithmetic against integer overflow when converting parsed delay-seconds — use strconv.ParseInt and reject values exceeding math.MaxInt64/time.Second before multiplying"
     pr: 359
@@ -113,6 +118,11 @@ pending_patterns:
     summary: "Assert diagnostic context fields on typed error structs (e.g., ScorecardError.Context) in tests — checking only error type and call count misses regressions that silently strip diagnostic metadata"
     pr: 359
     file: "internal/infrastructure/httpclient/client_test.go"
+    date: "2026-04-29"
+  - category: "defensive-coding"
+    summary: "Cap response body reads with io.LimitReader in retry paths (429/5xx) to prevent unbounded memory and log growth across retry attempts — consistent with existing codebase pattern for HTTP body reads"
+    pr: 359
+    file: "internal/infrastructure/httpclient/client.go"
     date: "2026-04-29"
   - category: "defensive-coding"
     summary: "Use time.NewTimer + Stop/drain instead of time.After in select with ctx.Done() to prevent timer accumulation during long cancellable waits"

--- a/.claude/rules/copilot-learned-coding.md
+++ b/.claude/rules/copilot-learned-coding.md
@@ -99,10 +99,20 @@ pending_patterns:
     pr: 140
     file: "internal/infrastructure/depparser/detect.go"
     date: "2026-04-05"
+  - category: "defensive-coding"
+    summary: "Guard time.Duration arithmetic against integer overflow when converting parsed delay-seconds — use strconv.ParseInt and reject values exceeding math.MaxInt64/time.Second before multiplying"
+    pr: 359
+    file: "internal/infrastructure/httpclient/client.go"
+    date: "2026-04-29"
   - category: "logging-consistency"
     summary: "Pass typed error values (e.g., *QueryError) directly to slog instead of pre-stringifying via .Error() — preserves type/structure and keeps logging consistent with slog conventions"
     pr: 346
     file: "internal/infrastructure/treesitter/analyzer.go"
+    date: "2026-04-29"
+  - category: "defensive-coding"
+    summary: "Use time.NewTimer + Stop/drain instead of time.After in select with ctx.Done() to prevent timer accumulation during long cancellable waits"
+    pr: 359
+    file: "internal/infrastructure/httpclient/client.go"
     date: "2026-04-29"
   - category: "api-consistency"
     summary: "Redundant gh pr view API call to fetch labels when pr_json from repos/.../pulls already contains label data — reuse already-fetched API response data instead of making redundant calls for a subset of the same information"

--- a/.claude/rules/copilot-learned-coding.md
+++ b/.claude/rules/copilot-learned-coding.md
@@ -100,12 +100,12 @@ pending_patterns:
     file: "internal/infrastructure/depparser/detect.go"
     date: "2026-04-05"
   - category: "comment-doc-drift"
-    summary: "RetryConfig doc comment claimed DoWithRetryFunc could opt out of 429 retries via retryDecider, but 429 retry is hardcoded and retryDecider is not consulted — fix comment to match actual behavior"
+    summary: "Doc comments must match implementation boundary conditions — RetryConfig said retryDecider controls 429 retries (it doesn't); rateLimitBackoff comment said 'negative' for a zero-inclusive guard (should say 'non-positive')"
     pr: 359
     file: "internal/infrastructure/httpclient/client.go"
     date: "2026-04-29"
   - category: "defensive-coding"
-    summary: "Guard time.Duration arithmetic against integer overflow when converting parsed delay-seconds — use strconv.ParseInt and reject values exceeding math.MaxInt64/time.Second before multiplying"
+    summary: "Guard time.Duration arithmetic against integer overflow — use strconv.ParseInt, reject values exceeding math.MaxInt64/time.Second, and do not clamp to an arbitrary policy constant (let the caller's configured cap decide)"
     pr: 359
     file: "internal/infrastructure/httpclient/client.go"
     date: "2026-04-29"
@@ -120,7 +120,7 @@ pending_patterns:
     file: "internal/infrastructure/httpclient/client_test.go"
     date: "2026-04-29"
   - category: "testing"
-    summary: "Assert diagnostic context fields on typed error structs (e.g., ScorecardError.Context) in tests — checking only error type and call count misses regressions that silently strip diagnostic metadata"
+    summary: "Assert diagnostic context fields on typed error structs; match context-error assertions to the specific context constructor (WithCancel → Canceled only, WithTimeout → DeadlineExceeded only) — permissive OR hides misrouted error paths"
     pr: 359
     file: "internal/infrastructure/httpclient/client_test.go"
     date: "2026-04-29"

--- a/.claude/rules/copilot-learned-coding.md
+++ b/.claude/rules/copilot-learned-coding.md
@@ -109,6 +109,11 @@ pending_patterns:
     pr: 346
     file: "internal/infrastructure/treesitter/analyzer.go"
     date: "2026-04-29"
+  - category: "testing"
+    summary: "Assert diagnostic context fields on typed error structs (e.g., ScorecardError.Context) in tests — checking only error type and call count misses regressions that silently strip diagnostic metadata"
+    pr: 359
+    file: "internal/infrastructure/httpclient/client_test.go"
+    date: "2026-04-29"
   - category: "defensive-coding"
     summary: "Use time.NewTimer + Stop/drain instead of time.After in select with ctx.Done() to prevent timer accumulation during long cancellable waits"
     pr: 359

--- a/.github/instructions/copilot-learned-coding.instructions.md
+++ b/.github/instructions/copilot-learned-coding.instructions.md
@@ -97,6 +97,11 @@ pending_patterns:
     pr: 140
     file: "internal/infrastructure/depparser/detect.go"
     date: "2026-04-05"
+  - category: "comment-doc-drift"
+    summary: "RetryConfig doc comment claimed DoWithRetryFunc could opt out of 429 retries via retryDecider, but 429 retry is hardcoded and retryDecider is not consulted — fix comment to match actual behavior"
+    pr: 359
+    file: "internal/infrastructure/httpclient/client.go"
+    date: "2026-04-29"
   - category: "defensive-coding"
     summary: "Guard time.Duration arithmetic against integer overflow when converting parsed delay-seconds — use strconv.ParseInt and reject values exceeding math.MaxInt64/time.Second before multiplying"
     pr: 359
@@ -111,6 +116,11 @@ pending_patterns:
     summary: "Assert diagnostic context fields on typed error structs (e.g., ScorecardError.Context) in tests — checking only error type and call count misses regressions that silently strip diagnostic metadata"
     pr: 359
     file: "internal/infrastructure/httpclient/client_test.go"
+    date: "2026-04-29"
+  - category: "defensive-coding"
+    summary: "Cap response body reads with io.LimitReader in retry paths (429/5xx) to prevent unbounded memory and log growth across retry attempts — consistent with existing codebase pattern for HTTP body reads"
+    pr: 359
+    file: "internal/infrastructure/httpclient/client.go"
     date: "2026-04-29"
   - category: "defensive-coding"
     summary: "Use time.NewTimer + Stop/drain instead of time.After in select with ctx.Done() to prevent timer accumulation during long cancellable waits"

--- a/.github/instructions/copilot-learned-coding.instructions.md
+++ b/.github/instructions/copilot-learned-coding.instructions.md
@@ -113,6 +113,11 @@ pending_patterns:
     file: "internal/infrastructure/treesitter/analyzer.go"
     date: "2026-04-29"
   - category: "testing"
+    summary: "When generating time-based test fixtures with coarse-grained formatters (e.g., http.TimeFormat at 1-second granularity), truncate to the format boundary and add enough offset (e.g., 2s) so the formatted value is deterministically in the expected range — sub-granularity offsets (50ms) can collapse to the current or past second"
+    pr: 359
+    file: "internal/infrastructure/httpclient/client_test.go"
+    date: "2026-04-29"
+  - category: "testing"
     summary: "Assert diagnostic context fields on typed error structs (e.g., ScorecardError.Context) in tests — checking only error type and call count misses regressions that silently strip diagnostic metadata"
     pr: 359
     file: "internal/infrastructure/httpclient/client_test.go"

--- a/.github/instructions/copilot-learned-coding.instructions.md
+++ b/.github/instructions/copilot-learned-coding.instructions.md
@@ -98,12 +98,12 @@ pending_patterns:
     file: "internal/infrastructure/depparser/detect.go"
     date: "2026-04-05"
   - category: "comment-doc-drift"
-    summary: "RetryConfig doc comment claimed DoWithRetryFunc could opt out of 429 retries via retryDecider, but 429 retry is hardcoded and retryDecider is not consulted — fix comment to match actual behavior"
+    summary: "Doc comments must match implementation boundary conditions — RetryConfig said retryDecider controls 429 retries (it doesn't); rateLimitBackoff comment said 'negative' for a zero-inclusive guard (should say 'non-positive')"
     pr: 359
     file: "internal/infrastructure/httpclient/client.go"
     date: "2026-04-29"
   - category: "defensive-coding"
-    summary: "Guard time.Duration arithmetic against integer overflow when converting parsed delay-seconds — use strconv.ParseInt and reject values exceeding math.MaxInt64/time.Second before multiplying"
+    summary: "Guard time.Duration arithmetic against integer overflow — use strconv.ParseInt, reject values exceeding math.MaxInt64/time.Second, and do not clamp to an arbitrary policy constant (let the caller's configured cap decide)"
     pr: 359
     file: "internal/infrastructure/httpclient/client.go"
     date: "2026-04-29"
@@ -118,7 +118,7 @@ pending_patterns:
     file: "internal/infrastructure/httpclient/client_test.go"
     date: "2026-04-29"
   - category: "testing"
-    summary: "Assert diagnostic context fields on typed error structs (e.g., ScorecardError.Context) in tests — checking only error type and call count misses regressions that silently strip diagnostic metadata"
+    summary: "Assert diagnostic context fields on typed error structs; match context-error assertions to the specific context constructor (WithCancel → Canceled only, WithTimeout → DeadlineExceeded only) — permissive OR hides misrouted error paths"
     pr: 359
     file: "internal/infrastructure/httpclient/client_test.go"
     date: "2026-04-29"

--- a/.github/instructions/copilot-learned-coding.instructions.md
+++ b/.github/instructions/copilot-learned-coding.instructions.md
@@ -97,10 +97,20 @@ pending_patterns:
     pr: 140
     file: "internal/infrastructure/depparser/detect.go"
     date: "2026-04-05"
+  - category: "defensive-coding"
+    summary: "Guard time.Duration arithmetic against integer overflow when converting parsed delay-seconds — use strconv.ParseInt and reject values exceeding math.MaxInt64/time.Second before multiplying"
+    pr: 359
+    file: "internal/infrastructure/httpclient/client.go"
+    date: "2026-04-29"
   - category: "logging-consistency"
     summary: "Pass typed error values (e.g., *QueryError) directly to slog instead of pre-stringifying via .Error() — preserves type/structure and keeps logging consistent with slog conventions"
     pr: 346
     file: "internal/infrastructure/treesitter/analyzer.go"
+    date: "2026-04-29"
+  - category: "defensive-coding"
+    summary: "Use time.NewTimer + Stop/drain instead of time.After in select with ctx.Done() to prevent timer accumulation during long cancellable waits"
+    pr: 359
+    file: "internal/infrastructure/httpclient/client.go"
     date: "2026-04-29"
   - category: "api-consistency"
     summary: "Redundant gh pr view API call to fetch labels when pr_json from repos/.../pulls already contains label data — reuse already-fetched API response data instead of making redundant calls for a subset of the same information"

--- a/.github/instructions/copilot-learned-coding.instructions.md
+++ b/.github/instructions/copilot-learned-coding.instructions.md
@@ -107,6 +107,11 @@ pending_patterns:
     pr: 346
     file: "internal/infrastructure/treesitter/analyzer.go"
     date: "2026-04-29"
+  - category: "testing"
+    summary: "Assert diagnostic context fields on typed error structs (e.g., ScorecardError.Context) in tests — checking only error type and call count misses regressions that silently strip diagnostic metadata"
+    pr: 359
+    file: "internal/infrastructure/httpclient/client_test.go"
+    date: "2026-04-29"
   - category: "defensive-coding"
     summary: "Use time.NewTimer + Stop/drain instead of time.After in select with ctx.Done() to prevent timer accumulation during long cancellable waits"
     pr: 359

--- a/internal/infrastructure/httpclient/client.go
+++ b/internal/infrastructure/httpclient/client.go
@@ -222,15 +222,15 @@ func (c *Client) calculateBackoff(attempt int) time.Duration { // exponential ba
 // Honors the server's Retry-After header (per RFC 9110 §10.2.3) according to
 // the following precedence:
 //
-//  1. Header parses to a past HTTP-date (negative duration) → return 0
-//     ("retry immediately"); do not fall through to exponential backoff.
+//  1. Header parses to a past or present HTTP-date (non-positive duration) →
+//     return 0 ("retry immediately"); do not fall through to exponential backoff.
 //  2. Header parses and the resulting duration fits within MaxBackoff →
 //     return the exact duration.
 //  3. Header is missing, unparseable, or its duration exceeds MaxBackoff →
 //     fall back to the same exponential backoff used for 5xx retries.
 func (c *Client) rateLimitBackoff(retryAfter string, attempt int) time.Duration {
 	if d, ok := parseRetryAfter(retryAfter, time.Now()); ok {
-		if d < 0 {
+		if d <= 0 {
 			return 0
 		}
 		if d <= c.config.MaxBackoff {
@@ -246,11 +246,10 @@ func (c *Client) rateLimitBackoff(retryAfter string, attempt int) time.Duration 
 // enough for diagnostic messages without risking large HTML error pages.
 const maxErrorBodyBytes = 64 << 10
 
-// maxRetryAfterSeconds caps a server-supplied delay-seconds value so that
-// pathological inputs (e.g., a header like "999999999999") cannot overflow
-// the time.Duration multiplication and produce a negative or absurd wait.
-// One day is well past any realistic rate-limit window.
-const maxRetryAfterSeconds = 24 * 60 * 60
+// maxSafeSeconds is the largest delay-seconds value whose multiplication by
+// time.Second will not overflow time.Duration (int64 nanoseconds). Values
+// beyond this are rejected so the caller falls back to exponential backoff.
+const maxSafeSeconds = math.MaxInt64 / int64(time.Second)
 
 // parseRetryAfter parses an RFC 9110 Retry-After header value. The header
 // can be either a delay-seconds integer (e.g., "30") or an HTTP-date. Returns
@@ -258,9 +257,10 @@ const maxRetryAfterSeconds = 24 * 60 * 60
 // (0, false). The "now" parameter is injected so tests can pin time.
 //
 // Per RFC, delay-seconds must be a non-negative integer; values exceeding
-// maxRetryAfterSeconds are clamped to that cap to avoid overflow on absurd
-// inputs. HTTP-date in the past resolves to a non-positive duration which
-// the caller should treat as "retry immediately".
+// maxSafeSeconds (the time.Duration overflow boundary) are rejected so the
+// caller falls back to exponential backoff. HTTP-date in the past resolves
+// to a non-positive duration which the caller should treat as "retry
+// immediately".
 func parseRetryAfter(header string, now time.Time) (time.Duration, bool) {
 	s := strings.TrimSpace(header)
 	if s == "" {
@@ -270,8 +270,8 @@ func parseRetryAfter(header string, now time.Time) (time.Duration, bool) {
 		if secs < 0 {
 			return 0, false
 		}
-		if secs > maxRetryAfterSeconds {
-			secs = maxRetryAfterSeconds
+		if secs > maxSafeSeconds {
+			return 0, false
 		}
 		return time.Duration(secs) * time.Second, true
 	}

--- a/internal/infrastructure/httpclient/client.go
+++ b/internal/infrastructure/httpclient/client.go
@@ -16,6 +16,12 @@ import (
 
 // RetryConfig defines retry configuration.
 // NOTE: Moved from pkg/httpclient (now internal) to avoid exposing infrastructure concerns publicly.
+//
+// 429 Too Many Requests responses are always retried up to MaxRetries —
+// independently of RetryOn5xx — because rate-limiting is a transient condition
+// and the server's Retry-After header carries the only timing signal we have.
+// Callers that need 429 to fail fast must construct their own retry policy via
+// DoWithRetryFunc.
 type RetryConfig struct {
 	MaxRetries        int           // Maximum number of retries
 	BaseBackoff       time.Duration // Base backoff time
@@ -213,27 +219,42 @@ func (c *Client) calculateBackoff(attempt int) time.Duration { // exponential ba
 }
 
 // rateLimitBackoff returns the wait duration before retrying a 429 response.
-// Honors the server's Retry-After header (per RFC 9110 §10.2.3) when present
-// and within the configured MaxBackoff cap; otherwise falls back to the same
-// exponential backoff used for 5xx retries.
+// Honors the server's Retry-After header (per RFC 9110 §10.2.3) according to
+// the following precedence:
+//
+//  1. Header parses to a past HTTP-date (negative duration) → return 0
+//     ("retry immediately"); do not fall through to exponential backoff.
+//  2. Header parses and the resulting duration fits within MaxBackoff →
+//     return the exact duration.
+//  3. Header is missing, unparseable, or its duration exceeds MaxBackoff →
+//     fall back to the same exponential backoff used for 5xx retries.
 func (c *Client) rateLimitBackoff(retryAfter string, attempt int) time.Duration {
-	if d, ok := parseRetryAfter(retryAfter, time.Now()); ok && d <= c.config.MaxBackoff {
+	if d, ok := parseRetryAfter(retryAfter, time.Now()); ok {
 		if d < 0 {
 			return 0
 		}
-		return d
+		if d <= c.config.MaxBackoff {
+			return d
+		}
 	}
 	return c.calculateBackoff(attempt)
 }
+
+// maxRetryAfterSeconds caps a server-supplied delay-seconds value so that
+// pathological inputs (e.g., a header like "999999999999") cannot overflow
+// the time.Duration multiplication and produce a negative or absurd wait.
+// One day is well past any realistic rate-limit window.
+const maxRetryAfterSeconds = 24 * 60 * 60
 
 // parseRetryAfter parses an RFC 9110 Retry-After header value. The header
 // can be either a delay-seconds integer (e.g., "30") or an HTTP-date. Returns
 // the resolved duration and true when the header was parseable, otherwise
 // (0, false). The "now" parameter is injected so tests can pin time.
 //
-// Per RFC, delay-seconds must be a non-negative integer; HTTP-date in the
-// past resolves to a non-positive duration which the caller should treat as
-// "retry immediately".
+// Per RFC, delay-seconds must be a non-negative integer; values exceeding
+// maxRetryAfterSeconds are clamped to that cap to avoid overflow on absurd
+// inputs. HTTP-date in the past resolves to a non-positive duration which
+// the caller should treat as "retry immediately".
 func parseRetryAfter(header string, now time.Time) (time.Duration, bool) {
 	s := strings.TrimSpace(header)
 	if s == "" {
@@ -243,11 +264,8 @@ func parseRetryAfter(header string, now time.Time) (time.Duration, bool) {
 		if secs < 0 {
 			return 0, false
 		}
-		// Guard against duration overflow: time.Duration is int64 nanoseconds,
-		// so max representable seconds is math.MaxInt64 / 1e9 ≈ 9.2e9 (~292 years).
-		const maxSafeSeconds = int64(math.MaxInt64 / int64(time.Second))
-		if secs > maxSafeSeconds {
-			return 0, false
+		if secs > maxRetryAfterSeconds {
+			secs = maxRetryAfterSeconds
 		}
 		return time.Duration(secs) * time.Second, true
 	}

--- a/internal/infrastructure/httpclient/client.go
+++ b/internal/infrastructure/httpclient/client.go
@@ -7,6 +7,8 @@ import (
 	"log/slog"
 	"math"
 	"net/http"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/future-architect/uzomuzo-oss/internal/common"
@@ -133,8 +135,33 @@ func (c *Client) DoWithRetryFunc(ctx context.Context, req *http.Request, retryDe
 
 		if resp.StatusCode == http.StatusTooManyRequests { // rate limit
 			body, _ := io.ReadAll(resp.Body)
+			retryAfter := resp.Header.Get("Retry-After")
 			_ = resp.Body.Close() // best-effort cleanup
-			return nil, common.NewRateLimitError("rate limit reached", nil).WithContext("request_url", req.URL.String()).WithContext("response_body", string(body)).WithContext("status_code", resp.StatusCode)
+			if attempt < c.config.MaxRetries {
+				wait := c.rateLimitBackoff(retryAfter, attempt)
+				slog.Warn("rate limit reached, retrying",
+					"status_code", resp.StatusCode,
+					"attempt", attempt+1,
+					"max_attempts", c.config.MaxRetries+1,
+					"retry_after_header", retryAfter,
+					"wait", wait,
+					"response_body", string(body))
+				select {
+				case <-ctx.Done():
+					if ctx.Err() == context.DeadlineExceeded {
+						return nil, common.NewTimeoutError("request timeout during rate limit retry", ctx.Err()).WithContext("request_url", req.URL.String())
+					}
+					return nil, ctx.Err()
+				case <-time.After(wait):
+					continue
+				}
+			}
+			return nil, common.NewRateLimitError("rate limit reached", nil).
+				WithContext("request_url", req.URL.String()).
+				WithContext("response_body", string(body)).
+				WithContext("status_code", resp.StatusCode).
+				WithContext("retry_after_header", retryAfter).
+				WithContext("max_attempts", c.config.MaxRetries+1)
 		}
 
 		if resp.StatusCode < 500 {
@@ -176,4 +203,43 @@ func (c *Client) calculateBackoff(attempt int) time.Duration { // exponential ba
 		backoff = c.config.MaxBackoff
 	}
 	return backoff
+}
+
+// rateLimitBackoff returns the wait duration before retrying a 429 response.
+// Honors the server's Retry-After header (per RFC 9110 §10.2.3) when present
+// and within the configured MaxBackoff cap; otherwise falls back to the same
+// exponential backoff used for 5xx retries.
+func (c *Client) rateLimitBackoff(retryAfter string, attempt int) time.Duration {
+	if d, ok := parseRetryAfter(retryAfter, time.Now()); ok && d <= c.config.MaxBackoff {
+		if d < 0 {
+			return 0
+		}
+		return d
+	}
+	return c.calculateBackoff(attempt)
+}
+
+// parseRetryAfter parses an RFC 9110 Retry-After header value. The header
+// can be either a delay-seconds integer (e.g., "30") or an HTTP-date. Returns
+// the resolved duration and true when the header was parseable, otherwise
+// (0, false). The "now" parameter is injected so tests can pin time.
+//
+// Per RFC, delay-seconds must be a non-negative integer; HTTP-date in the
+// past resolves to a non-positive duration which the caller should treat as
+// "retry immediately".
+func parseRetryAfter(header string, now time.Time) (time.Duration, bool) {
+	s := strings.TrimSpace(header)
+	if s == "" {
+		return 0, false
+	}
+	if secs, err := strconv.Atoi(s); err == nil {
+		if secs < 0 {
+			return 0, false
+		}
+		return time.Duration(secs) * time.Second, true
+	}
+	if t, err := http.ParseTime(s); err == nil {
+		return t.Sub(now), true
+	}
+	return 0, false
 }

--- a/internal/infrastructure/httpclient/client.go
+++ b/internal/infrastructure/httpclient/client.go
@@ -146,13 +146,20 @@ func (c *Client) DoWithRetryFunc(ctx context.Context, req *http.Request, retryDe
 					"retry_after_header", retryAfter,
 					"wait", wait,
 					"response_body", string(body))
+				timer := time.NewTimer(wait)
 				select {
 				case <-ctx.Done():
+					if !timer.Stop() {
+						select {
+						case <-timer.C:
+						default:
+						}
+					}
 					if ctx.Err() == context.DeadlineExceeded {
 						return nil, common.NewTimeoutError("request timeout during rate limit retry", ctx.Err()).WithContext("request_url", req.URL.String())
 					}
 					return nil, ctx.Err()
-				case <-time.After(wait):
+				case <-timer.C:
 					continue
 				}
 			}
@@ -232,8 +239,14 @@ func parseRetryAfter(header string, now time.Time) (time.Duration, bool) {
 	if s == "" {
 		return 0, false
 	}
-	if secs, err := strconv.Atoi(s); err == nil {
+	if secs, err := strconv.ParseInt(s, 10, 64); err == nil {
 		if secs < 0 {
+			return 0, false
+		}
+		// Guard against duration overflow: time.Duration is int64 nanoseconds,
+		// so max representable seconds is math.MaxInt64 / 1e9 ≈ 9.2e9 (~292 years).
+		const maxSafeSeconds = int64(math.MaxInt64 / int64(time.Second))
+		if secs > maxSafeSeconds {
 			return 0, false
 		}
 		return time.Duration(secs) * time.Second, true

--- a/internal/infrastructure/httpclient/client.go
+++ b/internal/infrastructure/httpclient/client.go
@@ -222,8 +222,9 @@ func (c *Client) calculateBackoff(attempt int) time.Duration { // exponential ba
 // Honors the server's Retry-After header (per RFC 9110 §10.2.3) according to
 // the following precedence:
 //
-//  1. Header parses to a past or present HTTP-date (non-positive duration) →
-//     return 0 ("retry immediately"); do not fall through to exponential backoff.
+//  1. Header parses to a non-positive duration (for example, a past or present
+//     HTTP-date or delay-seconds=0) → return 0 ("retry immediately"); do not
+//     fall through to exponential backoff.
 //  2. Header parses and the resulting duration fits within MaxBackoff →
 //     return the exact duration.
 //  3. Header is missing, unparseable, or its duration exceeds MaxBackoff →

--- a/internal/infrastructure/httpclient/client.go
+++ b/internal/infrastructure/httpclient/client.go
@@ -20,8 +20,8 @@ import (
 // 429 Too Many Requests responses are always retried up to MaxRetries —
 // independently of RetryOn5xx — because rate-limiting is a transient condition
 // and the server's Retry-After header carries the only timing signal we have.
-// Callers that need 429 to fail fast must construct their own retry policy via
-// DoWithRetryFunc.
+// This behavior is built into the retrying client, including DoWithRetryFunc, so
+// callers that need 429 to fail fast must set MaxRetries to 0 or bypass this client.
 type RetryConfig struct {
 	MaxRetries        int           // Maximum number of retries
 	BaseBackoff       time.Duration // Base backoff time
@@ -140,7 +140,7 @@ func (c *Client) DoWithRetryFunc(ctx context.Context, req *http.Request, retryDe
 		} // success
 
 		if resp.StatusCode == http.StatusTooManyRequests { // rate limit
-			body, _ := io.ReadAll(resp.Body)
+			body, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodyBytes))
 			retryAfter := resp.Header.Get("Retry-After")
 			_ = resp.Body.Close() // best-effort cleanup
 			if attempt < c.config.MaxRetries {
@@ -182,7 +182,7 @@ func (c *Client) DoWithRetryFunc(ctx context.Context, req *http.Request, retryDe
 		} // non-retryable 4xx
 
 		if resp.StatusCode >= 500 && c.config.RetryOn5xx { // server error retry
-			body, _ := io.ReadAll(resp.Body)
+			body, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodyBytes))
 			_ = resp.Body.Close() // best-effort cleanup
 			if attempt < c.config.MaxRetries {
 				backoff := c.calculateBackoff(attempt)
@@ -239,6 +239,12 @@ func (c *Client) rateLimitBackoff(retryAfter string, attempt int) time.Duration 
 	}
 	return c.calculateBackoff(attempt)
 }
+
+// maxErrorBodyBytes caps how much of a 429/5xx response body we read and
+// log/attach to errors. Rate-limited responses are retried, so an uncapped
+// read would accumulate memory and log volume across attempts. 64 KiB is
+// enough for diagnostic messages without risking large HTML error pages.
+const maxErrorBodyBytes = 64 << 10
 
 // maxRetryAfterSeconds caps a server-supplied delay-seconds value so that
 // pathological inputs (e.g., a header like "999999999999") cannot overflow

--- a/internal/infrastructure/httpclient/client_test.go
+++ b/internal/infrastructure/httpclient/client_test.go
@@ -54,41 +54,41 @@ func TestRateLimitBackoff(t *testing.T) {
 		MaxBackoff:  500 * time.Millisecond,
 	})
 	tests := []struct {
-		name       string
-		header     string
-		attempt    int
-		wantBetwen [2]time.Duration // inclusive bounds
+		name        string
+		header      string
+		attempt     int
+		wantBetween [2]time.Duration // inclusive bounds
 	}{
 		{
-			name:       "header_within_cap_used_directly",
-			header:     "0", // 0 seconds — well within cap
-			attempt:    0,
-			wantBetwen: [2]time.Duration{0, 0},
+			name:        "header_within_cap_used_directly",
+			header:      "0", // 0 seconds — well within cap
+			attempt:     0,
+			wantBetween: [2]time.Duration{0, 0},
 		},
 		{
-			name:       "header_exceeds_cap_falls_back_to_exponential",
-			header:     "9999", // far beyond MaxBackoff
-			attempt:    0,
-			wantBetwen: [2]time.Duration{10 * time.Millisecond, 10 * time.Millisecond},
+			name:        "header_exceeds_cap_falls_back_to_exponential",
+			header:      "9999", // far beyond MaxBackoff
+			attempt:     0,
+			wantBetween: [2]time.Duration{10 * time.Millisecond, 10 * time.Millisecond},
 		},
 		{
-			name:       "no_header_uses_exponential",
-			header:     "",
-			attempt:    1,
-			wantBetwen: [2]time.Duration{20 * time.Millisecond, 20 * time.Millisecond},
+			name:        "no_header_uses_exponential",
+			header:      "",
+			attempt:     1,
+			wantBetween: [2]time.Duration{20 * time.Millisecond, 20 * time.Millisecond},
 		},
 		{
-			name:       "invalid_header_uses_exponential",
-			header:     "bogus",
-			attempt:    2,
-			wantBetwen: [2]time.Duration{40 * time.Millisecond, 40 * time.Millisecond},
+			name:        "invalid_header_uses_exponential",
+			header:      "bogus",
+			attempt:     2,
+			wantBetween: [2]time.Duration{40 * time.Millisecond, 40 * time.Millisecond},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := c.rateLimitBackoff(tt.header, tt.attempt)
-			if got < tt.wantBetwen[0] || got > tt.wantBetwen[1] {
-				t.Errorf("rateLimitBackoff(%q, %d) = %v, want in [%v, %v]", tt.header, tt.attempt, got, tt.wantBetwen[0], tt.wantBetwen[1])
+			if got < tt.wantBetween[0] || got > tt.wantBetween[1] {
+				t.Errorf("rateLimitBackoff(%q, %d) = %v, want in [%v, %v]", tt.header, tt.attempt, got, tt.wantBetween[0], tt.wantBetween[1])
 			}
 		})
 	}

--- a/internal/infrastructure/httpclient/client_test.go
+++ b/internal/infrastructure/httpclient/client_test.go
@@ -1,0 +1,248 @@
+package httpclient
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/future-architect/uzomuzo-oss/internal/common"
+)
+
+func TestParseRetryAfter(t *testing.T) {
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name        string
+		header      string
+		wantOK      bool
+		wantSeconds float64 // approximate; HTTP-date paths may have rounding
+	}{
+		{name: "empty", header: "", wantOK: false},
+		{name: "whitespace", header: "   ", wantOK: false},
+		{name: "delay_seconds_30", header: "30", wantOK: true, wantSeconds: 30},
+		{name: "delay_seconds_zero", header: "0", wantOK: true, wantSeconds: 0},
+		{name: "delay_seconds_with_padding", header: "  30  ", wantOK: true, wantSeconds: 30},
+		{name: "delay_seconds_negative_rejected", header: "-1", wantOK: false},
+		{name: "delay_seconds_invalid_text", header: "soon", wantOK: false},
+		{name: "http_date_imf_fixdate_future", header: "Wed, 29 Apr 2026 12:00:30 GMT", wantOK: true, wantSeconds: 30},
+		{name: "http_date_imf_fixdate_past_negative", header: "Wed, 29 Apr 2026 11:59:30 GMT", wantOK: true, wantSeconds: -30},
+		{name: "http_date_invalid_format", header: "not a date", wantOK: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := parseRetryAfter(tt.header, now)
+			if ok != tt.wantOK {
+				t.Fatalf("parseRetryAfter(%q) ok = %v, want %v (got=%v)", tt.header, ok, tt.wantOK, got)
+			}
+			if !tt.wantOK {
+				return
+			}
+			if delta := got.Seconds() - tt.wantSeconds; delta < -1 || delta > 1 {
+				t.Errorf("parseRetryAfter(%q) = %v, want approximately %vs", tt.header, got, tt.wantSeconds)
+			}
+		})
+	}
+}
+
+func TestRateLimitBackoff(t *testing.T) {
+	c := NewClient(nil, RetryConfig{
+		MaxRetries:  3,
+		BaseBackoff: 10 * time.Millisecond,
+		MaxBackoff:  500 * time.Millisecond,
+	})
+	tests := []struct {
+		name       string
+		header     string
+		attempt    int
+		wantBetwen [2]time.Duration // inclusive bounds
+	}{
+		{
+			name:       "header_within_cap_used_directly",
+			header:     "0", // 0 seconds — well within cap
+			attempt:    0,
+			wantBetwen: [2]time.Duration{0, 0},
+		},
+		{
+			name:       "header_exceeds_cap_falls_back_to_exponential",
+			header:     "9999", // far beyond MaxBackoff
+			attempt:    0,
+			wantBetwen: [2]time.Duration{10 * time.Millisecond, 10 * time.Millisecond},
+		},
+		{
+			name:       "no_header_uses_exponential",
+			header:     "",
+			attempt:    1,
+			wantBetwen: [2]time.Duration{20 * time.Millisecond, 20 * time.Millisecond},
+		},
+		{
+			name:       "invalid_header_uses_exponential",
+			header:     "bogus",
+			attempt:    2,
+			wantBetwen: [2]time.Duration{40 * time.Millisecond, 40 * time.Millisecond},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := c.rateLimitBackoff(tt.header, tt.attempt)
+			if got < tt.wantBetwen[0] || got > tt.wantBetwen[1] {
+				t.Errorf("rateLimitBackoff(%q, %d) = %v, want in [%v, %v]", tt.header, tt.attempt, got, tt.wantBetwen[0], tt.wantBetwen[1])
+			}
+		})
+	}
+}
+
+// TestDo_RateLimitRetriesThenSucceeds verifies that a 429 response with a
+// short Retry-After header triggers a retry, and a subsequent 200 ends the
+// loop.
+func TestDo_RateLimitRetriesThenSucceeds(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&calls, 1)
+		if n == 1 {
+			w.Header().Set("Retry-After", "0")
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte("slow down"))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	t.Cleanup(srv.Close)
+
+	c := NewClient(nil, RetryConfig{
+		MaxRetries:  3,
+		BaseBackoff: 1 * time.Millisecond,
+		MaxBackoff:  100 * time.Millisecond,
+	})
+	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	resp, err := c.Do(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Do returned error: %v", err)
+	}
+	t.Cleanup(func() { _ = resp.Body.Close() })
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Errorf("server call count = %d, want 2 (one rate-limited, one success)", got)
+	}
+}
+
+// TestDo_RateLimitRetriesExhaustedReturnsRateLimitError verifies that when a
+// server keeps returning 429 past MaxRetries, the client returns a RateLimit
+// error tagged with the Retry-After header for diagnostics.
+func TestDo_RateLimitRetriesExhaustedReturnsRateLimitError(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.Header().Set("Retry-After", "0")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	t.Cleanup(srv.Close)
+
+	c := NewClient(nil, RetryConfig{
+		MaxRetries:  2,
+		BaseBackoff: 1 * time.Millisecond,
+		MaxBackoff:  10 * time.Millisecond,
+	})
+	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	resp, err := c.Do(context.Background(), req)
+	if err == nil {
+		_ = resp.Body.Close()
+		t.Fatal("Do returned nil error, want RateLimitError")
+	}
+	var sErr *common.ScorecardError
+	if !errors.As(err, &sErr) || sErr.Type != common.ErrorTypeRateLimit {
+		t.Fatalf("err type = %T %v, want RateLimitError", err, err)
+	}
+	wantCalls := int32(c.config.MaxRetries + 1)
+	if got := atomic.LoadInt32(&calls); got != wantCalls {
+		t.Errorf("server call count = %d, want %d", got, wantCalls)
+	}
+}
+
+// TestDo_RateLimitContextCancellationDuringWait verifies that ctx cancellation
+// while sleeping for a Retry-After window terminates the retry loop promptly.
+func TestDo_RateLimitContextCancellationDuringWait(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "60") // long enough to outlast the test
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	t.Cleanup(srv.Close)
+
+	c := NewClient(nil, RetryConfig{
+		MaxRetries:  3,
+		BaseBackoff: 1 * time.Millisecond,
+		MaxBackoff:  120 * time.Second, // accept the 60s header so we sleep, not back off
+	})
+	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	resp, err := c.Do(ctx, req)
+	if err == nil {
+		_ = resp.Body.Close()
+		t.Fatal("Do returned nil error, want context.Canceled")
+	}
+	if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("err = %v, want context-derived error", err)
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Errorf("Do took %v after cancel; expected prompt return", elapsed)
+	}
+}
+
+// TestDo_RateLimitNoHeaderUsesBackoff verifies that a 429 response without a
+// Retry-After header still retries (using the configured exponential backoff).
+func TestDo_RateLimitNoHeaderUsesBackoff(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&calls, 1)
+		if n == 1 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	c := NewClient(nil, RetryConfig{
+		MaxRetries:  3,
+		BaseBackoff: 1 * time.Millisecond,
+		MaxBackoff:  10 * time.Millisecond,
+	})
+	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	resp, err := c.Do(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Do error: %v", err)
+	}
+	t.Cleanup(func() { _ = resp.Body.Close() })
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Errorf("server call count = %d, want 2", got)
+	}
+}

--- a/internal/infrastructure/httpclient/client_test.go
+++ b/internal/infrastructure/httpclient/client_test.go
@@ -235,17 +235,18 @@ func TestDo_RateLimitContextCancellationDuringWait(t *testing.T) {
 }
 
 // TestDo_RateLimitHTTPDateHeader verifies the end-to-end HTTP-date branch:
-// the server emits Retry-After as an IMF-fixdate, the client computes a
-// duration via time.Sub, and the retry succeeds.
+// the server emits Retry-After as an IMF-fixdate, the client parses it,
+// computes a non-positive wait via time.Sub, and the retry succeeds
+// without incurring a real wall-clock sleep.
 func TestDo_RateLimitHTTPDateHeader(t *testing.T) {
 	var calls int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		n := atomic.AddInt32(&calls, 1)
 		if n == 1 {
-			// http.TimeFormat has 1-second granularity, so construct a timestamp
-			// on a whole-second boundary and move it far enough into the future
-			// that formatting cannot collapse it back to the current second.
-			retryAt := time.Now().UTC().Truncate(time.Second).Add(2 * time.Second)
+			// Use a valid HTTP-date that is already in the past so this test
+			// still exercises the HTTP-date parsing branch end-to-end without
+			// slowing the test suite with a real sleep.
+			retryAt := time.Now().UTC().Add(-1 * time.Second)
 			w.Header().Set("Retry-After", retryAt.Format(http.TimeFormat))
 			w.WriteHeader(http.StatusTooManyRequests)
 			return
@@ -257,7 +258,7 @@ func TestDo_RateLimitHTTPDateHeader(t *testing.T) {
 	c := NewClient(nil, RetryConfig{
 		MaxRetries:  3,
 		BaseBackoff: 1 * time.Millisecond,
-		MaxBackoff:  5 * time.Second, // generous so the HTTP-date is honored
+		MaxBackoff:  5 * time.Second,
 	})
 	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
 	if err != nil {

--- a/internal/infrastructure/httpclient/client_test.go
+++ b/internal/infrastructure/httpclient/client_test.go
@@ -168,6 +168,28 @@ func TestDo_RateLimitRetriesExhaustedReturnsRateLimitError(t *testing.T) {
 	if !errors.As(err, &sErr) || sErr.Type != common.ErrorTypeRateLimit {
 		t.Fatalf("err type = %T %v, want RateLimitError", err, err)
 	}
+
+	// Assert diagnostic context fields are present so regressions that strip
+	// them are caught (Copilot review feedback).
+	wantCtx := map[string]interface{}{
+		"retry_after_header": "0",
+		"max_attempts":       c.config.MaxRetries + 1,
+		"status_code":        http.StatusTooManyRequests,
+	}
+	for k, want := range wantCtx {
+		got, ok := sErr.Context[k]
+		if !ok {
+			t.Errorf("ScorecardError.Context missing key %q", k)
+			continue
+		}
+		if got != want {
+			t.Errorf("ScorecardError.Context[%q] = %v (%T), want %v (%T)", k, got, got, want, want)
+		}
+	}
+	if _, ok := sErr.Context["request_url"]; !ok {
+		t.Error("ScorecardError.Context missing key \"request_url\"")
+	}
+
 	wantCalls := int32(c.config.MaxRetries + 1)
 	if got := atomic.LoadInt32(&calls); got != wantCalls {
 		t.Errorf("server call count = %d, want %d", got, wantCalls)

--- a/internal/infrastructure/httpclient/client_test.go
+++ b/internal/infrastructure/httpclient/client_test.go
@@ -27,7 +27,7 @@ func TestParseRetryAfter(t *testing.T) {
 		{name: "delay_seconds_with_padding", header: "  30  ", wantOK: true, wantSeconds: 30},
 		{name: "delay_seconds_negative_rejected", header: "-1", wantOK: false},
 		{name: "delay_seconds_invalid_text", header: "soon", wantOK: false},
-		{name: "delay_seconds_overflow_clamped", header: "999999999999", wantOK: true, wantSeconds: maxRetryAfterSeconds},
+		{name: "delay_seconds_overflow_rejected", header: "999999999999999999", wantOK: false},
 		{name: "http_date_imf_fixdate_future", header: "Wed, 29 Apr 2026 12:00:30 GMT", wantOK: true, wantSeconds: 30},
 		{name: "http_date_imf_fixdate_past_negative", header: "Wed, 29 Apr 2026 11:59:30 GMT", wantOK: true, wantSeconds: -30},
 		{name: "http_date_invalid_format", header: "not a date", wantOK: false},
@@ -226,8 +226,8 @@ func TestDo_RateLimitContextCancellationDuringWait(t *testing.T) {
 		_ = resp.Body.Close()
 		t.Fatal("Do returned nil error, want context.Canceled")
 	}
-	if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
-		t.Errorf("err = %v, want context-derived error", err)
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("err = %v, want %v", err, context.Canceled)
 	}
 	if elapsed := time.Since(start); elapsed > 5*time.Second {
 		t.Errorf("Do took %v after cancel; expected prompt return", elapsed)

--- a/internal/infrastructure/httpclient/client_test.go
+++ b/internal/infrastructure/httpclient/client_test.go
@@ -27,6 +27,7 @@ func TestParseRetryAfter(t *testing.T) {
 		{name: "delay_seconds_with_padding", header: "  30  ", wantOK: true, wantSeconds: 30},
 		{name: "delay_seconds_negative_rejected", header: "-1", wantOK: false},
 		{name: "delay_seconds_invalid_text", header: "soon", wantOK: false},
+		{name: "delay_seconds_overflow_clamped", header: "999999999999", wantOK: true, wantSeconds: maxRetryAfterSeconds},
 		{name: "http_date_imf_fixdate_future", header: "Wed, 29 Apr 2026 12:00:30 GMT", wantOK: true, wantSeconds: 30},
 		{name: "http_date_imf_fixdate_past_negative", header: "Wed, 29 Apr 2026 11:59:30 GMT", wantOK: true, wantSeconds: -30},
 		{name: "http_date_invalid_format", header: "not a date", wantOK: false},
@@ -208,6 +209,79 @@ func TestDo_RateLimitContextCancellationDuringWait(t *testing.T) {
 	}
 	if elapsed := time.Since(start); elapsed > 5*time.Second {
 		t.Errorf("Do took %v after cancel; expected prompt return", elapsed)
+	}
+}
+
+// TestDo_RateLimitHTTPDateHeader verifies the end-to-end HTTP-date branch:
+// the server emits Retry-After as an IMF-fixdate, the client computes a
+// duration via time.Sub, and the retry succeeds.
+func TestDo_RateLimitHTTPDateHeader(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&calls, 1)
+		if n == 1 {
+			// 50ms in the future — short enough to keep the test fast,
+			// long enough to be unambiguously a future date.
+			w.Header().Set("Retry-After", time.Now().Add(50*time.Millisecond).UTC().Format(http.TimeFormat))
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	c := NewClient(nil, RetryConfig{
+		MaxRetries:  3,
+		BaseBackoff: 1 * time.Millisecond,
+		MaxBackoff:  5 * time.Second, // generous so the HTTP-date is honored
+	})
+	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	resp, err := c.Do(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Do error: %v", err)
+	}
+	t.Cleanup(func() { _ = resp.Body.Close() })
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Errorf("server call count = %d, want 2", got)
+	}
+}
+
+// TestDo_RateLimitDeadlineExceededDuringWait covers the DeadlineExceeded
+// branch in the retry loop, which wraps ctx.Err into a TimeoutError. Pairs
+// with TestDo_RateLimitContextCancellationDuringWait (Canceled branch).
+func TestDo_RateLimitDeadlineExceededDuringWait(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "60")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	t.Cleanup(srv.Close)
+
+	c := NewClient(nil, RetryConfig{
+		MaxRetries:  3,
+		BaseBackoff: 1 * time.Millisecond,
+		MaxBackoff:  120 * time.Second,
+	})
+	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+
+	resp, err := c.Do(ctx, req)
+	if err == nil {
+		_ = resp.Body.Close()
+		t.Fatal("Do returned nil error, want TimeoutError")
+	}
+	var sErr *common.ScorecardError
+	if !errors.As(err, &sErr) || sErr.Type != common.ErrorTypeTimeout {
+		t.Fatalf("err type = %v %v, want TimeoutError", err, err)
 	}
 }
 

--- a/internal/infrastructure/httpclient/client_test.go
+++ b/internal/infrastructure/httpclient/client_test.go
@@ -242,9 +242,11 @@ func TestDo_RateLimitHTTPDateHeader(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		n := atomic.AddInt32(&calls, 1)
 		if n == 1 {
-			// 50ms in the future — short enough to keep the test fast,
-			// long enough to be unambiguously a future date.
-			w.Header().Set("Retry-After", time.Now().Add(50*time.Millisecond).UTC().Format(http.TimeFormat))
+			// http.TimeFormat has 1-second granularity, so construct a timestamp
+			// on a whole-second boundary and move it far enough into the future
+			// that formatting cannot collapse it back to the current second.
+			retryAt := time.Now().UTC().Truncate(time.Second).Add(2 * time.Second)
+			w.Header().Set("Retry-After", retryAt.Format(http.TimeFormat))
 			w.WriteHeader(http.StatusTooManyRequests)
 			return
 		}


### PR DESCRIPTION
## Summary

- The shared `httpclient` previously failed fast on HTTP 429 with no retry, no `Retry-After` honor, no backoff. PR #345 (Maven POM fallback) added a new caller of Maven Central, where CDN-layer rate limits make this a sharper edge; #354 (ClearlyDefined.io) adds another caller of the same shared client.
- This PR adds RFC 9110 §10.2.3 `Retry-After` parsing (delay-seconds and HTTP-date), retries 429 up to `MaxRetries` honoring the header within `MaxBackoff`, falls back to the existing exponential backoff when no header / out-of-cap, and respects `ctx.Done()` during waits.
- On retry exhaustion, the existing `RateLimitError` is still returned (with additional context for triage). API contract is unchanged.

## Behavior matrix

| State | Behavior before | Behavior after |
|---|---|---|
| 429 with `Retry-After: 30` (within cap) | fail fast | sleep 30s, retry |
| 429 with `Retry-After: 9999` (over cap) | fail fast | exponential backoff, retry |
| 429 with no header | fail fast | exponential backoff, retry |
| 429 with invalid header | fail fast | exponential backoff, retry |
| Exhausted `MaxRetries` of 429 | RateLimitError | RateLimitError (same type, more context) |
| `ctx.Done()` during 429 wait | n/a | prompt return with ctx error |

## Test plan

- [x] `parseRetryAfter` unit cases: empty, whitespace, delay-seconds (0/30/padded/negative-rejected/invalid-text), HTTP-date future/past/invalid
- [x] `rateLimitBackoff` cap behavior: header-within-cap, header-over-cap, no-header, invalid-header
- [x] End-to-end via `httptest`: 429-then-200 retry success, exhaustion returning `RateLimitError`, ctx cancellation during the long-wait window, no-header fallback to exponential backoff
- [x] `go vet` clean, `golangci-lint run ./internal/infrastructure/httpclient/...` 0 issues
- [x] Full project `go test ./...` clean

Refs #327, closes #352.

🤖 Generated with [Claude Code](https://claude.com/claude-code)