### PR TITLE
ci: cron-poll @claude trigger fallback + GraphQL union:false stuck-detector bypass

### DIFF
--- a/.claude/rules/agents.md
+++ b/.claude/rules/agents.md
@@ -52,6 +52,19 @@ Reviewer agent findings (including CRITICAL severity) are **discussion input**, 
 
 **Why:** Reviewer agents see only code, not the design intent behind it. In PR #123, a reviewer flagged "transitive advisories not shown on RequestedVersion" as CRITICAL, but this was an intentional decision (see ADR-0011). Blindly implementing the "fix" re-introduced a bug the user had already reported and resolved.
 
+### Workflow-File PRs Are Resolved Locally, Not by CI Claude
+
+PRs whose changes touch `.github/workflows/**` MUST be fixed locally by a human-driven Claude session, not by the auto-fix loop in `copilot-review-fix.yml`.
+
+**Why:** The auto-fix PAT (`GH_ACTIONS_TOKEN`) intentionally lacks the `workflow` scope. Workflow files define CI runtime permissions and secret access — granting a bot the ability to rewrite them creates a privilege-escalation surface (prompt-injection or misbehaviour can self-modify the bot's own runtime). Defense-in-depth: keep PAT scope minimal; pay the small operational cost of manual intervention on workflow PRs.
+
+**How to apply:**
+- When CI Claude reports "PAT lacks `workflow` scope" on a workflow-file thread, do NOT propose granting the scope. Pull the branch locally, apply the fix, push.
+- The marker dedup in `copilot-review-fix.yml` invalidates on push (HEAD SHA changes), so a manual push cleanly re-arms the auto-fix loop for the next round.
+- If the same Copilot finding loops indefinitely on a non-workflow PR, that's a different bug — investigate the auto-fix loop, do NOT relax PAT scope.
+
+**Symptom of the broken case (for debugging):** trigger-claude job runs `success` but logs `trigger already posted for HEAD <sha> (count=1) — skip` because a prior Claude run posted the marker but couldn't push the actual fix.
+
 ## Worktree Isolation Policy
 
 Agents that **write files** (Edit, Write) MUST be launched with `isolation: "worktree"` to prevent branch conflicts during parallel development. This gives each agent an isolated copy of the repository.

--- a/.claude/rules/copilot-learned-coding.md
+++ b/.claude/rules/copilot-learned-coding.md
@@ -22,6 +22,7 @@ Rules extracted from recurring Copilot review patterns on coding-standards topic
 - **Interface Contract Documentation Must Match Signature Semantics**: When documenting an interface method, the doc comment must accurately reflect the method's full signature — including error returns, nil semantics, and parameter constraints. If the signature returns `(T, error)`, do not document it as "returns nil/empty on failure" — state that errors may be returned and describe the caller's expected handling (e.g., non-fatal/graceful degradation). Mismatched contract documentation misleads implementers and callers.
 - **GitHub Actions `||` Treats Empty as Falsy**: When a workflow input documents "empty = X behavior", do not use `${{ inputs.foo || 'default' }}` — the `||` operator treats empty string as falsy and applies the default, preventing users from intentionally selecting the empty option. Instead, pass the raw input via an env var and apply defaults conditionally (e.g., only for scheduled triggers).
 - **Guard Downstream Jobs Against Missing Outputs**: When a CI job produces outputs that downstream jobs depend on (exit codes, flags), gate downstream jobs on `needs.<job>.outputs.<key> != ''` to prevent execution when the upstream job fails before setting outputs. Otherwise, empty values may be misinterpreted (e.g., empty exit code `""` compared with `!= "0"` evaluates to true, creating misleading reports).
+- **Use Quoted Heredocs for Literal Text in CI Workflows**: When constructing multi-line literal text bodies in CI workflow scripts (e.g., comment bodies, PR descriptions), use quoted heredoc delimiters (`<<'DELIM'`) to prevent accidental parameter expansion and command substitution. Inject dynamic values (markers, timestamps) via append after the heredoc rather than embedding them inside an expansion-enabled body.
 - **CI Job Gating — Key on Outputs, Not Job Result**: When a CI job intentionally exits non-zero for a primary use case (e.g., policy violations), downstream jobs must not gate on `needs.<job>.result == 'success'`. Use explicit output variables (exit codes, flags) to control downstream behavior, so jobs run in the scenarios they are designed for.
 - **Remove Dead Configuration Inputs**: When a configuration surface (CLI flag, workflow input, env var) is no longer honored by the implementation (e.g., hardcoded internally), remove it entirely rather than leaving a misleading interface. A visible input that silently does nothing is worse than no input at all.
 - **CI Permissions Documentation — Verify Inheritance**: When documenting GitHub Actions job permissions, verify each job's actual `permissions:` block in the workflow file. Jobs without an explicit `permissions:` key inherit the workflow-level permissions — do not describe them as having "no permissions" or "no extra permissions". State what each job actually has, including inherited defaults.
@@ -30,6 +31,7 @@ Rules extracted from recurring Copilot review patterns on coding-standards topic
 - **Deterministic Output from Non-Deterministic Sources**: When building ordered output from non-deterministic sources (Go map iteration, goroutine-collected results, API directory listings), sort the data before further processing. This applies to rendered text, BFS seed queues, and any "first-seen wins" algorithm where input order determines provenance.
 - **Post-Filter Fuzzy Search Results**: When using search APIs that perform fuzzy or word-level matching (e.g., GitHub issue search), add a post-filter to verify exact matches before acting on results. Fuzzy matches can cause false-positive deduplication or incorrect state transitions.
 - **Rerun Analyzers with Combined Input Sets on Retry**: When retrying a subset of inputs through an analyzer that tracks collisions or shared matches, rerun with the combined input set (original + retry) to preserve attribution consistency. Subset reruns can misattribute shared matches to the wrong source.
+- **Guard Resource Bounds in HTTP Client Retry Logic**: When implementing retry/backoff logic for HTTP clients: (1) guard `time.Duration` arithmetic against integer overflow — use `strconv.ParseInt` and reject values exceeding `math.MaxInt64/time.Second` rather than clamping to an arbitrary policy constant; (2) cap response body reads with `io.LimitReader` in retry paths (429/5xx) to prevent unbounded memory and log growth across retry attempts; (3) use `time.NewTimer` + `Stop`/drain instead of `time.After` in `select` with `ctx.Done()` to prevent timer accumulation during long cancellable waits.
 - **Consolidate Detection Heuristics — Single Source of Truth**: When a detection heuristic (file type sniffing, format detection, path matching) is used in multiple locations, centralize it in the responsible package and have callers delegate. Duplicating the heuristic across layers (e.g., `cmd/` and `infrastructure/`) risks drift when one copy is updated but the other is not.
 - **Use Correct GitHub API Media Types**: When calling GitHub REST APIs, use the documented `Accept` header for the desired response format. For raw file content use `application/vnd.github.raw` (not `application/vnd.github.raw+json`). Incorrect media types may cause silent content-negotiation failures or unexpected response formats. Refer to GitHub's REST API media type documentation before adding a new endpoint call.
 - **Narrow Typed Error Matching to Specific Conditions**: When checking typed errors (e.g., `IsResourceNotFoundError`), verify the error's message or context matches the expected source — not just the error type. A single error type can be returned by multiple code paths with different semantics (e.g., "repo not found" vs "no package managers"), and a broad type check can trigger incorrect fallback behavior for unrelated error origins.
@@ -110,16 +112,6 @@ pending_patterns:
     pr: 370
     file: ".github/workflows/go-lint.yml"
     date: "2026-05-02"
-  - category: "defensive-coding"
-    summary: "Use quoted heredocs (<<'DELIM') for literal text bodies in CI workflows to prevent accidental parameter expansion and command substitution; inject dynamic values (markers, variables) via append after the heredoc rather than embedding them in an expansion-enabled body"
-    pr: 372
-    file: ".github/workflows/copilot-clean-label.yml"
-    date: "2026-05-02"
-  - category: "defensive-coding"
-    summary: "Guard time.Duration arithmetic against integer overflow — use strconv.ParseInt, reject values exceeding math.MaxInt64/time.Second, and do not clamp to an arbitrary policy constant (let the caller's configured cap decide)"
-    pr: 359
-    file: "internal/infrastructure/httpclient/client.go"
-    date: "2026-04-29"
   - category: "logging-consistency"
     summary: "Pass typed error values (e.g., *QueryError) directly to slog instead of pre-stringifying via .Error() — preserves type/structure and keeps logging consistent with slog conventions"
     pr: 346
@@ -140,21 +132,11 @@ pending_patterns:
     pr: 359
     file: "internal/infrastructure/httpclient/client_test.go"
     date: "2026-04-29"
-  - category: "defensive-coding"
-    summary: "Cap response body reads with io.LimitReader in retry paths (429/5xx) to prevent unbounded memory and log growth across retry attempts — consistent with existing codebase pattern for HTTP body reads"
-    pr: 359
-    file: "internal/infrastructure/httpclient/client.go"
-    date: "2026-04-29"
   - category: "ci-permissions"
     summary: "Verify that GitHub Actions reporter actions (e.g., reviewdog with github-pr-check) have the permissions they need — github-pr-check reporter requires checks: write to publish annotations; missing permissions cause silent failures or degraded reporting"
     pr: 370
     file: ".github/workflows/lint.yml"
     date: "2026-05-02"
-  - category: "defensive-coding"
-    summary: "Use time.NewTimer + Stop/drain instead of time.After in select with ctx.Done() to prevent timer accumulation during long cancellable waits"
-    pr: 359
-    file: "internal/infrastructure/httpclient/client.go"
-    date: "2026-04-29"
   - category: "api-consistency"
     summary: "Redundant gh pr view API call to fetch labels when pr_json from repos/.../pulls already contains label data — reuse already-fetched API response data instead of making redundant calls for a subset of the same information"
     pr: 338
@@ -163,6 +145,7 @@ pending_patterns:
 ```
 
 <!-- Promotion history (kept for audit trail):
+  # defensive-coding: promoted to copilot-learned-coding.instructions.md (PRs #359, #372 — guard resource bounds in HTTP client retry logic: time.Duration overflow, io.LimitReader cap, time.NewTimer lifecycle; use quoted heredocs for literal text in CI workflows)
   # defensive-coding: promoted to copilot-learned-coding.instructions.md (PRs #345, #366 — use dedicated predicates and full renderers for sentinel/composed values: IsUsableSPDX() not ad-hoc checks; canonicalize sentinel casing; use type renderer not single field; attribute provenance to correct resolution branch)
   # comment-doc-drift: promoted to copilot-learned-coding.instructions.md (PRs #359, #372 — attribute control claims to the correct mechanism: do not claim a permission/config/flag controls a behavior when a different mechanism is the effective authority)
   # defensive-coding: promoted to copilot-learned-coding.instructions.md (PRs #345, #366 — match write guard quantifiers to write semantics: an "any" flag guarding an "all/only" write misrepresents mixed inputs; verify replacement is a net improvement)

--- a/.claude/rules/copilot-learned-coding.md
+++ b/.claude/rules/copilot-learned-coding.md
@@ -25,6 +25,7 @@ Rules extracted from recurring Copilot review patterns on coding-standards topic
 - **CI Job Gating — Key on Outputs, Not Job Result**: When a CI job intentionally exits non-zero for a primary use case (e.g., policy violations), downstream jobs must not gate on `needs.<job>.result == 'success'`. Use explicit output variables (exit codes, flags) to control downstream behavior, so jobs run in the scenarios they are designed for.
 - **Remove Dead Configuration Inputs**: When a configuration surface (CLI flag, workflow input, env var) is no longer honored by the implementation (e.g., hardcoded internally), remove it entirely rather than leaving a misleading interface. A visible input that silently does nothing is worse than no input at all.
 - **CI Permissions Documentation — Verify Inheritance**: When documenting GitHub Actions job permissions, verify each job's actual `permissions:` block in the workflow file. Jobs without an explicit `permissions:` key inherit the workflow-level permissions — do not describe them as having "no permissions" or "no extra permissions". State what each job actually has, including inherited defaults.
+- **Attribute Control Claims to the Correct Mechanism**: When a comment asserts that a specific configuration, permission, or flag is "required for" or "controls" a behavior, verify the claim against the actual code path. Do not attribute behavior to a nearby-but-uninvolved mechanism (e.g., claiming `permissions:` block is "required for" `gh` commands when a PAT env var provides the effective auth; claiming a config field controls retries for an API where a different mechanism governs the retry decision). Misattributed control claims cause maintainers to debug or tune the wrong component.
 - **Lazy I/O During Format Detection**: When probing a file's format, prefer path-based checks first, then read only a small prefix for content-based heuristics. Read the full file only after confirming the format to avoid wasted I/O on non-matching files (e.g., reading an entire docker-compose.yml just to check if it's a GitHub Actions workflow).
 - **Deterministic Output from Non-Deterministic Sources**: When building ordered output from non-deterministic sources (Go map iteration, goroutine-collected results, API directory listings), sort the data before further processing. This applies to rendered text, BFS seed queues, and any "first-seen wins" algorithm where input order determines provenance.
 - **Post-Filter Fuzzy Search Results**: When using search APIs that perform fuzzy or word-level matching (e.g., GitHub issue search), add a post-filter to verify exact matches before acting on results. Fuzzy matches can cause false-positive deduplication or incorrect state transitions.
@@ -109,11 +110,11 @@ pending_patterns:
     pr: 370
     file: ".github/workflows/go-lint.yml"
     date: "2026-05-02"
-  - category: "comment-doc-drift"
-    summary: "Doc comments must match implementation boundary conditions — RetryConfig said retryDecider controls 429 retries (it doesn't); rateLimitBackoff comment said 'negative' for a zero-inclusive guard (should say 'non-positive')"
-    pr: 359
-    file: "internal/infrastructure/httpclient/client.go"
-    date: "2026-04-29"
+  - category: "defensive-coding"
+    summary: "Use quoted heredocs (<<'DELIM') for literal text bodies in CI workflows to prevent accidental parameter expansion and command substitution; inject dynamic values (markers, variables) via append after the heredoc rather than embedding them in an expansion-enabled body"
+    pr: 372
+    file: ".github/workflows/copilot-clean-label.yml"
+    date: "2026-05-02"
   - category: "defensive-coding"
     summary: "Guard time.Duration arithmetic against integer overflow — use strconv.ParseInt, reject values exceeding math.MaxInt64/time.Second, and do not clamp to an arbitrary policy constant (let the caller's configured cap decide)"
     pr: 359
@@ -163,6 +164,7 @@ pending_patterns:
 
 <!-- Promotion history (kept for audit trail):
   # defensive-coding: promoted to copilot-learned-coding.instructions.md (PRs #345, #366 — use dedicated predicates and full renderers for sentinel/composed values: IsUsableSPDX() not ad-hoc checks; canonicalize sentinel casing; use type renderer not single field; attribute provenance to correct resolution branch)
+  # comment-doc-drift: promoted to copilot-learned-coding.instructions.md (PRs #359, #372 — attribute control claims to the correct mechanism: do not claim a permission/config/flag controls a behavior when a different mechanism is the effective authority)
   # defensive-coding: promoted to copilot-learned-coding.instructions.md (PRs #345, #366 — match write guard quantifiers to write semantics: an "any" flag guarding an "all/only" write misrepresents mixed inputs; verify replacement is a net improvement)
   # testing (PR #366): already covered by "Scope Test Assertions to Specific Output Regions" in testing-performance + "Use Spec-Compliant Parsers for Standardized Formats" — use encoding/csv to parse CSV output and assert exact cells by header name instead of fragile strings.Contains on boolean patterns that match the wrong column
   # defensive-coding (PR #338): stale pending entry removed — already promoted as "Sanitize Dynamic Content in GitHub Actions Workflow Commands" rule

--- a/.github/instructions/agent-orchestration.instructions.md
+++ b/.github/instructions/agent-orchestration.instructions.md
@@ -50,6 +50,19 @@ Reviewer agent findings (including CRITICAL severity) are **discussion input**, 
 
 **Why:** Reviewer agents see only code, not the design intent behind it. In PR #123, a reviewer flagged "transitive advisories not shown on RequestedVersion" as CRITICAL, but this was an intentional decision (see ADR-0011). Blindly implementing the "fix" re-introduced a bug the user had already reported and resolved.
 
+### Workflow-File PRs Are Resolved Locally, Not by CI Claude
+
+PRs whose changes touch `.github/workflows/**` MUST be fixed locally by a human-driven Claude session, not by the auto-fix loop in `copilot-review-fix.yml`.
+
+**Why:** The auto-fix PAT (`GH_ACTIONS_TOKEN`) intentionally lacks the `workflow` scope. Workflow files define CI runtime permissions and secret access — granting a bot the ability to rewrite them creates a privilege-escalation surface (prompt-injection or misbehaviour can self-modify the bot's own runtime). Defense-in-depth: keep PAT scope minimal; pay the small operational cost of manual intervention on workflow PRs.
+
+**How to apply:**
+- When CI Claude reports "PAT lacks `workflow` scope" on a workflow-file thread, do NOT propose granting the scope. Pull the branch locally, apply the fix, push.
+- The marker dedup in `copilot-review-fix.yml` invalidates on push (HEAD SHA changes), so a manual push cleanly re-arms the auto-fix loop for the next round.
+- If the same Copilot finding loops indefinitely on a non-workflow PR, that's a different bug — investigate the auto-fix loop, do NOT relax PAT scope.
+
+**Symptom of the broken case (for debugging):** trigger-claude job runs `success` but logs `trigger already posted for HEAD <sha> (count=1) — skip` because a prior Claude run posted the marker but couldn't push the actual fix.
+
 ## Worktree Isolation Policy
 
 Agents that **write files** (Edit, Write) MUST be launched with `isolation: "worktree"` to prevent branch conflicts during parallel development. This gives each agent an isolated copy of the repository.

--- a/.github/instructions/copilot-learned-coding.instructions.md
+++ b/.github/instructions/copilot-learned-coding.instructions.md
@@ -23,6 +23,7 @@ Rules extracted from recurring Copilot review patterns on coding-standards topic
 - **CI Job Gating — Key on Outputs, Not Job Result**: When a CI job intentionally exits non-zero for a primary use case (e.g., policy violations), downstream jobs must not gate on `needs.<job>.result == 'success'`. Use explicit output variables (exit codes, flags) to control downstream behavior, so jobs run in the scenarios they are designed for.
 - **Remove Dead Configuration Inputs**: When a configuration surface (CLI flag, workflow input, env var) is no longer honored by the implementation (e.g., hardcoded internally), remove it entirely rather than leaving a misleading interface. A visible input that silently does nothing is worse than no input at all.
 - **CI Permissions Documentation — Verify Inheritance**: When documenting GitHub Actions job permissions, verify each job's actual `permissions:` block in the workflow file. Jobs without an explicit `permissions:` key inherit the workflow-level permissions — do not describe them as having "no permissions" or "no extra permissions". State what each job actually has, including inherited defaults.
+- **Attribute Control Claims to the Correct Mechanism**: When a comment asserts that a specific configuration, permission, or flag is "required for" or "controls" a behavior, verify the claim against the actual code path. Do not attribute behavior to a nearby-but-uninvolved mechanism (e.g., claiming `permissions:` block is "required for" `gh` commands when a PAT env var provides the effective auth; claiming a config field controls retries for an API where a different mechanism governs the retry decision). Misattributed control claims cause maintainers to debug or tune the wrong component.
 - **Lazy I/O During Format Detection**: When probing a file's format, prefer path-based checks first, then read only a small prefix for content-based heuristics. Read the full file only after confirming the format to avoid wasted I/O on non-matching files (e.g., reading an entire docker-compose.yml just to check if it's a GitHub Actions workflow).
 - **Deterministic Output from Non-Deterministic Sources**: When building ordered output from non-deterministic sources (Go map iteration, goroutine-collected results, API directory listings), sort the data before further processing. This applies to rendered text, BFS seed queues, and any "first-seen wins" algorithm where input order determines provenance.
 - **Post-Filter Fuzzy Search Results**: When using search APIs that perform fuzzy or word-level matching (e.g., GitHub issue search), add a post-filter to verify exact matches before acting on results. Fuzzy matches can cause false-positive deduplication or incorrect state transitions.
@@ -107,11 +108,11 @@ pending_patterns:
     pr: 370
     file: ".github/workflows/go-lint.yml"
     date: "2026-05-02"
-  - category: "comment-doc-drift"
-    summary: "Doc comments must match implementation boundary conditions — RetryConfig said retryDecider controls 429 retries (it doesn't); rateLimitBackoff comment said 'negative' for a zero-inclusive guard (should say 'non-positive')"
-    pr: 359
-    file: "internal/infrastructure/httpclient/client.go"
-    date: "2026-04-29"
+  - category: "defensive-coding"
+    summary: "Use quoted heredocs (<<'DELIM') for literal text bodies in CI workflows to prevent accidental parameter expansion and command substitution; inject dynamic values (markers, variables) via append after the heredoc rather than embedding them in an expansion-enabled body"
+    pr: 372
+    file: ".github/workflows/copilot-clean-label.yml"
+    date: "2026-05-02"
   - category: "defensive-coding"
     summary: "Guard time.Duration arithmetic against integer overflow — use strconv.ParseInt, reject values exceeding math.MaxInt64/time.Second, and do not clamp to an arbitrary policy constant (let the caller's configured cap decide)"
     pr: 359
@@ -161,6 +162,7 @@ pending_patterns:
 
 <!-- Promotion history (kept for audit trail):
   # defensive-coding: promoted to copilot-learned-coding.instructions.md (PRs #345, #366 — use dedicated predicates and full renderers for sentinel/composed values: IsUsableSPDX() not ad-hoc checks; canonicalize sentinel casing; use type renderer not single field; attribute provenance to correct resolution branch)
+  # comment-doc-drift: promoted to copilot-learned-coding.instructions.md (PRs #359, #372 — attribute control claims to the correct mechanism: do not claim a permission/config/flag controls a behavior when a different mechanism is the effective authority)
   # defensive-coding: promoted to copilot-learned-coding.instructions.md (PRs #345, #366 — match write guard quantifiers to write semantics: an "any" flag guarding an "all/only" write misrepresents mixed inputs; verify replacement is a net improvement)
   # testing (PR #366): already covered by "Scope Test Assertions to Specific Output Regions" in testing-performance + "Use Spec-Compliant Parsers for Standardized Formats" — use encoding/csv to parse CSV output and assert exact cells by header name instead of fragile strings.Contains on boolean patterns that match the wrong column
   # defensive-coding (PR #338): stale pending entry removed — already promoted as "Sanitize Dynamic Content in GitHub Actions Workflow Commands" rule

--- a/.github/instructions/copilot-learned-coding.instructions.md
+++ b/.github/instructions/copilot-learned-coding.instructions.md
@@ -20,6 +20,7 @@ Rules extracted from recurring Copilot review patterns on coding-standards topic
 - **Interface Contract Documentation Must Match Signature Semantics**: When documenting an interface method, the doc comment must accurately reflect the method's full signature — including error returns, nil semantics, and parameter constraints. If the signature returns `(T, error)`, do not document it as "returns nil/empty on failure" — state that errors may be returned and describe the caller's expected handling (e.g., non-fatal/graceful degradation). Mismatched contract documentation misleads implementers and callers.
 - **GitHub Actions `||` Treats Empty as Falsy**: When a workflow input documents "empty = X behavior", do not use `${{ inputs.foo || 'default' }}` — the `||` operator treats empty string as falsy and applies the default, preventing users from intentionally selecting the empty option. Instead, pass the raw input via an env var and apply defaults conditionally (e.g., only for scheduled triggers).
 - **Guard Downstream Jobs Against Missing Outputs**: When a CI job produces outputs that downstream jobs depend on (exit codes, flags), gate downstream jobs on `needs.<job>.outputs.<key> != ''` to prevent execution when the upstream job fails before setting outputs. Otherwise, empty values may be misinterpreted (e.g., empty exit code `""` compared with `!= "0"` evaluates to true, creating misleading reports).
+- **Use Quoted Heredocs for Literal Text in CI Workflows**: When constructing multi-line literal text bodies in CI workflow scripts (e.g., comment bodies, PR descriptions), use quoted heredoc delimiters (`<<'DELIM'`) to prevent accidental parameter expansion and command substitution. Inject dynamic values (markers, timestamps) via append after the heredoc rather than embedding them inside an expansion-enabled body.
 - **CI Job Gating — Key on Outputs, Not Job Result**: When a CI job intentionally exits non-zero for a primary use case (e.g., policy violations), downstream jobs must not gate on `needs.<job>.result == 'success'`. Use explicit output variables (exit codes, flags) to control downstream behavior, so jobs run in the scenarios they are designed for.
 - **Remove Dead Configuration Inputs**: When a configuration surface (CLI flag, workflow input, env var) is no longer honored by the implementation (e.g., hardcoded internally), remove it entirely rather than leaving a misleading interface. A visible input that silently does nothing is worse than no input at all.
 - **CI Permissions Documentation — Verify Inheritance**: When documenting GitHub Actions job permissions, verify each job's actual `permissions:` block in the workflow file. Jobs without an explicit `permissions:` key inherit the workflow-level permissions — do not describe them as having "no permissions" or "no extra permissions". State what each job actually has, including inherited defaults.
@@ -28,6 +29,7 @@ Rules extracted from recurring Copilot review patterns on coding-standards topic
 - **Deterministic Output from Non-Deterministic Sources**: When building ordered output from non-deterministic sources (Go map iteration, goroutine-collected results, API directory listings), sort the data before further processing. This applies to rendered text, BFS seed queues, and any "first-seen wins" algorithm where input order determines provenance.
 - **Post-Filter Fuzzy Search Results**: When using search APIs that perform fuzzy or word-level matching (e.g., GitHub issue search), add a post-filter to verify exact matches before acting on results. Fuzzy matches can cause false-positive deduplication or incorrect state transitions.
 - **Rerun Analyzers with Combined Input Sets on Retry**: When retrying a subset of inputs through an analyzer that tracks collisions or shared matches, rerun with the combined input set (original + retry) to preserve attribution consistency. Subset reruns can misattribute shared matches to the wrong source.
+- **Guard Resource Bounds in HTTP Client Retry Logic**: When implementing retry/backoff logic for HTTP clients: (1) guard `time.Duration` arithmetic against integer overflow — use `strconv.ParseInt` and reject values exceeding `math.MaxInt64/time.Second` rather than clamping to an arbitrary policy constant; (2) cap response body reads with `io.LimitReader` in retry paths (429/5xx) to prevent unbounded memory and log growth across retry attempts; (3) use `time.NewTimer` + `Stop`/drain instead of `time.After` in `select` with `ctx.Done()` to prevent timer accumulation during long cancellable waits.
 - **Consolidate Detection Heuristics — Single Source of Truth**: When a detection heuristic (file type sniffing, format detection, path matching) is used in multiple locations, centralize it in the responsible package and have callers delegate. Duplicating the heuristic across layers (e.g., `cmd/` and `infrastructure/`) risks drift when one copy is updated but the other is not.
 - **Use Correct GitHub API Media Types**: When calling GitHub REST APIs, use the documented `Accept` header for the desired response format. For raw file content use `application/vnd.github.raw` (not `application/vnd.github.raw+json`). Incorrect media types may cause silent content-negotiation failures or unexpected response formats. Refer to GitHub's REST API media type documentation before adding a new endpoint call.
 - **Narrow Typed Error Matching to Specific Conditions**: When checking typed errors (e.g., `IsResourceNotFoundError`), verify the error's message or context matches the expected source — not just the error type. A single error type can be returned by multiple code paths with different semantics (e.g., "repo not found" vs "no package managers"), and a broad type check can trigger incorrect fallback behavior for unrelated error origins.
@@ -108,16 +110,6 @@ pending_patterns:
     pr: 370
     file: ".github/workflows/go-lint.yml"
     date: "2026-05-02"
-  - category: "defensive-coding"
-    summary: "Use quoted heredocs (<<'DELIM') for literal text bodies in CI workflows to prevent accidental parameter expansion and command substitution; inject dynamic values (markers, variables) via append after the heredoc rather than embedding them in an expansion-enabled body"
-    pr: 372
-    file: ".github/workflows/copilot-clean-label.yml"
-    date: "2026-05-02"
-  - category: "defensive-coding"
-    summary: "Guard time.Duration arithmetic against integer overflow — use strconv.ParseInt, reject values exceeding math.MaxInt64/time.Second, and do not clamp to an arbitrary policy constant (let the caller's configured cap decide)"
-    pr: 359
-    file: "internal/infrastructure/httpclient/client.go"
-    date: "2026-04-29"
   - category: "logging-consistency"
     summary: "Pass typed error values (e.g., *QueryError) directly to slog instead of pre-stringifying via .Error() — preserves type/structure and keeps logging consistent with slog conventions"
     pr: 346
@@ -138,21 +130,11 @@ pending_patterns:
     pr: 359
     file: "internal/infrastructure/httpclient/client_test.go"
     date: "2026-04-29"
-  - category: "defensive-coding"
-    summary: "Cap response body reads with io.LimitReader in retry paths (429/5xx) to prevent unbounded memory and log growth across retry attempts — consistent with existing codebase pattern for HTTP body reads"
-    pr: 359
-    file: "internal/infrastructure/httpclient/client.go"
-    date: "2026-04-29"
   - category: "ci-permissions"
     summary: "Verify that GitHub Actions reporter actions (e.g., reviewdog with github-pr-check) have the permissions they need — github-pr-check reporter requires checks: write to publish annotations; missing permissions cause silent failures or degraded reporting"
     pr: 370
     file: ".github/workflows/lint.yml"
     date: "2026-05-02"
-  - category: "defensive-coding"
-    summary: "Use time.NewTimer + Stop/drain instead of time.After in select with ctx.Done() to prevent timer accumulation during long cancellable waits"
-    pr: 359
-    file: "internal/infrastructure/httpclient/client.go"
-    date: "2026-04-29"
   - category: "api-consistency"
     summary: "Redundant gh pr view API call to fetch labels when pr_json from repos/.../pulls already contains label data — reuse already-fetched API response data instead of making redundant calls for a subset of the same information"
     pr: 338
@@ -161,6 +143,7 @@ pending_patterns:
 ```
 
 <!-- Promotion history (kept for audit trail):
+  # defensive-coding: promoted to copilot-learned-coding.instructions.md (PRs #359, #372 — guard resource bounds in HTTP client retry logic: time.Duration overflow, io.LimitReader cap, time.NewTimer lifecycle; use quoted heredocs for literal text in CI workflows)
   # defensive-coding: promoted to copilot-learned-coding.instructions.md (PRs #345, #366 — use dedicated predicates and full renderers for sentinel/composed values: IsUsableSPDX() not ad-hoc checks; canonicalize sentinel casing; use type renderer not single field; attribute provenance to correct resolution branch)
   # comment-doc-drift: promoted to copilot-learned-coding.instructions.md (PRs #359, #372 — attribute control claims to the correct mechanism: do not claim a permission/config/flag controls a behavior when a different mechanism is the effective authority)
   # defensive-coding: promoted to copilot-learned-coding.instructions.md (PRs #345, #366 — match write guard quantifiers to write semantics: an "any" flag guarding an "all/only" write misrepresents mixed inputs; verify replacement is a net improvement)

--- a/.github/workflows/copilot-clean-label.yml
+++ b/.github/workflows/copilot-clean-label.yml
@@ -2,7 +2,7 @@ name: Copilot Clean Label
 
 # Apply the `copilot-clean` label to a PR when its latest Copilot review on the
 # current HEAD reports no (new) comments, matching `generated no( new)? comments`
-# (case-insensitive). Remove the label otherwise. Driven by cron (every 10 min)
+# (case-insensitive). Remove the label otherwise. Driven by cron (every 5 min)
 # because `pull_request_review` (submitted) does not fire for Copilot since the
 # 2026-03-05 agentic-architecture migration. The `synchronize` event handles
 # instant label removal on new commits.
@@ -13,7 +13,7 @@ name: Copilot Clean Label
 
 on:
   schedule:
-    - cron: '*/10 * * * *'
+    - cron: '*/5 * * * *'
   pull_request:
     types: [opened, reopened, synchronize]
   workflow_dispatch:
@@ -50,6 +50,10 @@ jobs:
     timeout-minutes: 5
     permissions:
       pull-requests: write
+      # Required for `gh pr edit --add-label/--remove-label` (label edits route
+      # through the Issues API) and for `gh pr comment` (PR comments are issue
+      # comments at the API level), used by the cron-poll @claude trigger fallback.
+      issues: write
     env:
       # PAT (kotakanbe), not GITHUB_TOKEN: GraphQL `requestReviews` for the
       # Copilot bot silently no-ops under GITHUB_TOKEN (200 OK with data, no
@@ -76,9 +80,15 @@ jobs:
       CLEAN_PHRASE_ERE: 'generated no( new)? comments'
       # Stuck-PR detector threshold. If the latest `review_requested` event
       # for Copilot is older than this (and HEAD has no Copilot review yet),
-      # re-fire the mutation. 5 min sits comfortably outside the observed
-      # short-lived dedup window when paired with the cron's 10 min period.
-      STUCK_THRESHOLD_MIN: '5'
+      # re-fire the mutation.
+      # Effective refire cadence with cron 5 min + threshold 7 min:
+      #   T+5: age=5 < 7 -> skip; T+10: age=10 >= 7 -> fire (timestamp=10);
+      #   T+15: age=5 < 7 -> skip; T+20: age=10 >= 7 -> fire ...
+      # = refire every other cron cycle (~10 min effective interval).
+      # This matches the prior cron 10 min + threshold 5 min behavior, so the
+      # absolute refire pressure on Copilot is unchanged; only the @claude
+      # trigger latency is halved.
+      STUCK_THRESHOLD_MIN: '7'
     steps:
       - name: Resolve target PR list
         env:
@@ -127,8 +137,12 @@ jobs:
             echo "::group::PR #$pr"
 
             # Single fetch of PR metadata: author + head SHA + labels + node_id.
-            if ! pr_json=$(gh api "repos/$REPO/pulls/$pr" 2>&1); then
-              echo "::warning::PR #$pr: failed to fetch PR metadata: $pr_json"
+            # Capture stdout only; gh writes errors to stderr which lands in
+            # the workflow log directly, and merging stderr into the captured
+            # variable would poison downstream jq parsing on success paths
+            # that emit non-fatal warnings (rate-limit notices, etc.).
+            if ! pr_json=$(gh api "repos/$REPO/pulls/$pr"); then
+              echo "::warning::PR #$pr: failed to fetch PR metadata"
               echo "::endgroup::"
               continue
             fi
@@ -153,8 +167,8 @@ jobs:
             # Aggregate paginated reviews into one array, then sort+last.
             # `gh api --paginate --jq` evaluates per-page, which would return
             # the per-page last instead of the global last.
-            if ! reviews_json=$(gh api --paginate "repos/$REPO/pulls/$pr/reviews" 2>&1); then
-              echo "::warning::PR #$pr: failed to fetch reviews: $reviews_json"
+            if ! reviews_json=$(gh api --paginate "repos/$REPO/pulls/$pr/reviews"); then
+              echo "::warning::PR #$pr: failed to fetch reviews"
               echo "::endgroup::"
               continue
             fi
@@ -210,6 +224,98 @@ jobs:
                 else
                   echo "no change (already unlabeled, review has comments)"
                 fi
+
+                # Cron-poll fallback for the @claude auto-fix trigger.
+                # `pull_request_review_comment` events are unreliable for the
+                # Copilot bot (agentic-architecture event suppression).
+                # To guarantee Claude is invoked even when those events do not
+                # fire, post the @claude trigger here when:
+                #   - Copilot's latest review on HEAD has actual inline comments
+                #   - AND we have not already posted a trigger for this HEAD
+                #
+                # MARKER CONTRACT (also implemented by copilot-review-fix.yml):
+                #   format:    <!-- copilot-fix-trigger:<HEAD_SHA> -->
+                #   placement: last line of the @claude comment body
+                #   author:    posted via PAT (kotakanbe), so the dedup query
+                #              scopes to .user.login == "kotakanbe"
+                #   prefix:    body starts with "@claude" so a quoted marker
+                #              in human prose does not produce a false match
+                # Marker auto-invalidates on push (new HEAD = new marker key).
+                # If you change ANY part of this contract, update both files.
+
+                # Verify the latest Copilot review has actual inline comments,
+                # not just a summary text change (which also produces dirty).
+                review_id=$(printf '%s' "$latest" | jq -r '.id')
+                has_review_comments=1
+                if [ -n "$review_id" ] && [ "$review_id" != "null" ]; then
+                  if ! rc_json=$(gh api "repos/$REPO/pulls/$pr/reviews/$review_id/comments"); then
+                    echo "::warning::PR #$pr: failed to verify review comments — proceeding with trigger"
+                  else
+                    rc_count=$(printf '%s' "$rc_json" | jq 'length' 2>/dev/null || echo 1)
+                    case "$rc_count" in
+                      ''|*[!0-9]*) rc_count=1 ;;
+                    esac
+                    if [ "$rc_count" = "0" ]; then
+                      echo "Copilot review on HEAD has no inline comments (summary-only) — skip @claude trigger"
+                      has_review_comments=0
+                    else
+                      echo "Copilot review on HEAD has $rc_count inline comment(s)"
+                    fi
+                  fi
+                fi
+
+                if [ "$has_review_comments" = "1" ]; then
+                  if [ -z "$head_sha" ] || [ "${#head_sha}" -lt 40 ]; then
+                    echo "::warning::PR #$pr: missing/short head_sha '$head_sha' — skip @claude trigger"
+                  else
+                    trigger_marker="<!-- copilot-fix-trigger:$head_sha -->"
+                    # Capture stdout only; on failure gh writes diagnostics to
+                    # stderr which lands in the workflow log (visible without
+                    # parsing). `set -e` is active but all fallible commands use
+                    # `if ! ...; then` guards so failures warn-and-continue.
+                    # On dedup fetch failure, proceed to post (worst case is a
+                    # duplicate, which claude.yml mitigates via cancel-in-progress).
+                    already_triggered=0
+                    if ! issue_comments=$(gh api --paginate "repos/$REPO/issues/$pr/comments"); then
+                      echo "::warning::PR #$pr: failed to fetch issue comments for trigger dedup — proceeding with post"
+                    else
+                      # Null-safe: comments authored by deleted/redacted users
+                      # may have body == null which would crash `contains()`.
+                      # Author + prefix scope: only kotakanbe-authored comments
+                      # that begin with "@claude" count, eliminating the
+                      # quoted-marker-in-prose false positive.
+                      already_triggered=$(printf '%s' "$issue_comments" | jq -s -r --arg m "$trigger_marker" '
+                        add // []
+                        | [.[] | select(
+                            .user.login == "kotakanbe"
+                            and .body != null
+                            and (.body | startswith("@claude"))
+                            and (.body | contains($m))
+                          )] | length
+                      ' 2>/dev/null || echo 0)
+                      case "$already_triggered" in
+                        ''|*[!0-9]*) already_triggered=0 ;;
+                      esac
+                    fi
+                    if [ "$already_triggered" = "0" ]; then
+                      echo "Posting @claude trigger for HEAD $head_sha (cron fallback)"
+                      if ! gh pr comment "$pr" --repo "$REPO" --body "$(cat <<BODY
+          @claude Follow the procedure in \`.github/prompts/review.prompt.md\` with \`--copilot-only\` mode for this PR.
+
+          Phase 2: Resolve all unresolved Copilot review threads (discover → classify → fix → build/test/lint → commit/push → reply/resolve).
+          Phase 3: Detect recurring patterns from FIX-classified comments, propose and apply coding rules to \`.github/instructions/\`, then run \`make sync-instructions\`.
+          Phase 4: Post a summary comment on this PR.
+
+          $trigger_marker
+          BODY
+          )"; then
+                        echo "::warning::PR #$pr: failed to post @claude trigger comment"
+                      fi
+                    else
+                      echo "trigger already posted for HEAD $head_sha (count=$already_triggered) — skip"
+                    fi
+                  fi
+                fi
                 ;;
               pending)
                 # No review yet, or latest review is for an older HEAD.
@@ -229,8 +335,38 @@ jobs:
                 # pinged recently. Recovers from cases where the push-event
                 # mutation in copilot-rereview-on-push.yml was silently
                 # deduped (200 OK but no `review_requested` event).
-                if ! timeline=$(gh api --paginate "repos/$REPO/issues/$pr/timeline" 2>&1); then
-                  echo "::warning::PR #$pr: failed to fetch timeline for stuck detection: $timeline"
+                #
+                # Empirically observed (in the sibling vuls-reach repo): a
+                # plain refire of `requestReviews` against a bot that is already
+                # on the requested-reviewer list is *also* deduped — the
+                # GraphQL mutation succeeds but no `review_requested`
+                # timeline event fires and Copilot does not re-review.
+                # So the refire below first clears Copilot from the
+                # reviewer slot via GraphQL `requestReviews(union:false)`
+                # (preserving humans + teams; bots are excluded by
+                # passing `botIds:[]`), then re-adds Copilot via a
+                # second GraphQL `requestReviews` call. The remove +
+                # re-add forces GitHub to consider it a fresh request,
+                # which fires the event and wakes Copilot.
+                #
+                # An earlier draft of this bypass used REST `DELETE
+                # /pulls/{n}/requested_reviewers` for step 1, but the
+                # REST endpoint only addresses User reviewers — Bot
+                # reviewers (Copilot) live in a separate request slot
+                # the REST endpoint cannot see, so the DELETE always
+                # 422'd and the subsequent re-add was still deduped.
+                # GraphQL is the only API that can manipulate bot
+                # reviewer slots.
+                #
+                # The push-event path (copilot-rereview-on-push.yml) is
+                # intentionally NOT modified: it tries the cheap mutation
+                # first; only this cron path escalates to remove + re-add
+                # when the cheap path has already failed.
+                # Permission: GraphQL `requestReviews` is covered by
+                # `pull-requests: write` (already granted at the job
+                # level above).
+                if ! timeline=$(gh api --paginate "repos/$REPO/issues/$pr/timeline"); then
+                  echo "::warning::PR #$pr: failed to fetch timeline for stuck detection"
                 else
                   # Note: timeline events use yet a third login form for Copilot
                   # ("Copilot", capitalized) — distinct from REST's
@@ -264,15 +400,167 @@ jobs:
                   fi
                   if [ "$refire_stuck" = "1" ]; then
                     pr_node_id=$(printf '%s' "$pr_json" | jq -r '.node_id')
-                    echo "stuck detector: refiring requestReviews"
+                    # Why GraphQL, not REST DELETE:
+                    # GitHub's REST `DELETE /pulls/{n}/requested_reviewers`
+                    # with `reviewers[]=...` only addresses User reviewers
+                    # — Bot reviewers (Copilot is a Bot, added via
+                    # `requestReviews{botIds:[...]}`) live in a separate
+                    # request slot the REST endpoint cannot see. Empirical
+                    # confirmation: REST DELETE returned `HTTP 422 Reviewer
+                    # is not a user` for both `reviewers[]=Copilot` and
+                    # `reviewers[]=copilot-pull-request-reviewer[bot]`.
+                    # The earlier REST-based bypass therefore never
+                    # cleared anything and the subsequent re-add was
+                    # still deduped.
+                    #
+                    # GraphQL `requestReviews(union:false)` REPLACES the
+                    # entire reviewer set, so to remove only the bot we
+                    # must first read the current set and then replay it
+                    # without any bots. Humans and teams are preserved.
+                    echo "stuck detector: clearing Copilot via GraphQL union:false (dedup bypass)"
+                    cleared=0
+                    # `clear_attempted` is set when the clear mutation was
+                    # actually dispatched (including partial-success / errors
+                    # paths). The sleep below gates on attempt, not success,
+                    # because GitHub may have partially committed the
+                    # reviewer-slot mutation even on `.errors` return — and
+                    # the whole point of the 2s pause is to let any such
+                    # commit settle before the re-add.
+                    clear_attempted=0
+                    _stderr_tmp=$(mktemp)
+                    if ! query_out=$(gh api graphql \
+                      -f query='query($pr:ID!){node(id:$pr){... on PullRequest{reviewRequests(first:100){nodes{requestedReviewer{__typename ... on User{id} ... on Team{id} ... on Bot{id}}}}}}}' \
+                      -f pr="$pr_node_id" 2>"$_stderr_tmp"); then
+                      _err_detail=$(printf '%s' "$query_out" | jq -r '.errors[0].message // empty' 2>/dev/null || true)
+                      [ -z "$_err_detail" ] && _err_detail=$(tr '\n' ' ' < "$_stderr_tmp" | head -c 200)
+                      _err_detail=$(printf '%s' "${_err_detail}" | tr '\r' ' ' | sed 's/%/%25/g')
+                      echo "::warning::PR #$pr: failed to query reviewer requests: ${_err_detail:-(unknown)} — proceeding to add"
+                    elif printf '%s' "$query_out" | jq -e '(.errors // []) | length > 0' >/dev/null 2>&1; then
+                      # Partial-success path (HTTP 200 with .errors[]).
+                      # Symmetric with the clear / refire `.errors` checks below.
+                      # Skip parsing because users_json/teams_json may be
+                      # incomplete; the bypass falls back to a deduped re-add,
+                      # which is still no worse than the pre-PR-#7 state.
+                      _err_detail=$(printf '%s' "$query_out" | jq -r '.errors[0].message // empty' 2>/dev/null || true)
+                      _err_detail=$(printf '%s' "${_err_detail}" | tr '\r' ' ' | sed 's/%/%25/g')
+                      echo "::warning::PR #$pr: GraphQL reviewer query returned errors (exit 0): ${_err_detail:-(unknown)} — proceeding to add"
+                    else
+                      # Split current reviewers into user / team / bot
+                      # buckets. `// []` coalesces null at any path level
+                      # to an empty array. The shell `|| reviewer_query_ok=0`
+                      # branch catches genuine jq parse failures (empty
+                      # `query_out`, malformed JSON) — distinct from the
+                      # legitimate "no reviewers" case (`query_out` valid
+                      # JSON, just an empty `nodes` array).
+                      reviewer_query_ok=1
+                      reviewer_nodes=$(printf '%s' "$query_out" | jq -c \
+                        '[(.data.node.reviewRequests.nodes // [])[] | select(. != null and .requestedReviewer != null)]') || reviewer_query_ok=0
+                      if [ "$reviewer_query_ok" = "0" ]; then
+                        # Skip the clear entirely. With reviewer_nodes
+                        # unknown, building users_json=[]/teams_json=[]
+                        # and calling `requestReviews(union:false)` would
+                        # *remove every human reviewer* on the PR — a
+                        # silent and irreversible side effect of a
+                        # transient parse failure. Re-add Copilot only;
+                        # the dedup may still bite this round but the
+                        # next cron tick will retry safely.
+                        echo "::warning::PR #$pr: reviewer_nodes jq parse failed — skipping clear to avoid removing humans, proceeding to add"
+                      else
+                        users_json=$(printf '%s' "$reviewer_nodes" | jq -c '
+                          map(select(.requestedReviewer.__typename == "User")
+                                | .requestedReviewer.id)')
+                        teams_json=$(printf '%s' "$reviewer_nodes" | jq -c '
+                          map(select(.requestedReviewer.__typename == "Team")
+                                | .requestedReviewer.id)')
+                        copilot_present=$(printf '%s' "$reviewer_nodes" | jq -r --arg id "$COPILOT_BOT_ID" '
+                          any(.requestedReviewer.__typename == "Bot"
+                                and .requestedReviewer.id == $id)')
+
+                        if [ "$copilot_present" != "true" ]; then
+                          # Copilot is not in the reviewer set — nothing to
+                          # clear. Skip the mutation + sleep to avoid a
+                          # wasteful API call and 2s delay.
+                          echo "::notice::PR #$pr: Copilot was not in reviewer requests — skipping clear"
+                        else
+                          # Build the GraphQL request body. botIds is
+                          # explicitly empty: replacing with humans + teams
+                          # only removes any bots from the slot, including
+                          # Copilot. If users_json / teams_json are also
+                          # empty, the whole reviewer set is cleared, which
+                          # is still safe (no humans to lose).
+                          clear_body=$(jq -n \
+                            --arg pr "$pr_node_id" \
+                            --argjson users "$users_json" \
+                            --argjson teams "$teams_json" \
+                            '{
+                              query: "mutation($pr:ID!,$users:[ID!]!,$teams:[ID!]!){requestReviews(input:{pullRequestId:$pr, userIds:$users, teamIds:$teams, botIds:[], union:false}){pullRequest{id}}}",
+                              variables: {pr:$pr, users:$users, teams:$teams}
+                            }')
+                          clear_attempted=1
+                          if ! clear_out=$(printf '%s' "$clear_body" | gh api graphql --input - 2>"$_stderr_tmp"); then
+                            _err_detail=$(printf '%s' "$clear_out" | jq -r '.errors[0].message // empty' 2>/dev/null || true)
+                            [ -z "$_err_detail" ] && _err_detail=$(tr '\n' ' ' < "$_stderr_tmp" | head -c 200)
+                            _err_detail=$(printf '%s' "${_err_detail}" | tr '\r' ' ' | sed 's/%/%25/g')
+                            echo "::warning::PR #$pr: GraphQL clear of bot reviewers failed: ${_err_detail:-(unknown)} — proceeding to add"
+                          elif printf '%s' "$clear_out" | jq -e '(.errors // []) | length > 0' >/dev/null 2>&1; then
+                            # Symmetric with query / refire `.errors` checks (same `(.errors // [])` form).
+                            # `|| true` guards `set -euo pipefail` against jq exiting non-zero on malformed `clear_out`.
+                            _err_detail=$(printf '%s' "$clear_out" | jq -r '.errors[0].message // empty' 2>/dev/null || true)
+                            _err_detail=$(printf '%s' "${_err_detail}" | tr '\r' ' ' | sed 's/%/%25/g')
+                            echo "::warning::PR #$pr: GraphQL clear returned errors (exit 0): ${_err_detail:-(unknown)} — proceeding to add"
+                          else
+                            cleared=1
+                            echo "stuck detector: cleared Copilot from reviewer slot via GraphQL union:false"
+                          fi
+                        fi
+                      fi
+                    fi
+                    # Pause so GitHub commits the removal before the add.
+                    # Without it the add can race the delete and the new
+                    # review_requested event collapses with the
+                    # corresponding review_request_removed event on the
+                    # same activity stream, defeating the bypass.
+                    # 2s margin absorbs GitHub API replication lag for
+                    # reviewer mutations under load (well inside the
+                    # 5-min job timeout). Sleep on `clear_attempted`,
+                    # not `cleared`: a partial-success path (`.errors[]`
+                    # on HTTP 200) may still have committed the mutation
+                    # — skipping the sleep there would race the dedup
+                    # window the bypass is trying to escape.
+                    if [ "$clear_attempted" = "1" ]; then
+                      sleep 2
+                    fi
+                    # Step 2: re-add Copilot via GraphQL. Now that the
+                    # request slot is clean, this fires a fresh
+                    # review_requested event.
+                    echo "stuck detector: re-requesting Copilot review"
                     if ! refire=$(gh api graphql \
                       -f query='mutation($pr:ID!,$bot:ID!){requestReviews(input:{pullRequestId:$pr, botIds:[$bot]}){pullRequest{id}}}' \
                       -f pr="$pr_node_id" \
-                      -f bot="$COPILOT_BOT_ID" 2>&1); then
-                      echo "::warning::PR #$pr: stuck-detector refire failed: $refire"
+                      -f bot="$COPILOT_BOT_ID" 2>"$_stderr_tmp"); then
+                      _err_detail=$(printf '%s' "$refire" | jq -r '.errors[0].message // empty' 2>/dev/null || true)
+                      [ -z "$_err_detail" ] && _err_detail=$(tr '\n' ' ' < "$_stderr_tmp" | head -c 200)
+                      _err_detail=$(printf '%s' "${_err_detail}" | tr '\r' ' ' | sed 's/%/%25/g')
+                      echo "::warning::PR #$pr: stuck-detector refire failed: ${_err_detail:-(unknown)}"
+                    elif printf '%s' "$refire" | jq -e '(.errors // []) | length > 0' >/dev/null 2>&1; then
+                      # Partial-success path: HTTP 200 with .errors[] (e.g.
+                      # `Could not resolve to a node`, permission downgrade).
+                      # Symmetric with the query / clear `.errors` checks
+                      # above. The whole point of the bypass is to fire a
+                      # fresh `review_requested` event; if GraphQL silently
+                      # returned errors here we have not actually fired
+                      # one and must surface that as a warning.
+                      _err_detail=$(printf '%s' "$refire" | jq -r '.errors[0].message // empty' 2>/dev/null || true)
+                      _err_detail=$(printf '%s' "${_err_detail}" | tr '\r' ' ' | sed 's/%/%25/g')
+                      echo "::warning::PR #$pr: stuck-detector refire returned errors (exit 0): ${_err_detail:-(unknown)}"
                     else
-                      echo "stuck detector: refire ok"
+                      if [ "$cleared" = "1" ]; then
+                        echo "stuck detector: refire ok (cleared + re-requested)"
+                      else
+                        echo "stuck detector: refire ok (re-requested without clear)"
+                      fi
                     fi
+                    rm -f "$_stderr_tmp"
                   fi
                 fi
                 ;;

--- a/.github/workflows/copilot-clean-label.yml
+++ b/.github/workflows/copilot-clean-label.yml
@@ -50,9 +50,12 @@ jobs:
     timeout-minutes: 5
     permissions:
       pull-requests: write
-      # Required for `gh pr edit --add-label/--remove-label` (label edits route
-      # through the Issues API) and for `gh pr comment` (PR comments are issue
-      # comments at the API level), used by the cron-poll @claude trigger fallback.
+      # `gh pr edit --add-label/--remove-label` and `gh pr comment` route
+      # through the Issues API, so they need `issues: write` — but only when
+      # `gh` authenticates via GITHUB_TOKEN. This job authenticates via the
+      # PAT in `GH_TOKEN` (env below), so this entry is the documented
+      # GITHUB_TOKEN scope set if the PAT were removed; it does NOT control
+      # the effective auth for the `gh` calls in this workflow.
       issues: write
     env:
       # PAT (kotakanbe), not GITHUB_TOKEN: GraphQL `requestReviews` for the
@@ -299,16 +302,25 @@ jobs:
                     fi
                     if [ "$already_triggered" = "0" ]; then
                       echo "Posting @claude trigger for HEAD $head_sha (cron fallback)"
-                      if ! gh pr comment "$pr" --repo "$REPO" --body "$(cat <<BODY
-          @claude Follow the procedure in \`.github/prompts/review.prompt.md\` with \`--copilot-only\` mode for this PR.
+                      # Quoted heredoc disables parameter expansion / command
+                      # substitution inside the literal instruction block;
+                      # the dynamic $trigger_marker is appended after the
+                      # body so future edits cannot accidentally introduce
+                      # `$()` or backtick execution paths.
+                      trigger_body=$(cat <<'BODY'
+          @claude Follow the procedure in `.github/prompts/review.prompt.md` with `--copilot-only` mode for this PR.
 
           Phase 2: Resolve all unresolved Copilot review threads (discover → classify → fix → build/test/lint → commit/push → reply/resolve).
-          Phase 3: Detect recurring patterns from FIX-classified comments, propose and apply coding rules to \`.github/instructions/\`, then run \`make sync-instructions\`.
+          Phase 3: Detect recurring patterns from FIX-classified comments, propose and apply coding rules to `.github/instructions/`, then run `make sync-instructions`.
           Phase 4: Post a summary comment on this PR.
-
-          $trigger_marker
           BODY
-          )"; then
+          )
+                      # $() strips trailing newlines, so re-introduce a blank
+                      # line before the marker to keep the previous layout.
+                      trigger_body="${trigger_body}
+
+          ${trigger_marker}"
+                      if ! gh pr comment "$pr" --repo "$REPO" --body "$trigger_body"; then
                         echo "::warning::PR #$pr: failed to post @claude trigger comment"
                       fi
                     else


### PR DESCRIPTION
## Summary

Sync `copilot-clean-label.yml` with the version battle-tested in `vuls-saas/vuls-reach`.

This is the **guarantee path** for the Copilot → @claude auto-fix loop. The event-driven fast path lives in `copilot-review-fix.yml` (PR #371); this cron handles every case the events miss.

## Why

Two production failures observed on vuls-reach drove these changes:

1. **GITHUB_TOKEN event suppression**: under the agentic-architecture migration, `pull_request_review_comment` events do not always fire when Copilot posts inline review comments. The `copilot-review-fix.yml` event-driven path silently misses those reviews and Claude is never invoked. The cron-poll fallback in this PR closes that gap.
2. **Plain `requestReviews` refire is also deduped**: when `copilot-rereview-on-push.yml`'s push-event mutation is silently deduped, refiring the same mutation does nothing — GraphQL returns 200 OK with valid data but no `review_requested` event fires. The remove + re-add pattern (clear via `union:false` then re-add) is the only sequence that actually wakes Copilot.

## Changes

### Cron-poll @claude trigger fallback (new)

When the latest Copilot review on HEAD is dirty (has actual inline comments — verified via the per-review comments endpoint to skip summary-only events) AND the marker dedup query shows no prior trigger, post `@claude` directly from the cron path. Marker contract matches `copilot-review-fix.yml`:

```
<!-- copilot-fix-trigger:<HEAD_SHA> -->
```

last line of the body, scoped to kotakanbe-authored comments starting with `@claude`. Auto-invalidates on push.

### GraphQL union:false stuck-detector bypass (new)

When the push-event mutation was deduped, this cron now:

1. Reads the current reviewer set via GraphQL.
2. Replays the set with `union:false`, `botIds:[]`, and the existing user/team IDs — removing any bots (Copilot) while preserving humans + teams.
3. Pauses 2s for GitHub replication.
4. Re-adds Copilot via a fresh `requestReviews(botIds:[<copilot>])` call.

Safety: if the reviewer-set parse fails, the clear is skipped (otherwise we'd silently remove every human reviewer). Re-add only runs in that case.

### Cadence + threshold

- Cron `*/10` → `*/5`
- `STUCK_THRESHOLD_MIN` `5` → `7`

Effective refire pressure on Copilot is unchanged (~10min between refires) but @claude trigger latency is halved.

### Other hardening

- `head.repo.full_name == github.repository` guard (skip fork PRs that can't access `GH_ACTIONS_TOKEN`).
- `issues: write` permission (required for `gh pr comment` and label edits via the Issues API).
- Reuse labels from the pulls metadata response (drop redundant `gh pr view --json labels` fetch).
- Stop merging `2>&1` into `gh api` capture variables (was poisoning jq parsing on success paths with non-fatal stderr warnings).
- Phase 2/3/4 layout in the cron-fallback `@claude` body preserved (`make sync-instructions` Phase 3 stays, OSS-specific).

## Test plan

- [x] `actionlint .github/workflows/copilot-clean-label.yml` clean locally
- [ ] After merge: open a test PR, verify cron-poll posts `@claude` exactly once when Copilot reviews go through the suppressed-event path
- [ ] Verify the marker comment dedups subsequent cron runs on the same HEAD
- [ ] Verify the GraphQL union:false bypass clears + re-adds Copilot when the push-event mutation was deduped

## Companion PRs

- #371 — `copilot-review-fix.yml` (the marker contract counterpart)
- Coming next: `lint.yml` (actionlint) — would have caught some of the `2>&1` / stderr-poisoning issues that bit us in vuls-reach

🤖 Generated with [Claude Code](https://claude.com/claude-code)