### PR TITLE
feat(claude): plan-mode architect-consultation soft reminder

### DIFF
--- a/.claude/hooks/plan-mode-architect-check.sh
+++ b/.claude/hooks/plan-mode-architect-check.sh
@@ -65,11 +65,12 @@ if [ "$JQ_EXIT" -eq 0 ] || [ -n "$JQ_STDERR" ]; then
   exit 0
 fi
 
-USER_MSG='ExitPlanMode without consulting the architect subagent. If this plan touches DDD layer placement, repository interfaces, or cross-layer boundaries, consider consulting architect first. Trivial fixes can ignore.'
-MODEL_CTX='REMINDER: no architect subagent tool-use found in this session before ExitPlanMode. If this plan involves DDD layer placement (domain / application / infrastructure / interfaces), repository interface design, or cross-layer concerns, consult the architect subagent before exiting plan mode. Trivial fixes (typo, comment, single-file refactor, simple flag addition) can ignore.'
+REMINDER='REMINDER: no architect subagent tool-use found in this session before ExitPlanMode. If this plan involves DDD layer placement (domain / application / infrastructure / interfaces), repository interface design, or cross-layer concerns, consult the architect subagent before exiting plan mode. Trivial fixes (typo, comment, single-file refactor, simple flag addition) can ignore.'
 
-# Emit the reminder JSON. If jq fails for any reason, still exit 0 to
-# preserve the soft-reminder contract — silent allow is preferable to a
-# blocked ExitPlanMode.
-jq -nc --arg msg "$USER_MSG" --arg ctx "$MODEL_CTX" \
-  '{systemMessage: $msg, hookSpecificOutput: {hookEventName: "PreToolUse", additionalContext: $ctx}}' || true
+# Emit the reminder JSON. Match the output schema used by other PreToolUse
+# hooks in this repo (hookSpecificOutput.additionalContext only — no
+# systemMessage). If jq fails for any reason, still exit 0 to preserve
+# the soft-reminder contract — silent allow is preferable to a blocked
+# ExitPlanMode.
+jq -nc --arg ctx "$REMINDER" \
+  '{"hookSpecificOutput": {"hookEventName": "PreToolUse", "additionalContext": $ctx}}' || true

--- a/.claude/hooks/plan-mode-architect-check.sh
+++ b/.claude/hooks/plan-mode-architect-check.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Plan-mode architect-consultation soft reminder.
+#
+# WHY: plan-mode work that affects DDD layer placement (domain /
+# application / infrastructure / interfaces), repository interfaces,
+# or cross-layer boundaries should consult the architect subagent
+# before exiting plan mode. This hook nudges — it always allows
+# ExitPlanMode and emits a reminder when no genuine architect tool-use
+# record is found in the session transcript. Trivial fixes can ignore.
+#
+# Detection scope: the entire session transcript (jq scans every JSONL
+# record for a tool_use object whose name == "Task" and
+# input.subagent_type == "architect"). If architect was consulted earlier
+# in the same session for an unrelated topic, this hook stays silent for
+# the next ExitPlanMode — acceptable for a soft nudge.
+#
+# Requires: jq.
+set -euo pipefail
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+# Extract transcript_path from stdin JSON. If stdin isn't valid JSON
+# (jq parse error) or the field is missing, treat it as "no transcript"
+# and silently allow — this hook is fail-open by design.
+TRANSCRIPT=$(jq -r '.transcript_path // empty' 2>/dev/null || true)
+
+if [ -z "$TRANSCRIPT" ] || [ ! -f "$TRANSCRIPT" ]; then
+  exit 0
+fi
+
+# Scan transcript for an architect Task tool_use record. Recurse into
+# nested objects with `..|objects` so we find the tool_use block
+# regardless of envelope shape, then match strictly on the three fields
+# together. This deliberately excludes prose mentions of the pattern
+# (rule-doc text, this hook's own additionalContext echoed in a prior
+# turn) — only a real Task tool invocation counts.
+#
+# `any(inputs | ..|objects; cond)` streams JSONL via `inputs` and
+# short-circuits as soon as it finds a tool_use record whose name is
+# `Task` and input.subagent_type is `architect` — does NOT walk the
+# whole transcript. With `-e`: outputs `true` and exits 0 on match,
+# `false` and exits 1 on no match, and prints to stderr on parse / I/O
+# error.
+#
+# `2>&1 1>/dev/null`: redirect jq's stderr into the $() capture (same
+# target as stdout at that point), then send stdout to /dev/null. Net:
+# stderr lands in $JQ_STDERR, stdout discarded. No temp file needed —
+# avoids a `mktemp` failure path that would break fail-open.
+set +e
+JQ_STDERR=$(jq -n -e '
+  any(
+    inputs | ..|objects;
+    (.type? == "tool_use") and
+    (.name? == "Task") and
+    (.input?.subagent_type? == "architect")
+  )
+' < "$TRANSCRIPT" 2>&1 1>/dev/null)
+JQ_EXIT=$?
+set -e
+
+# Match (exit 0) OR any jq stderr (parse / I/O error) → silent allow.
+# Only a clean "no match" (exit 1, empty stderr) falls through to
+# emit the reminder.
+if [ "$JQ_EXIT" -eq 0 ] || [ -n "$JQ_STDERR" ]; then
+  exit 0
+fi
+
+USER_MSG='ExitPlanMode without consulting the architect subagent. If this plan touches DDD layer placement, repository interfaces, or cross-layer boundaries, consider consulting architect first. Trivial fixes can ignore.'
+MODEL_CTX='REMINDER: no architect subagent tool-use found in this session before ExitPlanMode. If this plan involves DDD layer placement (domain / application / infrastructure / interfaces), repository interface design, or cross-layer concerns, consult the architect subagent before exiting plan mode. Trivial fixes (typo, comment, single-file refactor, simple flag addition) can ignore.'
+
+# Emit the reminder JSON. If jq fails for any reason, still exit 0 to
+# preserve the soft-reminder contract — silent allow is preferable to a
+# blocked ExitPlanMode.
+jq -nc --arg msg "$USER_MSG" --arg ctx "$MODEL_CTX" \
+  '{systemMessage: $msg, hookSpecificOutput: {hookEventName: "PreToolUse", additionalContext: $ctx}}' || true

--- a/.claude/rules/agents.md
+++ b/.claude/rules/agents.md
@@ -40,7 +40,20 @@ Task(subagent_type="general-purpose", prompt="...")     # generic agent + freefo
 No user prompt needed:
 1. Complex feature requests - Use **planner** agent
 2. Code just written/modified - Use **code-reviewer** agent
-3. Architectural decision - Use **architect** agent
+3. Architectural decision - Use **architect** agent (on plan-mode entry, launch **planner + architect** in parallel by default — see "Plan Mode Default Behavior" below)
+
+## Plan Mode Default Behavior
+
+**The default action when entering plan mode is to launch `planner + architect` in parallel in a single message.** Proactive, not reactive ("I'll only call architect if architectural judgment seems needed" is the wrong default).
+
+```
+# Default action right after entering plan mode
+Task(subagent_type="planner", prompt="...")  +  Task(subagent_type="architect", prompt="...")
+```
+
+The only case where skipping is acceptable: **trivial fixes** (typo, comment, single-file refactor, simple flag addition, etc. with no DDD layer placement, repository interface, or cross-layer concerns). When in doubt, launch — calling unnecessarily is safer than not calling when needed.
+
+A `PreToolUse` hook (`.claude/hooks/plan-mode-architect-check.sh`) detects missing architect consultation on `ExitPlanMode` and emits a soft reminder. It is advisory only — `ExitPlanMode` itself is always allowed (never blocked). If the reminder fires, ignore it only if you can immediately answer "this was trivial"; otherwise, consult the architect subagent and re-propose the plan before user approval.
 
 ## Code Review Policy
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,6 +2,17 @@
   "hooks": {
     "PreToolUse": [
       {
+        "matcher": "ExitPlanMode",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/plan-mode-architect-check.sh",
+            "timeout": 10,
+            "statusMessage": "Checking architect consultation..."
+          }
+        ]
+      },
+      {
         "matcher": "Bash",
         "hooks": [
           {

--- a/.github/instructions/agent-orchestration.instructions.md
+++ b/.github/instructions/agent-orchestration.instructions.md
@@ -38,7 +38,20 @@ Task(subagent_type="general-purpose", prompt="...")     # generic agent + freefo
 No user prompt needed:
 1. Complex feature requests - Use **planner** agent
 2. Code just written/modified - Use **code-reviewer** agent
-3. Architectural decision - Use **architect** agent
+3. Architectural decision - Use **architect** agent (on plan-mode entry, launch **planner + architect** in parallel by default — see "Plan Mode Default Behavior" below)
+
+## Plan Mode Default Behavior
+
+**The default action when entering plan mode is to launch `planner + architect` in parallel in a single message.** Proactive, not reactive ("I'll only call architect if architectural judgment seems needed" is the wrong default).
+
+```
+# Default action right after entering plan mode
+Task(subagent_type="planner", prompt="...")  +  Task(subagent_type="architect", prompt="...")
+```
+
+The only case where skipping is acceptable: **trivial fixes** (typo, comment, single-file refactor, simple flag addition, etc. with no DDD layer placement, repository interface, or cross-layer concerns). When in doubt, launch — calling unnecessarily is safer than not calling when needed.
+
+A `PreToolUse` hook (`.claude/hooks/plan-mode-architect-check.sh`) detects missing architect consultation on `ExitPlanMode` and emits a soft reminder. It is advisory only — `ExitPlanMode` itself is always allowed (never blocked). If the reminder fires, ignore it only if you can immediately answer "this was trivial"; otherwise, consult the architect subagent and re-propose the plan before user approval.
 
 ## Code Review Policy
 


### PR DESCRIPTION
## Summary

Migration of [vuls-saas/vuls-reach#39](https://github.com/vuls-saas/vuls-reach/pull/39) — adds a `PreToolUse:ExitPlanMode` hook that scans the session transcript for a real `Task` tool_use with `subagent_type=architect`. If none is found, emits a **soft reminder** (advisory only — `ExitPlanMode` is never blocked). Trivial fixes can ignore.

- Add `.claude/hooks/plan-mode-architect-check.sh` — jq-only, fail-open. `command -v jq >/dev/null || exit 0` guard means jq-absent environments silently allow.
- Detection uses `jq -n -e 'any(inputs | ..|objects; cond)'` — streams JSONL lazily and short-circuits at first match. Excludes prose mentions (rule-doc text, hook's own additionalContext echoed in a prior turn) — only a real Task tool invocation counts.
- Stderr/stdout discrimination via `$(jq ... 2>&1 1>/dev/null)`: any jq error → silent allow; only clean `no-match` (exit 1, empty stderr) emits the reminder.
- Register the hook in `.claude/settings.json` under `PreToolUse:ExitPlanMode`.
- Add **"Plan Mode Default Behavior"** section to `.github/instructions/agent-orchestration.instructions.md` — default action on entering plan mode is `planner + architect` in parallel. Cross-reference from `Immediate Agent Usage #3`. Sync to `.claude/rules/agents.md` via `make sync-instructions`.

## Why migrate

vuls-reach landed this in #39 to nudge architect consultation on non-trivial plans. The same dynamic applies here — DDD layer placement / repository interfaces / cross-layer concerns benefit from architect input, but reactive triage tends to skip it. A soft reminder lets trivial fixes pass while flagging non-trivial ones.

## Adapted for this repo

The reminder text from vuls-reach's hexagonal terminology ("layer 配置 / port 設計 / hexagonal 判断") was rewritten in English for **DDD** terminology ("DDD layer placement, repository interfaces, cross-layer boundaries"). Functional behavior is identical to PR #39.

## Test plan

- [x] hook unit pipe-test 4 cases: no transcript / real architect tool_use / prose mention only / different subagent — all behaved as expected (cases 1+2 silent allow, cases 3+4 emit reminder JSON)
- [x] jq-absence guard: `PATH=/tmp/no-jq-bin` → exit 0 silent allow
- [x] `jq .` on `.claude/settings.json` — valid
- [x] hook reminder JSON validates as JSON
- [x] `make sync-instructions` regenerated `.claude/rules/agents.md` from canonical
- [ ] reviewer opens `/hooks` locally and confirms hook is recognized
- [ ] reviewer enters plan mode without consulting architect, calls `ExitPlanMode` → reminder appears
- [ ] reviewer calls `Task(subagent_type="architect", ...)`, then `ExitPlanMode` → no reminder

## Notes

- `.claude/settings.json` is team-shared (project-level); merge applies to all contributors.
- Detection scope is the **entire session transcript** (per-plan tracking is out of scope) — if architect was consulted earlier in the same session for an unrelated topic, this hook stays silent. Acceptable for a soft nudge; documented in the hook's WHY block.
- No Go source changes; no godoc/README sync required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)