### PR TITLE
docs(skill): harden Phase B exit criteria with explicit 4-condition checklist

### DIFF
--- a/.github/prompts/review-until-clean.prompt.md
+++ b/.github/prompts/review-until-clean.prompt.md
@@ -446,6 +446,17 @@ PHASE_C_OK=0                     # fail-safe default; Step 11.5 verification fli
 
 ### Step 8: Copilot review iteration loop (max 5 rounds)
 
+**Phase B exit criteria — DO NOT MISREAD.** Step 8.2 below is the only authoritative path that exits Phase B with `PHASE_B_EXIT_REASON=B_CLEAN`. A common operator mistake is to look at "unresolved Copilot thread count == 0" (a Phase C / GraphQL `reviewThreads` query) and conclude the loop is done — that is **wrong**. Thread-resolved count is a Phase C verification metric (Step 11.5); it does not reflect whether Copilot has yet re-reviewed the latest pushed HEAD. The four-condition Phase B exit checklist (formalizing Step 8.2's branches) is:
+
+1. **`HEAD_SHA` captured** for the latest commit on the branch (`git rev-parse HEAD` after the most recent push).
+2. **Latest Copilot review fetched** for the PR (Step 8.1's `latest`).
+3. **`review_commit == HEAD_SHA`** — the review is for the current HEAD, not a stale earlier commit. (If not, state is `pending` → Step 8.3.)
+4. **`review_body =~ /generated no( new)? comments/i`** — Copilot itself declared the PR clean for this HEAD.
+
+ALL four must be true to flip `PHASE_B_EXIT_REASON=B_CLEAN` and exit to Phase C. If 1-3 hold but condition 4 fails, the state is `dirty` → Step 8.4 (fix cycle). If condition 3 fails, the state is `pending` → Step 8.3 (wait + re-request). Do **not** infer Phase B done from `unresolved_thread_count == 0` alone — that count can be 0 between rounds (after Phase C of the previous round resolved everything) while Copilot has not yet re-reviewed the new HEAD; exiting on that signal is how round-N regressions slip through.
+
+When relaying state to the user mid-loop ("is the PR clean yet?"), re-run the four conditions every time — do **not** trust an earlier "clean" conclusion across a push, because a push invalidates condition 3.
+
 At each round entry, **heartbeat the marker**:
 
 ```bash


### PR DESCRIPTION
## Summary

Add a "Phase B exit criteria — DO NOT MISREAD" preamble to Step 8 of `.github/prompts/review-until-clean.prompt.md` that formalizes the four conditions Step 8.2 already checks:

1. `HEAD_SHA` captured for the latest commit
2. Latest Copilot review fetched
3. `review_commit == HEAD_SHA` (review is for the current HEAD, not a stale earlier commit)
4. `review_body =~ /generated no( new)? comments/i`

Plus the rule: when relaying state to the user mid-loop, re-run all four every time (a push invalidates condition 3).

## Why

During the recent catalog #225 / oss #379 / vuls-reach #23 review iterations, the operator mistake "unresolved Copilot thread count == 0 → declare Phase B done" recurred several times. That count is a Phase C (Step 11.5) verification metric and goes to 0 right after Phase C resolves the previous round's threads — but Copilot may not yet have re-reviewed the latest pushed HEAD. Exiting on the thread-count signal lets round-N regressions slip through, forcing the user to point out "ループまだ終わってない" ("the loop hasn't finished").

The four-condition checklist is exactly what Step 8.2's branching table already encodes; this PR just hoists it into prose so an operator skimming the section can't miss it.

## Cross-repo

This same diff (11 lines, identical wording) is being added to:
- catalog (this PR — canonical)
- oss
- vuls-reach

via separate fix PRs to keep all three skill prompts aligned.

## Test plan

- [ ] No code-flow change; verify only prose addition (Step 8 unchanged otherwise).
- [ ] Skill operator (me) follows the new checklist on the next /review-until-clean invocation.
- [ ] Memory rule `feedback_review_until_clean_phase_b_exit.md` already enforces the same check at the operator level; the prompt change makes it explicit in the canonical procedure too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)