### PR TITLE
ci(lint): add checks: write + fix path filter on actionlint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,20 +1,37 @@
 name: Lint
 
-# Lint GitHub Actions workflows with actionlint (embeds shellcheck for `run:`
-# block bash). Catches GitHub Actions specific issues (deprecated actions,
-# unsafe `${{ ... }}` interpolation, missing permissions, stale runner labels)
-# plus shellcheck-detectable bash issues.
+# Lint GitHub Actions workflows with actionlint (which embeds shellcheck for
+# `run:` block bash). Coverage:
+#   - GitHub Actions specific issues (unknown event types, deprecated actions,
+#     missing required permissions, unsafe `${{ ... }}` interpolation in `run:`,
+#     stale runner labels, etc.)
+#   - Shellcheck rules on `run:` blocks (unquoted variables, glob misuse,
+#     suspicious arithmetic, command substitution mistakes, etc.)
+#
+# Known *not* caught (still requires reviewer / Copilot eye):
+#   - `set -euo pipefail` × `var=$(... | jq ...)` exit propagation when jq
+#     parse fails on malformed JSON. Shellcheck does not model this control-
+#     flow chain. We mitigate with `|| true` guards in the workflows that need
+#     it (see comments in copilot-clean-label.yml stuck-detector for the
+#     reference pattern).
+#
+# Scope: only runs when workflow files or actionlint config change. Cheap, and
+# avoids noise on non-CI PRs.
+#
+# Note: composite actions (.github/actions/) are NOT linted by actionlint's
+# default invocation. When composite actions are added, update actionlint_flags
+# to pass those paths explicitly.
 
 on:
   pull_request:
     paths:
       - '.github/workflows/**'
-      - '.github/actions/**'
+      - '.github/actionlint.yaml'
   push:
     branches: [main]
     paths:
       - '.github/workflows/**'
-      - '.github/actions/**'
+      - '.github/actionlint.yaml'
 
 permissions: {}
 
@@ -24,16 +41,29 @@ jobs:
     timeout-minutes: 3
     permissions:
       contents: read
+      # `checks: write` is required for reviewdog's `github-pr-check` reporter
+      # to post annotations via the Checks API. Without it, findings only
+      # appear in the run log — not as inline annotations on the PR diff.
+      checks: write
       pull-requests: read
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: actionlint
-        # Pinned to v1.72.0 SHA (released 2026-03-31). Bumps via dependabot.
+        # Pin to v1.72.0 SHA (released 2026-03-31). Update manually or add a
+        # `.github/dependabot.yml` entry for github-actions to automate bumps.
+        # Wraps `rhysd/actionlint` v1.7.x which is the upstream linter.
         uses: reviewdog/action-actionlint@6fb7acc99f4a1008869fa8a0f09cfca740837d9d # v1.72.0
         with:
+          # `github-pr-check` posts annotations on the PR diff via the Checks
+          # API (requires `checks: write`, granted above). `level=error` makes
+          # the check fail on any actionlint finding so the PR cannot merge
+          # with lint failures.
           reporter: github-pr-check
           level: error
           fail_level: any
+          # Pass `-color` for nicer terminal output in run logs. The action's
+          # default rules are kept; project-specific suppressions go in
+          # `.github/actionlint.yaml` (created only if needed).
           actionlint_flags: -color


### PR DESCRIPTION
## Summary

Reworked from the original "create `lint.yml`" form to a **modification** of the existing `lint.yml` that #370 introduced. Three functional changes versus current `main`.

> **Context**: this PR was opened before #370 merged and originally created `lint.yml` from scratch (39 → 69 lines). After #370 landed `lint.yml` on main, the change was rebased to the diff form below.

## Functional changes vs. main

### 1. `permissions:` — add `checks: write`

Required for reviewdog's `github-pr-check` reporter to publish inline annotations via the Checks API. Without it, findings only appear in the run log, not on the PR diff — a silent degradation that defeats the point of the `github-pr-check` reporter.

### 2. `paths:` — `.github/actions/**` → `.github/actionlint.yaml`

actionlint's default invocation does **not** lint composite actions under `.github/actions/`, so the previous path filter triggered the workflow on changes that never affected lint output. The new filter tracks the actionlint config file (which DOES affect lint results when it exists).

A note in the file header documents that composite actions need explicit `actionlint_flags` paths if they are added in the future.

### 3. Documentation

- Caveats: `set -euo pipefail` × `var=$(... | jq ...)` exit-propagation gap that shellcheck does not model — referenced as `|| true` guard pattern in `copilot-clean-label.yml` stuck-detector.
- Composite-action lint coverage gap (point 2 above).
- Per-setting rationale on `checks: write`, the v1.72.0 SHA pin, and `actionlint_flags: -color`.

Synced from `vuls-saas/vuls-reach` PR #9.

## Test plan

- [x] `git diff origin/main` is a pure modification (no add/add file conflict)
- [ ] After merge: open a PR that introduces an intentional actionlint violation and verify the check fails **with inline annotation on the PR diff** (the bit that requires `checks: write`)
- [ ] Verify the workflow fires when `.github/actionlint.yaml` is touched (currently absent — can be tested by adding an empty config)
- [ ] Verify the workflow does **not** fire on `.github/actions/**` changes (no composite actions exist yet, so this is a no-op verification — leave a TODO for when one is added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)