### PR TITLE
fix(ci): cron timing doc + concurrency label-stuck race in copilot-review-fix.yml

### DIFF
--- a/.github/workflows/copilot-review-fix.yml
+++ b/.github/workflows/copilot-review-fix.yml
@@ -8,10 +8,14 @@ on:
   # (created) events are unreliable for the Copilot bot due to the agentic
   # architecture's GITHUB_TOKEN-driven event suppression. They are still listened
   # for as a best-effort fast path; the cron-driven fallback in
-  # `copilot-clean-label.yml` covers the suppressed cases within ~5 min.
+  # `copilot-clean-label.yml` covers the suppressed cases within ~30–60 min
+  # (cron fires every 30 minutes, worst case is "marker posted just after a
+  # tick" so cron only resumes on the tick after, ≈60 min later).
   #
-  # Multiple comments may trigger multiple events; concurrency cancel-in-progress
-  # ensures only the last one runs.
+  # Multiple events for the same PR are deduped by the marker-based check
+  # below (`already_triggered` / `local_in_progress` jq passes), so the
+  # concurrency group below uses `cancel-in-progress: false` and lets
+  # queued events run sequentially.
   pull_request_review:
     types: [submitted]
   pull_request_review_comment:
@@ -26,7 +30,15 @@ jobs:
   trigger-claude:
     concurrency:
       group: copilot-review-${{ github.event.pull_request.number }}
-      cancel-in-progress: true
+      # `cancel-in-progress: false` is intentional. With `true`, a new
+      # Copilot review/comment event can cancel a label-triggered run
+      # before its first step removes the `copilot-review` label,
+      # leaving the label stuck on the PR. Re-adding an already-present
+      # label fires no event, so the manual retry path breaks. Marker-
+      # based dedup later in the job (`already_triggered` /
+      # `local_in_progress`) already prevents duplicate `@claude` posts,
+      # so queueing is the safe choice.
+      cancel-in-progress: false
     # Run when: Copilot submits a review OR posts a review comment OR
     # 'copilot-review' label is added by the maintainer.
     # Only for same-repo PRs authored by kotakanbe (fork PRs cannot access

--- a/.github/workflows/copilot-review-fix.yml
+++ b/.github/workflows/copilot-review-fix.yml
@@ -134,9 +134,30 @@ jobs:
           # error: skipping is safer than posting a possibly-stale
           # trigger.
           payload_sha="${HEAD_SHA:-}"
+          current_sha=""
           if ! current_sha=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json headRefOid --jq '.headRefOid'); then
-            echo "::warning::PR #$PR_NUMBER: gh pr view --json headRefOid failed — skipping @claude trigger (will be re-driven by cron / next event)"
-            exit 0
+            current_sha=""
+            if [ "${GITHUB_EVENT_NAME:-}" = "pull_request" ]; then
+              # Manual label path: the earlier step has already
+              # removed `copilot-review`, so an exit here would be
+              # a silent no-op (no `@claude` trigger, no PR
+              # feedback). Fall back to the payload SHA and
+              # proceed; if the payload SHA was stale, the marker
+              # dedup further down will skip cleanly. The operator
+              # gets a CI run for what we can verify (payload
+              # HEAD), which is better than nothing.
+              echo "::warning::PR #$PR_NUMBER: gh pr view --json headRefOid failed on manual label path — falling back to payload HEAD ($payload_sha) and proceeding (label was already removed; silent exit would break the manual retry path)"
+              current_sha="$payload_sha"
+            else
+              # Auto event paths: skipping is safe — the same
+              # Copilot review/comment that fired this run will
+              # re-fire on the next cron tick / re-request, so
+              # cron / a fresh Copilot review will eventually
+              # drive this PR forward without us posting a
+              # possibly-stale trigger now.
+              echo "::warning::PR #$PR_NUMBER: gh pr view --json headRefOid failed on auto event path — skipping @claude trigger (will be re-driven by cron / next Copilot review)"
+              exit 0
+            fi
           fi
           if [ -z "$current_sha" ] || [ "${#current_sha}" -lt 40 ]; then
             echo "::warning::missing/short current PR HEAD '$current_sha' — skip @claude trigger"
@@ -156,12 +177,14 @@ jobs:
               echo "stale label event: payload HEAD=$payload_sha, current HEAD=$current_sha — proceeding with current HEAD (manual label path: no newer event will reach this workflow)"
             else
               # Auto event paths (`pull_request_review` /
-              # `pull_request_review_comment`): a newer push triggers
-              # a fresh review/comment event that will reach this
-              # workflow with the up-to-date HEAD, so it's safe (and
-              # correct) to skip this stale-SHA run rather than post
-              # a duplicate trigger.
-              echo "stale auto event: payload HEAD=$payload_sha, current HEAD=$current_sha — skip @claude trigger (newer event will handle current HEAD)"
+              # `pull_request_review_comment`): a fresh Copilot
+              # review/comment for the newer HEAD will fire its
+              # own event reaching this workflow with the up-to-
+              # date HEAD; if Copilot does NOT re-review, the
+              # cron fallback in `copilot-clean-label.yml` covers
+              # this PR within ~30–60 min. Either way, skipping
+              # this stale-SHA run is correct.
+              echo "stale auto event: payload HEAD=$payload_sha, current HEAD=$current_sha — skip @claude trigger (newer Copilot review/comment for current HEAD will fire its own event, otherwise cron fallback handles within ~30–60 min)"
               exit 0
             fi
           fi

--- a/.github/workflows/copilot-review-fix.yml
+++ b/.github/workflows/copilot-review-fix.yml
@@ -13,7 +13,7 @@ on:
   # tick" so cron only resumes on the tick after, ≈60 min later).
   #
   # Multiple events for the same PR are deduped by the marker-based check
-  # below (`already_triggered` / `local_in_progress` jq passes), so the
+  # below (`already` / `local_in_progress` jq passes), so the
   # concurrency group below uses `cancel-in-progress: false` and lets
   # queued events run sequentially.
   pull_request_review:
@@ -35,7 +35,7 @@ jobs:
       # before its first step removes the `copilot-review` label,
       # leaving the label stuck on the PR. Re-adding an already-present
       # label fires no event, so the manual retry path breaks. Marker-
-      # based dedup later in the job (`already_triggered` /
+      # based dedup later in the job (`already` /
       # `local_in_progress`) already prevents duplicate `@claude` posts,
       # so queueing is the safe choice.
       cancel-in-progress: false
@@ -119,6 +119,34 @@ jobs:
           # has no TTL (HEAD-scoped, cleared by next push). Same semantics
           # as the cron path in copilot-clean-label.yml.
           LOCAL_MARKER_MAX_AGE_MIN=30
+
+          # Refresh HEAD_SHA at runtime, not from the event payload.
+          # `cancel-in-progress: false` (above) means an older queued
+          # event can run after a newer push has advanced the PR HEAD;
+          # the payload-derived `github.event.pull_request.head.sha`
+          # would then post a marker / `@claude` trigger keyed to a
+          # stale SHA, while the cron / event-driven dedup looks up
+          # the current SHA and would still post a duplicate trigger
+          # for the newer HEAD. Read the current PR HEAD via
+          # `gh pr view` and exit early if the payload SHA no longer
+          # matches it (the newer event will run separately and
+          # handle the current HEAD). Fail-closed on `gh pr view`
+          # error: skipping is safer than posting a possibly-stale
+          # trigger.
+          payload_sha="${HEAD_SHA:-}"
+          if ! current_sha=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json headRefOid --jq '.headRefOid'); then
+            echo "::warning::PR #$PR_NUMBER: gh pr view --json headRefOid failed — skipping @claude trigger (will be re-driven by cron / next event)"
+            exit 0
+          fi
+          if [ -z "$current_sha" ] || [ "${#current_sha}" -lt 40 ]; then
+            echo "::warning::missing/short current PR HEAD '$current_sha' — skip @claude trigger"
+            exit 0
+          fi
+          if [ -n "$payload_sha" ] && [ "$payload_sha" != "$current_sha" ]; then
+            echo "stale event: payload HEAD=$payload_sha, current HEAD=$current_sha — skip @claude trigger (newer event will handle current HEAD)"
+            exit 0
+          fi
+          HEAD_SHA="$current_sha"
           if [ -z "${HEAD_SHA:-}" ] || [ "${#HEAD_SHA}" -lt 40 ]; then
             echo "::warning::missing/short HEAD_SHA '$HEAD_SHA' — skip @claude trigger"
             exit 0

--- a/.github/workflows/copilot-review-fix.yml
+++ b/.github/workflows/copilot-review-fix.yml
@@ -143,8 +143,27 @@ jobs:
             exit 0
           fi
           if [ -n "$payload_sha" ] && [ "$payload_sha" != "$current_sha" ]; then
-            echo "stale event: payload HEAD=$payload_sha, current HEAD=$current_sha — skip @claude trigger (newer event will handle current HEAD)"
-            exit 0
+            if [ "${GITHUB_EVENT_NAME:-}" = "pull_request" ]; then
+              # Manual label path: the operator already chose to
+              # engage CI by attaching `copilot-review`, and the
+              # label-add event has already been consumed (the
+              # earlier "Remove copilot-review label if present"
+              # step ate the label). No newer event will reach this
+              # workflow on this label-add, so a stale-SHA exit
+              # here would be a silent no-op (label removed, no CI
+              # run, no feedback comment for the operator). Proceed
+              # using the current HEAD instead.
+              echo "stale label event: payload HEAD=$payload_sha, current HEAD=$current_sha — proceeding with current HEAD (manual label path: no newer event will reach this workflow)"
+            else
+              # Auto event paths (`pull_request_review` /
+              # `pull_request_review_comment`): a newer push triggers
+              # a fresh review/comment event that will reach this
+              # workflow with the up-to-date HEAD, so it's safe (and
+              # correct) to skip this stale-SHA run rather than post
+              # a duplicate trigger.
+              echo "stale auto event: payload HEAD=$payload_sha, current HEAD=$current_sha — skip @claude trigger (newer event will handle current HEAD)"
+              exit 0
+            fi
           fi
           HEAD_SHA="$current_sha"
           if [ -z "${HEAD_SHA:-}" ] || [ "${#HEAD_SHA}" -lt 40 ]; then

--- a/.github/workflows/copilot-review-fix.yml
+++ b/.github/workflows/copilot-review-fix.yml
@@ -8,9 +8,12 @@ on:
   # (created) events are unreliable for the Copilot bot due to the agentic
   # architecture's GITHUB_TOKEN-driven event suppression. They are still listened
   # for as a best-effort fast path; the cron-driven fallback in
-  # `copilot-clean-label.yml` covers the suppressed cases within ~30–60 min
-  # (cron fires every 30 minutes, worst case is "marker posted just after a
-  # tick" so cron only resumes on the tick after, ≈60 min later).
+  # `copilot-clean-label.yml` runs every 30 minutes, so:
+  #   - suppressed-event recovery: ≤30 min worst case (next tick fires).
+  #   - local-marker TTL recovery: 30–60 min worst case (a fresh
+  #     `copilot-fix-local:<HEAD>` marker may cause the first tick to
+  #     skip; the next tick is needed to resume — see the marker
+  #     freshness check in `copilot-clean-label.yml`).
   #
   # Multiple events for the same PR are deduped by the marker-based check
   # below (`already` / `local_in_progress` jq passes), so the
@@ -128,11 +131,41 @@ jobs:
           # stale SHA, while the cron / event-driven dedup looks up
           # the current SHA and would still post a duplicate trigger
           # for the newer HEAD. Read the current PR HEAD via
-          # `gh pr view` and exit early if the payload SHA no longer
-          # matches it (the newer event will run separately and
-          # handle the current HEAD). Fail-closed on `gh pr view`
-          # error: skipping is safer than posting a possibly-stale
-          # trigger.
+          # `gh pr view` and branch by event type:
+          #
+          #   AUTO event paths (`pull_request_review` /
+          #   `pull_request_review_comment`):
+          #     - on `gh pr view` error: fail-CLOSED (exit 0). The
+          #       same Copilot review/comment that fired this run
+          #       will re-fire on the next cron tick / re-request,
+          #       so cron / a fresh Copilot review will eventually
+          #       drive the PR forward without us posting a
+          #       possibly-stale trigger now.
+          #     - on payload-vs-current SHA mismatch: exit early. A
+          #       fresh Copilot review/comment for the newer HEAD
+          #       will fire its own event reaching this workflow,
+          #       and if Copilot does NOT re-review, the cron
+          #       fallback covers within ~30–60 min.
+          #
+          #   MANUAL label path (`pull_request` event):
+          #     - on `gh pr view` error: fail-OPEN (fall back to
+          #       payload SHA and proceed). The earlier step has
+          #       already removed `copilot-review`, so a silent
+          #       exit would leave the operator with no CI run and
+          #       no feedback comment. Note: the manual label path
+          #       intentionally bypasses both `already` /
+          #       `local_in_progress` dedup checks below (escape
+          #       hatch semantics), so this fallback may post a
+          #       trigger keyed to a stale SHA — that is the
+          #       documented trade-off for keeping the retry path
+          #       actionable. Operator can re-attach the label
+          #       (after manually removing it) once the API
+          #       recovers if the stale-SHA trigger is unwanted.
+          #     - on payload-vs-current SHA mismatch: proceed using
+          #       the current SHA (no newer label-add event will
+          #       reach this workflow because the label-add event
+          #       has been consumed by the earlier remove step;
+          #       skipping would silently no-op).
           payload_sha="${HEAD_SHA:-}"
           current_sha=""
           if ! current_sha=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json headRefOid --jq '.headRefOid'); then
@@ -142,10 +175,14 @@ jobs:
               # removed `copilot-review`, so an exit here would be
               # a silent no-op (no `@claude` trigger, no PR
               # feedback). Fall back to the payload SHA and
-              # proceed; if the payload SHA was stale, the marker
-              # dedup further down will skip cleanly. The operator
-              # gets a CI run for what we can verify (payload
-              # HEAD), which is better than nothing.
+              # proceed. The operator gets a CI run for what we
+              # can verify (payload HEAD), which is better than
+              # nothing. (The manual label path bypasses the
+              # `already` / `local_in_progress` dedup further
+              # down — see "Manual label path bypasses both
+              # suppressions" below — so this fallback may post a
+              # trigger keyed to a stale SHA. Documented trade-off
+              # for keeping the retry path actionable.)
               echo "::warning::PR #$PR_NUMBER: gh pr view --json headRefOid failed on manual label path — falling back to payload HEAD ($payload_sha) and proceeding (label was already removed; silent exit would break the manual retry path)"
               current_sha="$payload_sha"
             else


### PR DESCRIPTION
## Summary

Two Copilot-flagged bugs in `copilot-review-fix.yml` (caught on the parallel vuls-reach back-port [vuls-saas/vuls-reach#22](https://github.com/vuls-saas/vuls-reach/pull/22)). The same bugs exist verbatim in this OSS copy and in catalog post-#223 (which is already merged — separate fix PR will follow there).

1. **Stale "~5 min" cron-fallback claim**: comment said "covers suppressed cases within ~5 min" but `copilot-clean-label.yml` actually uses `*/30` (cron fires every 30 minutes, worst case ~60 min — marker posted just after a tick stays fresh on the next tick). Updated to match the documented 30–60 min recovery window used elsewhere.
2. **`cancel-in-progress: true` race with label removal**: the first step on the labeled-PR path is "Remove copilot-review label if present" (so the label acts as a single-shot trigger). With `cancel-in-progress: true`, a new Copilot review/comment event for the same PR cancels the label-triggered run before that first step completes, leaving the label stuck on the PR. Re-adding an already-present label fires no event, so the manual retry path silently breaks. Switched to `cancel-in-progress: false` so queued events run sequentially; the marker-based dedup later in the job (`already_triggered` / `local_in_progress` jq passes) already prevents duplicate `@claude` posts, so queueing is the safe choice.

## Test plan

- [ ] `actionlint` clean (verified: exit 0).
- [ ] Same fix landed in vuls-reach #22 (commit `821e3da`).
- [ ] Catalog follow-up PR opened separately (catalog #223 merged before this issue surfaced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)