### PR TITLE
feat(skill): force re-review on no-fix round + apply copilot-clean label

### DIFF
--- a/.github/prompts/review-until-clean.prompt.md
+++ b/.github/prompts/review-until-clean.prompt.md
@@ -747,8 +747,8 @@ Step 8.4.5 forces Copilot to adjudicate on the same HEAD before exit:
 
 ```bash
 # 1. Snapshot the current set of unresolved Copilot thread CIDs as the
-#    "previously seen" baseline. Step 3 below distinguishes 3c (any new
-#    CID) from 3b (every CID is in this set). The
+#    "previously seen" baseline. The classification block below (step 4)
+#    distinguishes 3c (any new CID) from 3b (every CID is in this set). The
 #    `... || PRIOR_THREAD_CIDS=""` guard handles the empty-input case
 #    (e.g., the prior fetch returned no nodes): under
 #    `set -euo pipefail` a bare jq parse error here would abort Step

--- a/.github/prompts/review-until-clean.prompt.md
+++ b/.github/prompts/review-until-clean.prompt.md
@@ -915,7 +915,10 @@ done
 #    matters: clean phrase wins over thread-set comparison so that
 #    even if Copilot re-flagged something but ALSO declared
 #    `generated no new comments`, we treat it as 3a verified.
-new_body=$(printf '%s' "$latest_new" | jq -r '.body // ""')
+# Same `2>/dev/null) || …=""` guard as the other jq extractions in this
+# step: a parse error on empty/null `$latest_new` would abort under
+# `set -euo pipefail` and skip the timeout → B_ABORTED branch below.
+new_body=$(printf '%s' "$latest_new" | jq -r '.body // ""' 2>/dev/null) || new_body=""
 if [ "$new_id" = "$PRIOR_REVIEW_ID" ] || [ "$new_commit" != "$HEAD_SHA" ]; then
     # 5-min timeout reached without a fresh review on the current HEAD.
     # Treat as B_ABORTED — cron will retry on its next tick and may
@@ -931,6 +934,12 @@ elif printf '%s' "$new_body" | grep -qiE 'generated no( new)? comments'; then
 else
     # Fetch the post-re-review thread CIDs and compare against the
     # baseline. Any CID not in PRIOR_THREAD_CIDS is a new finding ⇒ 3c.
+    # Guard the `gh api` like the other Step 8.4.5 calls: a transient
+    # 5xx / rate limit / network failure under `set -euo pipefail`
+    # would abort the whole procedure and skip the intended marker
+    # cleanup. On failure, fall through with an empty `threads_new`,
+    # which the new_cids extraction (next block) handles via its own
+    # `|| new_cids=""` guard ⇒ has_new_finding=0 ⇒ 3b operator-clean.
     threads_new=$(gh api graphql --paginate \
         -F owner="$OWNER" -F repo="$REPO" -F pr="$PR" \
         -f query='
@@ -950,7 +959,7 @@ else
       }
     }' --jq '.data.repository.pullRequest.reviewThreads.nodes[]
         | select(.isResolved == false
-            and .comments.nodes[0].author.login == "copilot-pull-request-reviewer")')
+            and .comments.nodes[0].author.login == "copilot-pull-request-reviewer")' 2>/dev/null) || threads_new=""
     # Same `|| ""` guard as PRIOR_THREAD_CIDS extraction at the top of
     # Step 8.4.5: a bare jq parse error on empty `$threads_new` would
     # abort under `set -euo pipefail`, masking the 3b operator-clean

--- a/.github/prompts/review-until-clean.prompt.md
+++ b/.github/prompts/review-until-clean.prompt.md
@@ -529,7 +529,7 @@ PHASE_C_OK=0                     # fail-safe default; Step 11.5 verification fli
 |---|---|---|---|
 | `B_CLEAN_VERIFIED` | Copilot itself reported `generated no (new) comments` for the current HEAD (either via Step 8.2's clean path on a fix-cycle round, or via Step 8.4.5's forced re-review after a WONT_FIX-only round). | **Apply** in Step 11.9 (when `PHASE_C_OK=1`). | `mark_local_converged` |
 | `B_CLEAN_OPERATOR` | All threads are WONT_FIX/ALREADY_FIXED so the operator considers the PR clean, but Copilot's forced re-review (Step 8.4.5) re-emitted the same set of threads (cross-round consensus = false-positive confirmed). Operator-judged clean only. | **Do not apply** — Copilot still disagrees, so the literal label semantic is unmet. | `mark_local_converged` (still suppress cron from re-running the same WONT_FIX pass) |
-| `B_ABORTED` | Phase B did not converge (max rounds, unrecoverable build failure, push reject after rebase, Step 8.4.5 surfaced new findings that exhausted the round budget, etc.). | **Do not apply** (and remove if previously set, although the cron `copilot-clean-label.yml`'s `synchronize`/`dirty` paths handle that on the next event). | `delete_local_marker` (let cron retry) |
+| `B_ABORTED` | Phase B did not converge (max rounds, unrecoverable build failure, push reject after rebase, Step 8.4.5 surfaced new findings that exhausted the round budget, etc.). | **Do not apply.** The skill does NOT remove an existing label here — that strip is owned by `copilot-clean-label.yml` (its `synchronize`/`dirty`/`pending` paths on the next event tick) so a redundant skill-side strip would just double-fire the API call. | `delete_local_marker` (let cron retry) |
 
 `PHASE_C_OK` is a separate fail-safe flag from `PHASE_B_EXIT_REASON` because Phase B can converge clean (`B_CLEAN_VERIFIED` / `B_CLEAN_OPERATOR`) yet Phase C can still fail mid-way (rate-limited reply, permission error, network partition during the resolve mutation). Without this flag the Step 11.9 if/else gate would mark the marker `converged` even though some FIX / ALREADY_FIXED threads were never replied to or resolved, permanently suppressing cron on a HEAD that still has unresolved Copilot threads. The gate requires **both** a `B_CLEAN_*` exit AND `PHASE_C_OK=1` before flipping to the converged marker form (and additionally requires `B_CLEAN_VERIFIED` before applying the `copilot-clean` label).
 
@@ -760,7 +760,7 @@ PRIOR_THREAD_CIDS=$(printf '%s' "$threads" | jq -r '
 #    entire reviewer set. We must first query current reviewers and replay
 #    humans + teams, omitting only bots — otherwise all human/team review
 #    requests are silently dropped. This mirrors the safe pattern in
-#    copilot-clean-label.yml (search: "query current reviewers").
+#    copilot-clean-label.yml (search: "reviewer_query_ok").
 PR_NID=$(gh api graphql -F owner="$OWNER" -F repo="$REPO" -F pr="$PR" \
     -f query='query($owner:String!,$repo:String!,$pr:Int!){
       repository(owner:$owner,name:$repo){ pullRequest(number:$pr){ id } } }' \
@@ -934,12 +934,16 @@ elif printf '%s' "$new_body" | grep -qiE 'generated no( new)? comments'; then
 else
     # Fetch the post-re-review thread CIDs and compare against the
     # baseline. Any CID not in PRIOR_THREAD_CIDS is a new finding ⇒ 3c.
-    # Guard the `gh api` like the other Step 8.4.5 calls: a transient
-    # 5xx / rate limit / network failure under `set -euo pipefail`
-    # would abort the whole procedure and skip the intended marker
-    # cleanup. On failure, fall through with an empty `threads_new`,
-    # which the new_cids extraction (next block) handles via its own
-    # `|| new_cids=""` guard ⇒ has_new_finding=0 ⇒ 3b operator-clean.
+    # Guard the `gh api` like the other Step 8.4.5 calls so a transient
+    # 5xx / rate limit / network failure does not abort the whole
+    # procedure under `set -euo pipefail`. CRITICAL: a fetch failure
+    # (`threads_new_fetch_ok=0`) is NOT the same as "Copilot returned
+    # no threads" — falling through to `threads_new=""` would
+    # incorrectly flip to 3b `B_CLEAN_OPERATOR` and suppress further
+    # rounds, when the right behaviour is to exit `B_ABORTED` so cron
+    # retries the pipeline. The flag below distinguishes the two
+    # outcomes for the classification block at the bottom of step 4.
+    threads_new_fetch_ok=1
     threads_new=$(gh api graphql --paginate \
         -F owner="$OWNER" -F repo="$REPO" -F pr="$PR" \
         -f query='
@@ -959,7 +963,12 @@ else
       }
     }' --jq '.data.repository.pullRequest.reviewThreads.nodes[]
         | select(.isResolved == false
-            and .comments.nodes[0].author.login == "copilot-pull-request-reviewer")' 2>/dev/null) || threads_new=""
+            and .comments.nodes[0].author.login == "copilot-pull-request-reviewer")' 2>/dev/null) || { threads_new_fetch_ok=0; threads_new=""; }
+    if [ "$threads_new_fetch_ok" = "0" ]; then
+        echo "::warning::Step 8.4.5: post-re-review thread fetch failed — exiting B_ABORTED (cron will retry)"
+        PHASE_B_EXIT_REASON="B_ABORTED"
+        break
+    fi
     # Same `|| ""` guard as PRIOR_THREAD_CIDS extraction at the top of
     # Step 8.4.5: a bare jq parse error on empty `$threads_new` would
     # abort under `set -euo pipefail`, masking the 3b operator-clean

--- a/.github/prompts/review-until-clean.prompt.md
+++ b/.github/prompts/review-until-clean.prompt.md
@@ -755,6 +755,15 @@ PR_NID=$(gh api graphql -F owner="$OWNER" -F repo="$REPO" -F pr="$PR" \
     PHASE_B_EXIT_REASON="B_ABORTED"
     break
 }
+# Copilot bot's GraphQL node ID. Same value defined as `COPILOT_BOT_ID`
+# env var in `.github/workflows/copilot-clean-label.yml` (search:
+# "COPILOT_BOT_ID:"). Hard-coded once here and reused by both the clear
+# and the re-add to keep this Step 8.4.5 self-contained for skill
+# agents. If the bot's node ID ever changes (the value has been stable
+# since GitHub assigned it; a change would also break the workflow's
+# env), update both this prompt and the workflow in the same commit.
+COPILOT_BOT_ID="BOT_kgDOCnlnWA"
+
 # Query current reviewer requests so the clear mutation preserves
 # humans + teams (removing only bots via empty botIds).
 reviewer_query=$(gh api graphql -F pr_nid="$PR_NID" \
@@ -765,13 +774,16 @@ reviewer_query=$(gh api graphql -F pr_nid="$PR_NID" \
         } } }
       } } }' 2>/dev/null) || true
 # Guard: if the reviewer query failed or returned unparseable data,
-# skip the clear entirely. With reviewer_nodes unknown, building
+# OR returned `.errors` (HTTP 200 partial-success), skip the clear
+# entirely. With reviewer_nodes unknown, building
 # users_json=[]/teams_json=[] and calling requestReviews(union:false)
 # would remove every human reviewer on the PR (same guard as
-# copilot-clean-label.yml `reviewer_query_ok` guard).
+# copilot-clean-label.yml `reviewer_query_ok` guard, plus the
+# partial-success `(.errors // []) | length > 0` check that workflow
+# also applies).
 reviewer_query_ok=0
 if [ -n "$reviewer_query" ] && printf '%s' "$reviewer_query" \
-    | jq -e '.data.node.reviewRequests' >/dev/null 2>&1; then
+    | jq -e '.data.node.reviewRequests and ((.errors // []) | length == 0)' >/dev/null 2>&1; then
     reviewer_query_ok=1
 fi
 if [ "$reviewer_query_ok" = "1" ]; then
@@ -788,11 +800,16 @@ if [ "$reviewer_query_ok" = "1" ]; then
         --arg pr "$PR_NID" --argjson users "$users_json" --argjson teams "$teams_json" \
         '{ query: "mutation($pr:ID!,$users:[ID!]!,$teams:[ID!]!){requestReviews(input:{pullRequestId:$pr, userIds:$users, teamIds:$teams, botIds:[], union:false}){pullRequest{id}}}",
            variables: {pr:$pr, users:$users, teams:$teams} }')
-    if ! printf '%s' "$clear_body" | gh api graphql --input - >/dev/null 2>&1; then
+    # Capture stdout so we can inspect `.errors[]` even on HTTP 200
+    # partial-success (gh exits 0 on this path, so a bare `|| ...`
+    # check would miss it; mirrors copilot-clean-label.yml).
+    if ! clear_out=$(printf '%s' "$clear_body" | gh api graphql --input - 2>/dev/null); then
         echo "::warning::Step 8.4.5: clear mutation failed — re-add may be deduped"
+    elif printf '%s' "$clear_out" | jq -e '(.errors // []) | length > 0' >/dev/null 2>&1; then
+        echo "::warning::Step 8.4.5: clear mutation returned errors (exit 0) — re-add may be deduped"
     fi
 else
-    echo "::warning::Step 8.4.5: reviewer query failed — skipping clear to preserve human reviewers; re-add may be deduped"
+    echo "::warning::Step 8.4.5: reviewer query failed or returned errors — skipping clear to preserve human reviewers; re-add may be deduped"
 fi
 sleep 2
 # Re-add Copilot as a fresh reviewer request.
@@ -801,7 +818,7 @@ mutation($pr: ID!, $bot: ID!) {
   requestReviews(input: { pullRequestId: $pr, botIds: [$bot] }) {
     pullRequest { id }
   }
-}' -F pr="$PR_NID" -F bot="BOT_kgDOCnlnWA" >/dev/null 2>&1; then
+}' -F pr="$PR_NID" -F bot="$COPILOT_BOT_ID" >/dev/null 2>&1; then
     echo "::warning::Step 8.4.5: re-add mutation failed — poll may timeout"
 fi
 

--- a/.github/prompts/review-until-clean.prompt.md
+++ b/.github/prompts/review-until-clean.prompt.md
@@ -674,8 +674,17 @@ A literal `requestReviews` retry without this clear+re-add will often fail to wa
        # fresh re-review on this HEAD and let Copilot adjudicate
        # (3a verified, 3b operator-only, 3c new findings).
        echo "no-fix round (all WONT_FIX/ALREADY_FIXED) — entering Step 8.4.5 forced re-review"
-       # Skill agent: proceed to Step 8.4.5 below, skipping sub-steps 5-6.
-       break  # exit the fix-cycle inner block; fall into Step 8.4.5
+       # Skill-agent control flow: this `break` is a SEMANTIC marker
+       # ("stop step 4 and proceed to Step 8.4.5"), not a literal Bash
+       # statement that would unwind a `for`/`while` loop. The skill is
+       # executed step-by-step by an LLM agent that interprets these
+       # control-flow keywords as transitions between numbered steps,
+       # not by a single shell session running the prompt as a script.
+       # If a future caller transcribes the snippet into a real script,
+       # they must wrap the round body in a `for`/`while` loop and
+       # promote this to a flag (e.g., `NO_FIX_ROUND=1`) that the loop
+       # body checks after Step 8.4.
+       break  # → fall into Step 8.4.5
    fi
    git commit -m "fix: address Copilot review on PR #$PR (round N)
 
@@ -765,12 +774,16 @@ PR_NID=$(gh api graphql -F owner="$OWNER" -F repo="$REPO" -F pr="$PR" \
 COPILOT_BOT_ID="BOT_kgDOCnlnWA"
 
 # Query current reviewer requests so the clear mutation preserves
-# humans + teams (removing only bots via empty botIds).
+# humans + teams (removing only bots via empty botIds). The query also
+# includes Bot.id so we can detect whether Copilot is currently in the
+# reviewer slot — when it is not, the clear mutation is unnecessary
+# (and would needlessly remove any other bot reviewers, mirroring
+# copilot-clean-label.yml's `copilot_present` skip).
 reviewer_query=$(gh api graphql -F pr_nid="$PR_NID" \
     -f query='query($pr_nid:ID!){
       node(id:$pr_nid){ ... on PullRequest {
         reviewRequests(first:100){ nodes { requestedReviewer {
-          __typename ... on User { id } ... on Team { id }
+          __typename ... on User { id } ... on Team { id } ... on Bot { id }
         } } }
       } } }' 2>/dev/null) || true
 # Guard: if the reviewer query failed or returned unparseable data,
@@ -787,26 +800,46 @@ if [ -n "$reviewer_query" ] && printf '%s' "$reviewer_query" \
     reviewer_query_ok=1
 fi
 if [ "$reviewer_query_ok" = "1" ]; then
-    users_json=$(printf '%s' "$reviewer_query" | jq -c \
-        '[(.data.node.reviewRequests.nodes // [])[]
-          | select(.requestedReviewer.__typename == "User")
-          | .requestedReviewer.id]' 2>/dev/null) || users_json="[]"
-    teams_json=$(printf '%s' "$reviewer_query" | jq -c \
-        '[(.data.node.reviewRequests.nodes // [])[]
-          | select(.requestedReviewer.__typename == "Team")
-          | .requestedReviewer.id]' 2>/dev/null) || teams_json="[]"
-    # Clear: replay humans + teams with union:false, botIds:[] — drops bots only.
-    clear_body=$(jq -n \
-        --arg pr "$PR_NID" --argjson users "$users_json" --argjson teams "$teams_json" \
-        '{ query: "mutation($pr:ID!,$users:[ID!]!,$teams:[ID!]!){requestReviews(input:{pullRequestId:$pr, userIds:$users, teamIds:$teams, botIds:[], union:false}){pullRequest{id}}}",
-           variables: {pr:$pr, users:$users, teams:$teams} }')
-    # Capture stdout so we can inspect `.errors[]` even on HTTP 200
-    # partial-success (gh exits 0 on this path, so a bare `|| ...`
-    # check would miss it; mirrors copilot-clean-label.yml).
-    if ! clear_out=$(printf '%s' "$clear_body" | gh api graphql --input - 2>/dev/null); then
-        echo "::warning::Step 8.4.5: clear mutation failed — re-add may be deduped"
-    elif printf '%s' "$clear_out" | jq -e '(.errors // []) | length > 0' >/dev/null 2>&1; then
-        echo "::warning::Step 8.4.5: clear mutation returned errors (exit 0) — re-add may be deduped"
+    # Detect whether Copilot is currently in the reviewer slot. When it
+    # isn't, the bare re-add (no clear) is sufficient because there's
+    # nothing to dedup against — skipping the clear avoids unnecessary
+    # churn AND avoids silently removing other bot reviewers (e.g.,
+    # dependabot) that the clear's `botIds:[]` would also drop. Same
+    # skip pattern as copilot-clean-label.yml's `copilot_present` check.
+    copilot_present=$(printf '%s' "$reviewer_query" | jq -r --arg id "$COPILOT_BOT_ID" \
+        'any(.data.node.reviewRequests.nodes // [] | .[]?;
+             .requestedReviewer.__typename == "Bot"
+             and .requestedReviewer.id == $id)' 2>/dev/null) || copilot_present="true"
+    if [ "$copilot_present" = "true" ]; then
+        users_json=$(printf '%s' "$reviewer_query" | jq -c \
+            '[(.data.node.reviewRequests.nodes // [])[]
+              | select(.requestedReviewer.__typename == "User")
+              | .requestedReviewer.id]' 2>/dev/null) || users_json="[]"
+        teams_json=$(printf '%s' "$reviewer_query" | jq -c \
+            '[(.data.node.reviewRequests.nodes // [])[]
+              | select(.requestedReviewer.__typename == "Team")
+              | .requestedReviewer.id]' 2>/dev/null) || teams_json="[]"
+        # Clear: replay humans + teams with union:false, botIds:[] —
+        # drops Copilot AND any other bot reviewers. The cron's pattern
+        # makes the same trade-off (search "botIds is explicitly empty"
+        # in copilot-clean-label.yml). Documented because the only bot
+        # reviewer this PR family expects is Copilot; if a project ever
+        # adds dependabot/renovate as PR reviewers, this clear would
+        # need to preserve their bot IDs too.
+        clear_body=$(jq -n \
+            --arg pr "$PR_NID" --argjson users "$users_json" --argjson teams "$teams_json" \
+            '{ query: "mutation($pr:ID!,$users:[ID!]!,$teams:[ID!]!){requestReviews(input:{pullRequestId:$pr, userIds:$users, teamIds:$teams, botIds:[], union:false}){pullRequest{id}}}",
+               variables: {pr:$pr, users:$users, teams:$teams} }')
+        # Capture stdout so we can inspect `.errors[]` even on HTTP 200
+        # partial-success (gh exits 0 on this path, so a bare `|| ...`
+        # check would miss it; mirrors copilot-clean-label.yml).
+        if ! clear_out=$(printf '%s' "$clear_body" | gh api graphql --input - 2>/dev/null); then
+            echo "::warning::Step 8.4.5: clear mutation failed — re-add may be deduped"
+        elif printf '%s' "$clear_out" | jq -e '(.errors // []) | length > 0' >/dev/null 2>&1; then
+            echo "::warning::Step 8.4.5: clear mutation returned errors (exit 0) — re-add may be deduped"
+        fi
+    else
+        echo "Step 8.4.5: Copilot not in reviewer requests — skipping clear (re-add will fire fresh)"
     fi
 else
     echo "::warning::Step 8.4.5: reviewer query failed or returned errors — skipping clear to preserve human reviewers; re-add may be deduped"
@@ -902,8 +935,11 @@ else
         # No explicit ROUND increment here — `continue` returns to the
         # loop top where the heartbeat block increments ROUND. This avoids
         # double-counting (heartbeat + inline both firing on the same
-        # iteration).
-        continue  # back to Step 8.1 (heartbeat increments ROUND)
+        # iteration). Same skill-agent control-flow caveat as the
+        # `break` at the top of Step 8.4 step 4: this `continue` is a
+        # semantic transition ("re-enter Step 8.1") for the LLM agent,
+        # not a literal loop continuation.
+        continue  # → re-enter Step 8.1 (heartbeat increments ROUND)
     else
         # 3b — every CID in the new review is one we already classified
         # WONT_FIX. Cross-round consensus = persistent false-positive.

--- a/.github/prompts/review-until-clean.prompt.md
+++ b/.github/prompts/review-until-clean.prompt.md
@@ -542,13 +542,16 @@ PHASE_C_OK=0                     # fail-safe default; Step 11.5 verification fli
 3. **`review_commit == HEAD_SHA`** — the review is for the current HEAD, not a stale earlier commit. (If not, state is `pending` → Step 8.3.)
 4. **`review_body =~ /generated no( new)? comments/i`** — Copilot itself declared the PR clean for this HEAD.
 
-ALL four must be true to flip `PHASE_B_EXIT_REASON=B_CLEAN_VERIFIED` from Step 8.2 and exit to Phase C. If 1-3 hold but condition 4 fails, the state is `dirty` → Step 8.4 (fix cycle), where a no-fix sub-round will redirect to Step 8.4.5 (forced re-review) rather than exiting B_CLEAN immediately. If condition 3 fails, the state is `pending` → Step 8.3 (wait + re-request). Do **not** infer Phase B done from `unresolved_thread_count == 0` alone — that count can be 0 between rounds (after Phase C of the previous round resolved everything) while Copilot has not yet re-reviewed the new HEAD; exiting on that signal is how round-N regressions slip through.
+ALL four must be true to flip `PHASE_B_EXIT_REASON=B_CLEAN_VERIFIED` from Step 8.2 and exit to Phase C. If 1-3 hold but condition 4 fails, the state is `dirty` → Step 8.4 (fix cycle), where a no-fix sub-round will redirect to Step 8.4.5 (forced re-review) rather than exiting B_CLEAN_* immediately. If condition 3 fails, the state is `pending` → Step 8.3 (wait + re-request). Do **not** infer Phase B done from `unresolved_thread_count == 0` alone — that count can be 0 between rounds (after Phase C of the previous round resolved everything) while Copilot has not yet re-reviewed the new HEAD; exiting on that signal is how round-N regressions slip through.
 
 When relaying state to the user mid-loop ("is the PR clean yet?"), re-run the four conditions every time — do **not** trust an earlier "clean" conclusion across a push, because a push invalidates condition 3.
+
+Initialize the round counter before entering the loop: `ROUND=0`.
 
 At each round entry, **heartbeat the marker**:
 
 ```bash
+ROUND=$((ROUND + 1))
 NEW_HEAD=$(git rev-parse HEAD)
 if [ "$NEW_HEAD" = "$HEAD_SHA" ]; then
     update_local_marker "$NEW_HEAD"
@@ -665,14 +668,14 @@ A literal `requestReviews` retry without this clear+re-add will often fail to wa
    git add <files>
    if git diff --cached --quiet; then
        # No fix to commit ⇒ every thread classified WONT_FIX or
-       # ALREADY_FIXED. Do NOT exit B_CLEAN here — operator-judged
+       # ALREADY_FIXED. Do NOT exit B_CLEAN_* here — operator-judged
        # "all WONT_FIX/ALREADY_FIXED" is not the same as Copilot
        # itself confirming clean. Drop into Step 8.4.5 to force a
        # fresh re-review on this HEAD and let Copilot adjudicate
        # (3a verified, 3b operator-only, 3c new findings).
        echo "no-fix round (all WONT_FIX/ALREADY_FIXED) — entering Step 8.4.5 forced re-review"
-       goto_step_8_4_5=1  # skill agent: jump to Step 8.4.5 below
-       break              # exit the fix-cycle inner block; fall into Step 8.4.5
+       # Skill agent: proceed to Step 8.4.5 below, skipping sub-steps 5-6.
+       break  # exit the fix-cycle inner block; fall into Step 8.4.5
    fi
    git commit -m "fix: address Copilot review on PR #$PR (round N)
 
@@ -699,15 +702,16 @@ A literal `requestReviews` retry without this clear+re-add will often fail to wa
 
 5. **New HEAD: marker refresh** is automatic at the next round's heartbeat block.
 
-6. **Increment round counter**. Return to Step 8.1.
+6. **Return to Step 8.1** (the heartbeat block at round entry increments `ROUND`).
 
 #### Step 8.4.5: Forced re-review on a no-fix round (Copilot adjudication)
 
 When Step 8.4 step 4 detects an empty staged diff (every thread classified
 WONT_FIX or ALREADY_FIXED, nothing to commit), the operator's judgment is
 that the PR is clean — but Copilot has not been asked to re-evaluate the
-HEAD with that classification context. Going straight to `B_CLEAN` here
-risks two failure modes the empty-push shortcut used to mask:
+HEAD with that classification context. Going straight to an immediate
+`B_CLEAN_*` exit here risks two failure modes the old empty-push
+shortcut used to mask:
 
 - **3c — missed coverage**: Copilot's most recent review on this HEAD
   produced findings only because of partial state (mid-fix-cycle review,
@@ -726,46 +730,99 @@ Step 8.4.5 forces Copilot to adjudicate on the same HEAD before exit:
 # 1. Snapshot the current set of unresolved Copilot thread CIDs as the
 #    "previously seen" baseline. Step 3 below distinguishes 3c (any new
 #    CID) from 3b (every CID is in this set).
-PRIOR_THREAD_CIDS=$(printf '%s' "$threads" | jq -r '.comments.nodes[0].databaseId')
+PRIOR_THREAD_CIDS=$(printf '%s' "$threads" | jq -r '
+    select(.isResolved == false
+        and .comments.nodes[0].author.login == "copilot-pull-request-reviewer")
+    | .comments.nodes[0].databaseId')
 
-# 2. Stuck-detector dance (same procedure as Step 8.3): drop Copilot,
-#    sleep 2s, re-add. A bare `requestReviews` against a bot already on
-#    the reviewer slot is silently deduped (200 OK, no event). The
-#    drop-then-re-add is the only way to fire a fresh review_requested
-#    event without changing HEAD.
+# 2. Stuck-detector dance (same procedure as Step 8.3 and
+#    copilot-clean-label.yml's pending branch): drop Copilot from the
+#    reviewer slot, sleep 2s, re-add. A bare `requestReviews` against a
+#    bot already on the reviewer slot is silently deduped (200 OK, no
+#    event). The drop-then-re-add is the only way to fire a fresh
+#    review_requested event without changing HEAD.
+#
+#    CRITICAL: the clear mutation uses `union:false` which REPLACES the
+#    entire reviewer set. We must first query current reviewers and replay
+#    humans + teams, omitting only bots — otherwise all human/team review
+#    requests are silently dropped. This mirrors the safe pattern in
+#    copilot-clean-label.yml (search: "query current reviewers").
 PR_NID=$(gh api graphql -F owner="$OWNER" -F repo="$REPO" -F pr="$PR" \
     -f query='query($owner:String!,$repo:String!,$pr:Int!){
       repository(owner:$owner,name:$repo){ pullRequest(number:$pr){ id } } }' \
-    --jq '.data.repository.pullRequest.id')
-gh api graphql -f query='
-mutation($pr: ID!) {
-  requestReviews(input: { pullRequestId: $pr, union: false, userIds: [], teamIds: [], botIds: [] }) {
-    pullRequest { id }
-  }
-}' -F pr="$PR_NID" >/dev/null
+    --jq '.data.repository.pullRequest.id') || {
+    echo "::warning::Step 8.4.5: PR node ID fetch failed — skipping dance, falling through to B_ABORTED"
+    PHASE_B_EXIT_REASON="B_ABORTED"
+    break
+}
+# Query current reviewer requests so the clear mutation preserves
+# humans + teams (removing only bots via empty botIds).
+reviewer_query=$(gh api graphql -F pr_nid="$PR_NID" \
+    -f query='query($pr_nid:ID!){
+      node(id:$pr_nid){ ... on PullRequest {
+        reviewRequests(first:100){ nodes { requestedReviewer {
+          __typename ... on User { id } ... on Team { id }
+        } } }
+      } } }' 2>/dev/null) || true
+# Guard: if the reviewer query failed or returned unparseable data,
+# skip the clear entirely. With reviewer_nodes unknown, building
+# users_json=[]/teams_json=[] and calling requestReviews(union:false)
+# would remove every human reviewer on the PR (same guard as
+# copilot-clean-label.yml `reviewer_query_ok` guard).
+reviewer_query_ok=0
+if [ -n "$reviewer_query" ] && printf '%s' "$reviewer_query" \
+    | jq -e '.data.node.reviewRequests' >/dev/null 2>&1; then
+    reviewer_query_ok=1
+fi
+if [ "$reviewer_query_ok" = "1" ]; then
+    users_json=$(printf '%s' "$reviewer_query" | jq -c \
+        '[(.data.node.reviewRequests.nodes // [])[]
+          | select(.requestedReviewer.__typename == "User")
+          | .requestedReviewer.id]' 2>/dev/null) || users_json="[]"
+    teams_json=$(printf '%s' "$reviewer_query" | jq -c \
+        '[(.data.node.reviewRequests.nodes // [])[]
+          | select(.requestedReviewer.__typename == "Team")
+          | .requestedReviewer.id]' 2>/dev/null) || teams_json="[]"
+    # Clear: replay humans + teams with union:false, botIds:[] — drops bots only.
+    clear_body=$(jq -n \
+        --arg pr "$PR_NID" --argjson users "$users_json" --argjson teams "$teams_json" \
+        '{ query: "mutation($pr:ID!,$users:[ID!]!,$teams:[ID!]!){requestReviews(input:{pullRequestId:$pr, userIds:$users, teamIds:$teams, botIds:[], union:false}){pullRequest{id}}}",
+           variables: {pr:$pr, users:$users, teams:$teams} }')
+    if ! printf '%s' "$clear_body" | gh api graphql --input - >/dev/null 2>&1; then
+        echo "::warning::Step 8.4.5: clear mutation failed — re-add may be deduped"
+    fi
+else
+    echo "::warning::Step 8.4.5: reviewer query failed — skipping clear to preserve human reviewers; re-add may be deduped"
+fi
 sleep 2
-gh api graphql -f query='
+# Re-add Copilot as a fresh reviewer request.
+if ! gh api graphql -f query='
 mutation($pr: ID!, $bot: ID!) {
   requestReviews(input: { pullRequestId: $pr, botIds: [$bot] }) {
     pullRequest { id }
   }
-}' -F pr="$PR_NID" -F bot="BOT_kgDOCnlnWA" >/dev/null
+}' -F pr="$PR_NID" -F bot="BOT_kgDOCnlnWA" >/dev/null 2>&1; then
+    echo "::warning::Step 8.4.5: re-add mutation failed — poll may timeout"
+fi
 
 # 3. Poll Step 8.1 every 30s for up to 5 min. Capture the prior latest
 #    review timestamp first so we can detect a NEW review (not just
 #    re-read the old one). Heartbeat the marker each iteration so the
 #    wait does not let the freshness lock expire.
 PRIOR_REVIEW_AT=$(printf '%s' "$latest" | jq -r '.submitted_at // ""')
+# Initialize poll-result variables so timeout detection at step 4 below
+# works correctly even if the while loop body never executes (defensive).
+latest_new="$latest"  new_at="$PRIOR_REVIEW_AT"  new_commit="$review_commit"
 deadline=$(( $(date +%s) + 300 ))
-while [ $(date +%s) -lt $deadline ]; do
+while [ "$(date +%s)" -lt "$deadline" ]; do
     sleep 30
     update_local_marker "$HEAD_SHA"
-    reviews_new=$(gh api --paginate "repos/$OWNER/$REPO/pulls/$PR/reviews")
+    reviews_new=$(gh api --paginate "repos/$OWNER/$REPO/pulls/$PR/reviews" 2>/dev/null) || continue
     latest_new=$(printf '%s' "$reviews_new" | jq -s '
         add | [.[] | select(.user.login == "copilot-pull-request-reviewer[bot]")]
-        | sort_by(.submitted_at) | last')
-    new_at=$(printf '%s' "$latest_new" | jq -r '.submitted_at // ""')
-    new_commit=$(printf '%s' "$latest_new" | jq -r '.commit_id // ""')
+        | sort_by(.submitted_at) | last' 2>/dev/null) || continue
+    new_at=$(printf '%s' "$latest_new" | jq -r '.submitted_at // ""' 2>/dev/null) || continue
+    new_commit=$(printf '%s' "$latest_new" | jq -r '.commit_id // ""' 2>/dev/null) || continue
     if [ "$new_at" != "$PRIOR_REVIEW_AT" ] && [ "$new_commit" = "$HEAD_SHA" ]; then
         break
     fi
@@ -825,9 +882,11 @@ else
         # `threads` as the canonical input for the next iteration.
         echo "Step 8.4.5: forced re-review surfaced new findings (CID not in baseline) — continuing dirty loop"
         threads=$threads_new
-        # Round counter increments at Step 8.4 step 6 (next iteration);
-        # circuit breaker (max 5 rounds) still applies.
-        continue  # back to Step 8.1 of the round loop
+        # No explicit ROUND increment here — `continue` returns to the
+        # loop top where the heartbeat block increments ROUND. This avoids
+        # double-counting (heartbeat + inline both firing on the same
+        # iteration).
+        continue  # back to Step 8.1 (heartbeat increments ROUND)
     else
         # 3b — every CID in the new review is one we already classified
         # WONT_FIX. Cross-round consensus = persistent false-positive.
@@ -1037,7 +1096,7 @@ case "${PHASE_B_EXIT_REASON:-B_ABORTED}" in
             # review body matches `generated no( new)? comments`, but
             # applying here avoids that latency. Failures are
             # warn-and-continue: the cron is the safety net.
-            if ! gh pr edit "$PR" --repo "$OWNER/$REPO" --add-label copilot-clean 2>&1; then
+            if ! gh pr edit "$PR" --repo "$OWNER/$REPO" --add-label copilot-clean >/dev/null 2>&1; then
                 echo "::warning::PR #$PR: failed to apply copilot-clean label preemptively; cron will retry on next tick"
             fi
             echo "/review-until-clean done (B_CLEAN_VERIFIED + Phase C ok): marker marked converged + copilot-clean label applied for HEAD $HEAD_SHA."

--- a/.github/prompts/review-until-clean.prompt.md
+++ b/.github/prompts/review-until-clean.prompt.md
@@ -665,7 +665,7 @@ A literal `requestReviews` retry without this clear+re-add will often fail to wa
 4. **Commit + push** (commit only when something staged):
 
    ```bash
-   git add <files>
+   git add "${FILES_TO_STAGE[@]}"  # operator: replace with the actual fix-cycle file list
    if git diff --cached --quiet; then
        # No fix to commit ⇒ every thread classified WONT_FIX or
        # ALREADY_FIXED. Do NOT exit B_CLEAN_* here — operator-judged
@@ -738,12 +738,13 @@ Step 8.4.5 forces Copilot to adjudicate on the same HEAD before exit:
 ```bash
 # 1. Snapshot the current set of unresolved Copilot thread CIDs as the
 #    "previously seen" baseline. Step 3 below distinguishes 3c (any new
-#    CID) from 3b (every CID is in this set). The `|| ""` guard
-#    handles the empty-input case (e.g., the prior fetch returned no
-#    nodes): under `set -euo pipefail` a bare jq parse error here
-#    would abort Step 8.4.5 entirely, masking the intended 3a/3b/3c
-#    classification with an `B_ABORTED` exit. Empty baseline ⇒ every
-#    new CID flagged as "new finding" (3c), which is the safe default.
+#    CID) from 3b (every CID is in this set). The
+#    `... || PRIOR_THREAD_CIDS=""` guard handles the empty-input case
+#    (e.g., the prior fetch returned no nodes): under
+#    `set -euo pipefail` a bare jq parse error here would abort Step
+#    8.4.5 entirely, masking the intended 3a/3b/3c classification with
+#    a `B_ABORTED` exit. Empty baseline ⇒ every new CID flagged as
+#    "new finding" (3c), which is the safe default.
 PRIOR_THREAD_CIDS=$(printf '%s' "$threads" | jq -r '
     select(.isResolved == false
         and .comments.nodes[0].author.login == "copilot-pull-request-reviewer")
@@ -964,6 +965,26 @@ else
     }' --jq '.data.repository.pullRequest.reviewThreads.nodes[]
         | select(.isResolved == false
             and .comments.nodes[0].author.login == "copilot-pull-request-reviewer")' 2>/dev/null) || { threads_new_fetch_ok=0; threads_new=""; }
+    # Note: `gh api graphql` can return HTTP 200 with `.errors[]`
+    # populated (partial-success), in which case the `||` fall-through
+    # above does NOT fire. The `--jq` filter strips structure, so we
+    # cannot inspect `.errors[]` after the fact. Refetch the raw
+    # response to check; same defensive pattern as the clear mutation
+    # earlier in this step. A `.errors[]` populated response is treated
+    # as a fetch failure (B_ABORTED) so the partial data does not flow
+    # into the 3b/3c classifier.
+    if [ "$threads_new_fetch_ok" = "1" ]; then
+        threads_new_raw=$(gh api graphql --paginate \
+            -F owner="$OWNER" -F repo="$REPO" -F pr="$PR" \
+            -f query='query($owner: String!, $repo: String!, $pr: Int!, $endCursor: String) {
+              repository(owner: $owner, name: $repo) { pullRequest(number: $pr) {
+                reviewThreads(first: 100, after: $endCursor) { pageInfo { hasNextPage endCursor } } } } }' 2>/dev/null) || threads_new_raw=""
+        if [ -n "$threads_new_raw" ] && printf '%s' "$threads_new_raw" \
+            | jq -e '(.errors // []) | length > 0' >/dev/null 2>&1; then
+            threads_new_fetch_ok=0
+            echo "::warning::Step 8.4.5: thread fetch returned partial-success errors (HTTP 200 + .errors[]) — treating as fetch failure"
+        fi
+    fi
     if [ "$threads_new_fetch_ok" = "0" ]; then
         echo "::warning::Step 8.4.5: post-re-review thread fetch failed — exiting B_ABORTED (cron will retry)"
         PHASE_B_EXIT_REASON="B_ABORTED"

--- a/.github/prompts/review-until-clean.prompt.md
+++ b/.github/prompts/review-until-clean.prompt.md
@@ -474,8 +474,8 @@ delete_local_marker() {
 }
 
 # Abort-path contract for the skill agent. Step 11.9 is the canonical
-# cleanup point on a clean B_CLEAN/B_ABORTED exit, but the skill is run
-# step-by-step by an LLM agent — there is no shell-level `trap EXIT`.
+# cleanup point on a clean B_CLEAN_*/B_ABORTED exit, but the skill is
+# run step-by-step by an LLM agent — there is no shell-level `trap EXIT`.
 # Therefore: whenever the agent decides to abort Phase B/C for any
 # reason that does NOT reach Step 11.9 (jq parse failure mid-fetch,
 # unrecoverable build/test/lint error, gh API loop failure, manual
@@ -519,22 +519,30 @@ if ! git push origin "HEAD:$BRANCH"; then
     exit 1
 fi
 
-PHASE_B_EXIT_REASON="B_ABORTED"  # fail-safe default; Step 8.2 clean path flips to B_CLEAN
+PHASE_B_EXIT_REASON="B_ABORTED"  # fail-safe default. Step 8.2 clean path flips to B_CLEAN_VERIFIED. Step 8.4.5 re-review flips to B_CLEAN_VERIFIED (3a) or B_CLEAN_OPERATOR (3b).
 PHASE_C_OK=0                     # fail-safe default; Step 11.5 verification flips to 1 on success
 ```
 
-`PHASE_C_OK` is a separate fail-safe flag from `PHASE_B_EXIT_REASON` because Phase B can converge clean (B_CLEAN) yet Phase C can still fail mid-way (rate-limited reply, permission error, network partition during the resolve mutation). Without this flag the Step 11.9 if/else gate would mark the marker `converged` even though some FIX / ALREADY_FIXED threads were never replied to or resolved, permanently suppressing cron on a HEAD that still has unresolved Copilot threads. The gate requires **both** `PHASE_B_EXIT_REASON=B_CLEAN` **and** `PHASE_C_OK=1` before flipping to the converged marker form.
+`PHASE_B_EXIT_REASON` distinguishes three terminal states:
+
+| State | Meaning | `copilot-clean` label | Marker |
+|---|---|---|---|
+| `B_CLEAN_VERIFIED` | Copilot itself reported `generated no (new) comments` for the current HEAD (either via Step 8.2's clean path on a fix-cycle round, or via Step 8.4.5's forced re-review after a WONT_FIX-only round). | **Apply** in Step 11.9 (when `PHASE_C_OK=1`). | `mark_local_converged` |
+| `B_CLEAN_OPERATOR` | All threads are WONT_FIX/ALREADY_FIXED so the operator considers the PR clean, but Copilot's forced re-review (Step 8.4.5) re-emitted the same set of threads (cross-round consensus = false-positive confirmed). Operator-judged clean only. | **Do not apply** — Copilot still disagrees, so the literal label semantic is unmet. | `mark_local_converged` (still suppress cron from re-running the same WONT_FIX pass) |
+| `B_ABORTED` | Phase B did not converge (max rounds, unrecoverable build failure, push reject after rebase, Step 8.4.5 surfaced new findings that exhausted the round budget, etc.). | **Do not apply** (and remove if previously set, although the cron `copilot-clean-label.yml`'s `synchronize`/`dirty` paths handle that on the next event). | `delete_local_marker` (let cron retry) |
+
+`PHASE_C_OK` is a separate fail-safe flag from `PHASE_B_EXIT_REASON` because Phase B can converge clean (`B_CLEAN_VERIFIED` / `B_CLEAN_OPERATOR`) yet Phase C can still fail mid-way (rate-limited reply, permission error, network partition during the resolve mutation). Without this flag the Step 11.9 if/else gate would mark the marker `converged` even though some FIX / ALREADY_FIXED threads were never replied to or resolved, permanently suppressing cron on a HEAD that still has unresolved Copilot threads. The gate requires **both** a `B_CLEAN_*` exit AND `PHASE_C_OK=1` before flipping to the converged marker form (and additionally requires `B_CLEAN_VERIFIED` before applying the `copilot-clean` label).
 
 ### Step 8: Copilot review iteration loop (max 5 rounds)
 
-**Phase B exit criteria — DO NOT MISREAD.** Step 8.2 below is the only authoritative path that exits Phase B with `PHASE_B_EXIT_REASON=B_CLEAN`. A common operator mistake is to look at "unresolved Copilot thread count == 0" (a Phase C / GraphQL `reviewThreads` query) and conclude the loop is done — that is **wrong**. Thread-resolved count is a Phase C verification metric (Step 11.5); it does not reflect whether Copilot has yet re-reviewed the latest pushed HEAD. The four-condition Phase B exit checklist (formalizing Step 8.2's branches) is:
+**Phase B exit criteria — DO NOT MISREAD.** Two paths can exit Phase B with `PHASE_B_EXIT_REASON=B_CLEAN_VERIFIED`: (i) Step 8.2's clean classification on the natural fix cycle (Copilot already declared "no new comments" on the current HEAD) and (ii) Step 8.4.5's forced re-review path's 3a outcome (Copilot re-emitted "no new comments" after a stuck-detector dance). A third path, Step 8.4.5's 3b outcome, exits with `B_CLEAN_OPERATOR` (skill-judged clean only — Copilot kept emitting the same WONT_FIX threads). A common operator mistake is to look at "unresolved Copilot thread count == 0" (a Phase C / GraphQL `reviewThreads` query) and conclude the loop is done — that is **wrong**. Thread-resolved count is a Phase C verification metric (Step 11.5); it does not reflect whether Copilot has yet re-reviewed the latest pushed HEAD. The four-condition Phase B exit checklist (formalizing Step 8.2's branches) is:
 
 1. **`HEAD_SHA` captured** for the latest commit on the branch (`git rev-parse HEAD` after the most recent push).
 2. **Latest Copilot review fetched** for the PR (Step 8.1's `latest`).
 3. **`review_commit == HEAD_SHA`** — the review is for the current HEAD, not a stale earlier commit. (If not, state is `pending` → Step 8.3.)
 4. **`review_body =~ /generated no( new)? comments/i`** — Copilot itself declared the PR clean for this HEAD.
 
-ALL four must be true to flip `PHASE_B_EXIT_REASON=B_CLEAN` and exit to Phase C. If 1-3 hold but condition 4 fails, the state is `dirty` → Step 8.4 (fix cycle). If condition 3 fails, the state is `pending` → Step 8.3 (wait + re-request). Do **not** infer Phase B done from `unresolved_thread_count == 0` alone — that count can be 0 between rounds (after Phase C of the previous round resolved everything) while Copilot has not yet re-reviewed the new HEAD; exiting on that signal is how round-N regressions slip through.
+ALL four must be true to flip `PHASE_B_EXIT_REASON=B_CLEAN_VERIFIED` from Step 8.2 and exit to Phase C. If 1-3 hold but condition 4 fails, the state is `dirty` → Step 8.4 (fix cycle), where a no-fix sub-round will redirect to Step 8.4.5 (forced re-review) rather than exiting B_CLEAN immediately. If condition 3 fails, the state is `pending` → Step 8.3 (wait + re-request). Do **not** infer Phase B done from `unresolved_thread_count == 0` alone — that count can be 0 between rounds (after Phase C of the previous round resolved everything) while Copilot has not yet re-reviewed the new HEAD; exiting on that signal is how round-N regressions slip through.
 
 When relaying state to the user mid-loop ("is the PR clean yet?"), re-run the four conditions every time — do **not** trust an earlier "clean" conclusion across a push, because a push invalidates condition 3.
 
@@ -572,7 +580,7 @@ State classification is evaluated **in this exact order**: the `pending` check f
 | Order | State | Detection | Action | `PHASE_B_EXIT_REASON` |
 |---|---|---|---|---|
 | 1 | **pending** | `latest == null` or `review_commit != HEAD_SHA` | Step 8.3 | (in-flight) |
-| 2 | **clean** | (review on HEAD AND) `review_body =~ /generated no( new)? comments/i` | flip `PHASE_B_EXIT_REASON=B_CLEAN`, exit to Phase C | `B_CLEAN` |
+| 2 | **clean** | (review on HEAD AND) `review_body =~ /generated no( new)? comments/i` | flip `PHASE_B_EXIT_REASON=B_CLEAN_VERIFIED`, exit to Phase C | `B_CLEAN_VERIFIED` |
 | 3 | **dirty** | (review on HEAD AND) inline comments | Step 8.4 | (in-flight) |
 
 The order matters: without the pending check first, a stale `generated no comments` review left over for the **previous** HEAD would falsely trigger the clean exit on the new HEAD before Copilot has had a chance to re-review.
@@ -583,8 +591,9 @@ if [ -z "$latest" ] || [ "$latest" = "null" ] || [ "$review_commit" != "$HEAD_SH
 elif printf '%s' "$review_body" | grep -qiE 'generated no( new)? comments'; then
     # Reached only when review_commit == HEAD_SHA (gated by the pending
     # check above). The clean phrase here is therefore for the current
-    # HEAD, not a stale review of an older commit.
-    PHASE_B_EXIT_REASON="B_CLEAN"
+    # HEAD, not a stale review of an older commit. Copilot itself
+    # declared the PR clean ⇒ B_CLEAN_VERIFIED.
+    PHASE_B_EXIT_REASON="B_CLEAN_VERIFIED"
     break
 fi
 # else: dirty — review on HEAD with inline comments (Step 8.4)
@@ -656,15 +665,14 @@ A literal `requestReviews` retry without this clear+re-add will often fail to wa
    git add <files>
    if git diff --cached --quiet; then
        # No fix to commit ⇒ every thread classified WONT_FIX or
-       # ALREADY_FIXED. Treat this as a B_CLEAN exit immediately —
-       # iterating again on the same dirty review state would just
-       # re-classify the same threads the same way until the round
-       # counter trips, then leak the marker via B_ABORTED. Setting
-       # B_CLEAN here is the executable form of the "empty push (no
-       # fix to commit)" circuit breaker documented below.
-       PHASE_B_EXIT_REASON="B_CLEAN"
-       echo "no-fix round (all WONT_FIX/ALREADY_FIXED) — exiting Phase B with B_CLEAN"
-       break
+       # ALREADY_FIXED. Do NOT exit B_CLEAN here — operator-judged
+       # "all WONT_FIX/ALREADY_FIXED" is not the same as Copilot
+       # itself confirming clean. Drop into Step 8.4.5 to force a
+       # fresh re-review on this HEAD and let Copilot adjudicate
+       # (3a verified, 3b operator-only, 3c new findings).
+       echo "no-fix round (all WONT_FIX/ALREADY_FIXED) — entering Step 8.4.5 forced re-review"
+       goto_step_8_4_5=1  # skill agent: jump to Step 8.4.5 below
+       break              # exit the fix-cycle inner block; fall into Step 8.4.5
    fi
    git commit -m "fix: address Copilot review on PR #$PR (round N)
 
@@ -693,21 +701,168 @@ A literal `requestReviews` retry without this clear+re-add will often fail to wa
 
 6. **Increment round counter**. Return to Step 8.1.
 
+#### Step 8.4.5: Forced re-review on a no-fix round (Copilot adjudication)
+
+When Step 8.4 step 4 detects an empty staged diff (every thread classified
+WONT_FIX or ALREADY_FIXED, nothing to commit), the operator's judgment is
+that the PR is clean — but Copilot has not been asked to re-evaluate the
+HEAD with that classification context. Going straight to `B_CLEAN` here
+risks two failure modes the empty-push shortcut used to mask:
+
+- **3c — missed coverage**: Copilot's most recent review on this HEAD
+  produced findings only because of partial state (mid-fix-cycle review,
+  stale state, retry dedup). A fresh re-review can surface NEW issues
+  the previous round didn't catch. Exiting before re-review hides these
+  until the next push happens or the cron fallback fires.
+- **3b — false-positive cross-round consensus**: Copilot keeps
+  re-emitting the same threads we already classified WONT_FIX. That IS
+  a clean exit for the operator, but the literal `copilot-clean` label
+  semantic ("Copilot itself reported no new comments") is not met, so
+  applying that label would be a lie.
+
+Step 8.4.5 forces Copilot to adjudicate on the same HEAD before exit:
+
+```bash
+# 1. Snapshot the current set of unresolved Copilot thread CIDs as the
+#    "previously seen" baseline. Step 3 below distinguishes 3c (any new
+#    CID) from 3b (every CID is in this set).
+PRIOR_THREAD_CIDS=$(printf '%s' "$threads" | jq -r '.comments.nodes[0].databaseId')
+
+# 2. Stuck-detector dance (same procedure as Step 8.3): drop Copilot,
+#    sleep 2s, re-add. A bare `requestReviews` against a bot already on
+#    the reviewer slot is silently deduped (200 OK, no event). The
+#    drop-then-re-add is the only way to fire a fresh review_requested
+#    event without changing HEAD.
+PR_NID=$(gh api graphql -F owner="$OWNER" -F repo="$REPO" -F pr="$PR" \
+    -f query='query($owner:String!,$repo:String!,$pr:Int!){
+      repository(owner:$owner,name:$repo){ pullRequest(number:$pr){ id } } }' \
+    --jq '.data.repository.pullRequest.id')
+gh api graphql -f query='
+mutation($pr: ID!) {
+  requestReviews(input: { pullRequestId: $pr, union: false, userIds: [], teamIds: [], botIds: [] }) {
+    pullRequest { id }
+  }
+}' -F pr="$PR_NID" >/dev/null
+sleep 2
+gh api graphql -f query='
+mutation($pr: ID!, $bot: ID!) {
+  requestReviews(input: { pullRequestId: $pr, botIds: [$bot] }) {
+    pullRequest { id }
+  }
+}' -F pr="$PR_NID" -F bot="BOT_kgDOCnlnWA" >/dev/null
+
+# 3. Poll Step 8.1 every 30s for up to 5 min. Capture the prior latest
+#    review timestamp first so we can detect a NEW review (not just
+#    re-read the old one). Heartbeat the marker each iteration so the
+#    wait does not let the freshness lock expire.
+PRIOR_REVIEW_AT=$(printf '%s' "$latest" | jq -r '.submitted_at // ""')
+deadline=$(( $(date +%s) + 300 ))
+while [ $(date +%s) -lt $deadline ]; do
+    sleep 30
+    update_local_marker "$HEAD_SHA"
+    reviews_new=$(gh api --paginate "repos/$OWNER/$REPO/pulls/$PR/reviews")
+    latest_new=$(printf '%s' "$reviews_new" | jq -s '
+        add | [.[] | select(.user.login == "copilot-pull-request-reviewer[bot]")]
+        | sort_by(.submitted_at) | last')
+    new_at=$(printf '%s' "$latest_new" | jq -r '.submitted_at // ""')
+    new_commit=$(printf '%s' "$latest_new" | jq -r '.commit_id // ""')
+    if [ "$new_at" != "$PRIOR_REVIEW_AT" ] && [ "$new_commit" = "$HEAD_SHA" ]; then
+        break
+    fi
+done
+
+# 4. Classify the new review against the three outcomes. The order
+#    matters: clean phrase wins over thread-set comparison so that
+#    even if Copilot re-flagged something but ALSO declared
+#    `generated no new comments`, we treat it as 3a verified.
+new_body=$(printf '%s' "$latest_new" | jq -r '.body // ""')
+if [ "$new_at" = "$PRIOR_REVIEW_AT" ] || [ "$new_commit" != "$HEAD_SHA" ]; then
+    # 5-min timeout reached without a fresh review on the current HEAD.
+    # Treat as B_ABORTED — cron will retry on its next tick and may
+    # succeed where this synchronous wait failed.
+    echo "Step 8.4.5: no fresh re-review within 5 min (timeout) — exiting B_ABORTED"
+    PHASE_B_EXIT_REASON="B_ABORTED"
+    break  # exit the round loop
+elif printf '%s' "$new_body" | grep -qiE 'generated no( new)? comments'; then
+    # 3a — Copilot itself confirmed clean for this HEAD.
+    echo "Step 8.4.5: Copilot re-review reports no new comments — B_CLEAN_VERIFIED"
+    PHASE_B_EXIT_REASON="B_CLEAN_VERIFIED"
+    break
+else
+    # Fetch the post-re-review thread CIDs and compare against the
+    # baseline. Any CID not in PRIOR_THREAD_CIDS is a new finding ⇒ 3c.
+    threads_new=$(gh api graphql --paginate \
+        -F owner="$OWNER" -F repo="$REPO" -F pr="$PR" \
+        -f query='
+    query($owner: String!, $repo: String!, $pr: Int!, $endCursor: String) {
+      repository(owner: $owner, name: $repo) {
+        pullRequest(number: $pr) {
+          reviewThreads(first: 100, after: $endCursor) {
+            pageInfo { hasNextPage endCursor }
+            nodes {
+              id isResolved path line
+              comments(first: 10) {
+                nodes { databaseId author { login } body diffHunk }
+              }
+            }
+          }
+        }
+      }
+    }' --jq '.data.repository.pullRequest.reviewThreads.nodes[]
+        | select(.isResolved == false
+            and .comments.nodes[0].author.login == "copilot-pull-request-reviewer")')
+    new_cids=$(printf '%s' "$threads_new" | jq -r '.comments.nodes[0].databaseId')
+    has_new_finding=0
+    for cid in $new_cids; do
+        if ! printf '%s\n' "$PRIOR_THREAD_CIDS" | grep -qFx "$cid"; then
+            has_new_finding=1
+            break
+        fi
+    done
+    if [ "$has_new_finding" = "1" ]; then
+        # 3c — at least one CID is new. Continue the round loop with
+        # the refreshed thread set so Step 8.4 reclassifies. Reuse
+        # `threads` as the canonical input for the next iteration.
+        echo "Step 8.4.5: forced re-review surfaced new findings (CID not in baseline) — continuing dirty loop"
+        threads=$threads_new
+        # Round counter increments at Step 8.4 step 6 (next iteration);
+        # circuit breaker (max 5 rounds) still applies.
+        continue  # back to Step 8.1 of the round loop
+    else
+        # 3b — every CID in the new review is one we already classified
+        # WONT_FIX. Cross-round consensus = persistent false-positive.
+        # Operator-judged clean.
+        echo "Step 8.4.5: forced re-review re-emitted only known WONT_FIX threads — B_CLEAN_OPERATOR"
+        PHASE_B_EXIT_REASON="B_CLEAN_OPERATOR"
+        break
+    fi
+fi
+```
+
+The 5-minute polling cap matches typical Copilot re-review latency
+(~1-3 min observed in this repo's PR history). A miss falls through
+to `B_ABORTED` rather than waiting longer because (a) longer waits
+would let the marker freshness lock expire, and (b) cron's next tick
+will retry the whole pipeline within ~30 min.
+
 #### Round circuit breakers
 
-- **max 5 rounds**: round 6 ⇒ `B_ABORTED` (Copilot generates new issues forever ⇒ delegate to cron)
+- **max 5 rounds**: round 6 ⇒ `B_ABORTED` (Copilot generates new issues forever ⇒ delegate to cron). Step 8.4.5's 3c path also feeds the round counter so a stream of new findings still trips this breaker.
 - **same issue across 2+ rounds**: false positive, downgrade to WONT_FIX, continue
-- **empty push (no fix to commit)**: every thread WONT_FIX/ALREADY_FIXED ⇒ `B_CLEAN` ⇒ skip to Phase C
+- **empty push (no fix to commit)**: every thread WONT_FIX/ALREADY_FIXED ⇒ enter Step 8.4.5 (forced re-review), then exit `B_CLEAN_VERIFIED` (3a) / `B_CLEAN_OPERATOR` (3b) / continue dirty (3c) / `B_ABORTED` (timeout). The previous behaviour ("empty push ⇒ immediate B_CLEAN") is removed because it conflated operator judgment with Copilot adjudication and could mask 3c missed-coverage cases.
 - **unrecoverable build/test/lint failure**: cannot revert ⇒ `B_ABORTED` ⇒ Phase C
 
 Phase C Step 11.9 dispatches by exit reason:
 
-| Exit reason | Marker cleanup | Cron behavior |
-|---|---|---|
-| `B_CLEAN` | `mark_local_converged` PATCH (rewrites tag to `copilot-fix-local-converged:<HEAD>`) | Cron treats converged tag as `already_triggered` and skips `@claude` for this HEAD |
-| `B_ABORTED` | `delete_local_marker` removes the comment | Next cron tick (~30–60 min) fires `@claude` fallback |
+| Exit reason | Marker cleanup | `copilot-clean` label | Cron behavior |
+|---|---|---|---|
+| `B_CLEAN_VERIFIED` | `mark_local_converged` PATCH (rewrites tag to `copilot-fix-local-converged:<HEAD>`) | **`gh pr edit --add-label copilot-clean`** | Cron treats converged tag as `already_triggered` AND sees Copilot's literal "no new comments" body, so it keeps the label on its next tick. |
+| `B_CLEAN_OPERATOR` | `mark_local_converged` (same as above — still suppress duplicate WONT_FIX work from cron) | **No label** — Copilot still has comments on HEAD; the literal label semantic is unmet, so applying it would mislead consumers of the label. | Cron sees the converged tag and skips `@claude`, but its review-body check still sees comments and (correctly) does not add the label. |
+| `B_ABORTED` | `delete_local_marker` removes the comment | **No label** (and any prior label gets removed by cron's `dirty`/`pending` paths or by the `synchronize` event on the next push). | Next cron tick (~30–60 min) fires `@claude` fallback. |
 
-Freshness lock keys on the active tag only, so a re-run of `/review-until-clean` after `B_CLEAN` is allowed (POSTs a new active marker; converged tag is ignored by the lock).
+Freshness lock keys on the active tag only, so a re-run of `/review-until-clean` after `B_CLEAN_*` is allowed (POSTs a new active marker; converged tag is ignored by the lock).
+
+The `copilot-clean` label is owned by `.github/workflows/copilot-clean-label.yml` (cron-driven, cf. its `LABEL: copilot-clean` env). The skill applies the label preemptively on `B_CLEAN_VERIFIED` to avoid a 30-min cron-tick wait; the cron's natural lifecycle (add on Copilot literal-clean, remove on dirty/synchronize) preserves the same semantics on subsequent ticks. The skill does not need to remove the label on `B_ABORTED` because the cron's `dirty`/`pending` branches and the `synchronize` event each strip it independently — adding a redundant skill-side strip would just double-fire the API call.
 
 ## Phase C: Reply + resolve all unresolved threads
 
@@ -754,7 +909,7 @@ Reuse cached results from Phase A/B for known threads. Classify the rest using t
 
 The Step 9 query already filtered to Copilot threads, so iterating `$threads` here is safe.
 
-Initialize `WONT_FIX_COUNT=0` before the loop and increment for every WONT_FIX classification — Step 11.5 reads this counter to gate `PHASE_C_OK`. Without the counter the verify step has nothing to compare against and `PHASE_C_OK` would stay at 0 forever (B_CLEAN runs would still delete the marker, defeating cron suppression).
+Initialize `WONT_FIX_COUNT=0` before the loop and increment for every WONT_FIX classification — Step 11.5 reads this counter to gate `PHASE_C_OK`. Without the counter the verify step has nothing to compare against and `PHASE_C_OK` would stay at 0 forever (`B_CLEAN_*` runs would still delete the marker, defeating cron suppression).
 
 The loop **must** be fed via process substitution (`while ... done < <(...)`), not a pipe (`... | while ... done`). A piped `while` runs in a subshell, so `WONT_FIX_COUNT=$((... + 1))` updates a child variable that disappears when the subshell exits — the parent always reads `0`. Process substitution keeps the loop body in the parent shell so the increment persists.
 
@@ -867,26 +1022,61 @@ Expected: `unresolved_copilot` equals the number of Copilot WONT_FIX threads. Th
 ### Step 11.9: Cleanup marker by Phase B exit reason **and** Phase C completion
 
 ```bash
-# Both gates must pass: Phase B must have converged AND Phase C's reply +
-# resolve mutations must have completed cleanly (verified by Step 11.5).
-# Marking the marker `converged` permanently suppresses cron for this HEAD,
-# so we MUST NOT do it when Phase C left FIX / ALREADY_FIXED threads
-# unresolved — otherwise cron silently abandons a HEAD that still has
-# open Copilot findings.
-if [ "${PHASE_B_EXIT_REASON:-B_ABORTED}" = "B_CLEAN" ] && [ "${PHASE_C_OK:-0}" = "1" ]; then
-    mark_local_converged "$HEAD_SHA"
-    echo "/review-until-clean done (B_CLEAN + Phase C ok): marker marked converged for HEAD $HEAD_SHA."
-else
-    delete_local_marker
-    echo "/review-until-clean done (${PHASE_B_EXIT_REASON:-B_ABORTED}, PHASE_C_OK=${PHASE_C_OK:-0}): marker deleted, cron fallback will resume on next tick."
-fi
+# Three-way dispatch on PHASE_B_EXIT_REASON, gated additionally by
+# PHASE_C_OK for the "marker → converged" path. Marking the marker
+# converged permanently suppresses cron for this HEAD, so we MUST NOT
+# do it when Phase C left FIX/ALREADY_FIXED threads unresolved —
+# otherwise cron silently abandons a HEAD with open Copilot findings.
+case "${PHASE_B_EXIT_REASON:-B_ABORTED}" in
+    B_CLEAN_VERIFIED)
+        if [ "${PHASE_C_OK:-0}" = "1" ]; then
+            mark_local_converged "$HEAD_SHA"
+            # Apply the `copilot-clean` label preemptively. The cron
+            # `copilot-clean-label.yml` would also add it on its next
+            # tick (~30 min worst case) because the latest Copilot
+            # review body matches `generated no( new)? comments`, but
+            # applying here avoids that latency. Failures are
+            # warn-and-continue: the cron is the safety net.
+            if ! gh pr edit "$PR" --repo "$OWNER/$REPO" --add-label copilot-clean 2>&1; then
+                echo "::warning::PR #$PR: failed to apply copilot-clean label preemptively; cron will retry on next tick"
+            fi
+            echo "/review-until-clean done (B_CLEAN_VERIFIED + Phase C ok): marker marked converged + copilot-clean label applied for HEAD $HEAD_SHA."
+        else
+            delete_local_marker
+            echo "/review-until-clean done (B_CLEAN_VERIFIED + Phase C FAILED, PHASE_C_OK=$PHASE_C_OK): marker deleted (Phase C left threads unresolved); cron retries pipeline on next tick."
+        fi
+        ;;
+    B_CLEAN_OPERATOR)
+        if [ "${PHASE_C_OK:-0}" = "1" ]; then
+            mark_local_converged "$HEAD_SHA"
+            # Deliberately NOT applying `copilot-clean` label: Copilot's
+            # latest review still has comments, so the literal label
+            # semantic ("Copilot reported no new comments") is unmet.
+            # Cron's review-body check will (correctly) leave the label
+            # off on its next tick.
+            echo "/review-until-clean done (B_CLEAN_OPERATOR + Phase C ok): marker marked converged for HEAD $HEAD_SHA. No copilot-clean label (Copilot still has comments; cross-round consensus = WONT_FIX)."
+        else
+            delete_local_marker
+            echo "/review-until-clean done (B_CLEAN_OPERATOR + Phase C FAILED, PHASE_C_OK=$PHASE_C_OK): marker deleted; cron retries pipeline on next tick."
+        fi
+        ;;
+    *)
+        # B_ABORTED and any unhandled state. Always delete the marker
+        # so cron can re-fire on the next tick. No label work needed:
+        # cron's `dirty`/`pending` paths and the `synchronize` event
+        # each strip any stale `copilot-clean` label independently.
+        delete_local_marker
+        echo "/review-until-clean done (${PHASE_B_EXIT_REASON:-B_ABORTED}, PHASE_C_OK=${PHASE_C_OK:-0}): marker deleted, cron fallback will resume on next tick."
+        ;;
+esac
 ```
 
 Reasons:
 
-- `B_CLEAN` + `PHASE_C_OK=1`: Copilot converged AND Phase C resolved FIX/ALREADY_FIXED + WONT_FIX intentionally left unresolved. If cron re-fires `@claude`, CI claude task would repeat Phase C and post duplicate "declined" replies on WONT_FIX threads. The converged tag prevents this.
-- `B_CLEAN` + `PHASE_C_OK=0`: Phase B converged but Phase C failed (mid-loop reply/resolve error, rate limit, network partition). Treat as a non-clean exit — delete the marker so cron retries the pipeline rather than leaving open FIX/ALREADY_FIXED threads stamped as `converged` and silently abandoned.
-- `B_ABORTED` (any `PHASE_C_OK`): Phase B did not converge ⇒ delete so cron takes over within ~30–60 min.
+- `B_CLEAN_VERIFIED` + `PHASE_C_OK=1`: Copilot literally confirmed no new comments AND Phase C resolved FIX/ALREADY_FIXED + WONT_FIX intentionally left unresolved. Apply both the converged marker AND the `copilot-clean` label so downstream consumers (merge gate, dashboards, cron) immediately see the verified-clean state.
+- `B_CLEAN_OPERATOR` + `PHASE_C_OK=1`: skill judges clean (all threads WONT_FIX/ALREADY_FIXED) but Step 8.4.5's forced re-review re-emitted the same threads. Mark converged so cron does not waste budget re-running the same WONT_FIX classification, but skip the label because Copilot still disagrees with the operator-side verdict.
+- Either `B_CLEAN_*` + `PHASE_C_OK=0`: Phase B converged but Phase C failed (mid-loop reply/resolve error, rate limit, network partition). Treat as a non-clean exit — delete the marker so cron retries the pipeline rather than leaving open FIX/ALREADY_FIXED threads stamped as `converged` and silently abandoned.
+- `B_ABORTED` (any `PHASE_C_OK`): Phase B did not converge ⇒ delete the marker so cron takes over within ~30–60 min. Cron's existing `dirty`/`pending`/`synchronize` paths handle any stale label removal — no skill-side strip needed.
 
 ## Rules
 

--- a/.github/prompts/review-until-clean.prompt.md
+++ b/.github/prompts/review-until-clean.prompt.md
@@ -780,6 +780,16 @@ PR_NID=$(gh api graphql -F owner="$OWNER" -F repo="$REPO" -F pr="$PR" \
     PHASE_B_EXIT_REASON="B_ABORTED"
     break
 }
+# Validate explicitly: `gh api ... --jq` can exit 0 with `null` output
+# (e.g. PR not found, GraphQL partial response, missing field) which
+# would silently propagate `pr_nid=null` into the subsequent
+# `node(id:$pr_nid)` calls. Treat empty / "null" as the same failure
+# the `||` branch above handles.
+if [ -z "$PR_NID" ] || [ "$PR_NID" = "null" ]; then
+    echo "::warning::Step 8.4.5: PR node ID was empty or null — skipping dance, falling through to B_ABORTED"
+    PHASE_B_EXIT_REASON="B_ABORTED"
+    break
+fi
 # Copilot bot's GraphQL node ID. Same value defined as `COPILOT_BOT_ID`
 # env var in `.github/workflows/copilot-clean-label.yml` (search:
 # "COPILOT_BOT_ID:"). Hard-coded once here and reused by both the clear

--- a/.github/prompts/review-until-clean.prompt.md
+++ b/.github/prompts/review-until-clean.prompt.md
@@ -666,12 +666,16 @@ A literal `requestReviews` retry without this clear+re-add will often fail to wa
 
    ```bash
    # Operator: populate this array with the paths fixed during the
-   # current round, then run `git add`. Empty default keeps the array
-   # safe under `set -u` if the operator forgets to populate (the
-   # subsequent `git diff --cached --quiet` will then catch the
-   # no-fix case via the existing branch).
+   # current round, then run `git add`. The length-guarded form below
+   # is safe under both `set -u` (array is initialized) and `set -e`
+   # (empty array would otherwise make `git add --` exit non-zero
+   # with "nothing specified" and abort the round before the no-fix
+   # detection runs); when the array is empty, the existing
+   # `git diff --cached --quiet` branch catches the no-fix case.
    FILES_TO_STAGE=()  # e.g. (cmd/uzomuzo/main.go internal/foo/bar.go)
-   git add -- "${FILES_TO_STAGE[@]}"
+   if [ "${#FILES_TO_STAGE[@]}" -gt 0 ]; then
+       git add -- "${FILES_TO_STAGE[@]}"
+   fi
    if git diff --cached --quiet; then
        # No fix to commit ⇒ every thread classified WONT_FIX or
        # ALREADY_FIXED. Do NOT exit B_CLEAN_* here — operator-judged

--- a/.github/prompts/review-until-clean.prompt.md
+++ b/.github/prompts/review-until-clean.prompt.md
@@ -665,7 +665,13 @@ A literal `requestReviews` retry without this clear+re-add will often fail to wa
 4. **Commit + push** (commit only when something staged):
 
    ```bash
-   git add "${FILES_TO_STAGE[@]}"  # operator: replace with the actual fix-cycle file list
+   # Operator: populate this array with the paths fixed during the
+   # current round, then run `git add`. Empty default keeps the array
+   # safe under `set -u` if the operator forgets to populate (the
+   # subsequent `git diff --cached --quiet` will then catch the
+   # no-fix case via the existing branch).
+   FILES_TO_STAGE=()  # e.g. (cmd/uzomuzo/main.go internal/foo/bar.go)
+   git add -- "${FILES_TO_STAGE[@]}"
    if git diff --cached --quiet; then
        # No fix to commit ⇒ every thread classified WONT_FIX or
        # ALREADY_FIXED. Do NOT exit B_CLEAN_* here — operator-judged
@@ -812,6 +818,11 @@ if [ "$reviewer_query_ok" = "1" ]; then
     # churn AND avoids silently removing other bot reviewers (e.g.,
     # dependabot) that the clear's `botIds:[]` would also drop. Same
     # skip pattern as copilot-clean-label.yml's `copilot_present` check.
+    # Initialize users_json/teams_json before the copilot_present
+    # branch so the post-branch `[ -n "$users_json" ]` test below is
+    # always defined under `set -u`, even if `copilot_present` is
+    # `false` or `unknown` and the inner block never runs.
+    users_json=""; teams_json=""
     # Default to "unknown" on jq failure (NOT "true") and skip the clear
     # entirely. Defaulting "true" + falling through would rebuild the
     # users_json/teams_json from possibly-corrupt data and call
@@ -965,26 +976,21 @@ else
     }' --jq '.data.repository.pullRequest.reviewThreads.nodes[]
         | select(.isResolved == false
             and .comments.nodes[0].author.login == "copilot-pull-request-reviewer")' 2>/dev/null) || { threads_new_fetch_ok=0; threads_new=""; }
-    # Note: `gh api graphql` can return HTTP 200 with `.errors[]`
-    # populated (partial-success), in which case the `||` fall-through
-    # above does NOT fire. The `--jq` filter strips structure, so we
-    # cannot inspect `.errors[]` after the fact. Refetch the raw
-    # response to check; same defensive pattern as the clear mutation
-    # earlier in this step. A `.errors[]` populated response is treated
-    # as a fetch failure (B_ABORTED) so the partial data does not flow
-    # into the 3b/3c classifier.
-    if [ "$threads_new_fetch_ok" = "1" ]; then
-        threads_new_raw=$(gh api graphql --paginate \
-            -F owner="$OWNER" -F repo="$REPO" -F pr="$PR" \
-            -f query='query($owner: String!, $repo: String!, $pr: Int!, $endCursor: String) {
-              repository(owner: $owner, name: $repo) { pullRequest(number: $pr) {
-                reviewThreads(first: 100, after: $endCursor) { pageInfo { hasNextPage endCursor } } } } }' 2>/dev/null) || threads_new_raw=""
-        if [ -n "$threads_new_raw" ] && printf '%s' "$threads_new_raw" \
-            | jq -e '(.errors // []) | length > 0' >/dev/null 2>&1; then
-            threads_new_fetch_ok=0
-            echo "::warning::Step 8.4.5: thread fetch returned partial-success errors (HTTP 200 + .errors[]) — treating as fetch failure"
-        fi
-    fi
+    # Limitation: `gh api graphql` can return HTTP 200 with `.errors[]`
+    # populated (partial-success). The `--jq` filter on the main fetch
+    # above strips response structure, so we cannot retroactively
+    # inspect `.errors[]` from `$threads_new`. A separate `--jq`-less
+    # refetch would re-execute the same load against GitHub (rate-
+    # limit risk) and could itself return different errors than the
+    # main fetch (so the check would be unreliable anyway). Accepting
+    # the rare partial-success-as-empty case here: the resulting
+    # empty `threads_new` flows through to the 3b operator-clean
+    # branch, which is wrong but rare and recoverable on the next
+    # cron tick. The same trade-off is made by the clear mutation's
+    # `(.errors // []) | length > 0` check earlier in this step,
+    # where we DO have access to the raw response. If a future GitHub
+    # API change makes partial-success more common here, the right
+    # fix is to drop `--jq` and parse `threads_new` in two passes.
     if [ "$threads_new_fetch_ok" = "0" ]; then
         echo "::warning::Step 8.4.5: post-re-review thread fetch failed — exiting B_ABORTED (cron will retry)"
         PHASE_B_EXIT_REASON="B_ABORTED"

--- a/.github/prompts/review-until-clean.prompt.md
+++ b/.github/prompts/review-until-clean.prompt.md
@@ -738,11 +738,16 @@ Step 8.4.5 forces Copilot to adjudicate on the same HEAD before exit:
 ```bash
 # 1. Snapshot the current set of unresolved Copilot thread CIDs as the
 #    "previously seen" baseline. Step 3 below distinguishes 3c (any new
-#    CID) from 3b (every CID is in this set).
+#    CID) from 3b (every CID is in this set). The `|| ""` guard
+#    handles the empty-input case (e.g., the prior fetch returned no
+#    nodes): under `set -euo pipefail` a bare jq parse error here
+#    would abort Step 8.4.5 entirely, masking the intended 3a/3b/3c
+#    classification with an `B_ABORTED` exit. Empty baseline ⇒ every
+#    new CID flagged as "new finding" (3c), which is the safe default.
 PRIOR_THREAD_CIDS=$(printf '%s' "$threads" | jq -r '
     select(.isResolved == false
         and .comments.nodes[0].author.login == "copilot-pull-request-reviewer")
-    | .comments.nodes[0].databaseId')
+    | .comments.nodes[0].databaseId' 2>/dev/null) || PRIOR_THREAD_CIDS=""
 
 # 2. Stuck-detector dance (same procedure as Step 8.3 and
 #    copilot-clean-label.yml's pending branch): drop Copilot from the
@@ -806,19 +811,40 @@ if [ "$reviewer_query_ok" = "1" ]; then
     # churn AND avoids silently removing other bot reviewers (e.g.,
     # dependabot) that the clear's `botIds:[]` would also drop. Same
     # skip pattern as copilot-clean-label.yml's `copilot_present` check.
+    # Default to "unknown" on jq failure (NOT "true") and skip the clear
+    # entirely. Defaulting "true" + falling through would rebuild the
+    # users_json/teams_json from possibly-corrupt data and call
+    # requestReviews(union:false) which REPLACES the reviewer set —
+    # the same way an empty users_json="[]" would silently drop every
+    # human reviewer. Skipping clear is the safe default (re-add will
+    # be deduped, but the dance still falls through to B_ABORTED
+    # cleanly via cron retry).
     copilot_present=$(printf '%s' "$reviewer_query" | jq -r --arg id "$COPILOT_BOT_ID" \
         'any(.data.node.reviewRequests.nodes // [] | .[]?;
              .requestedReviewer.__typename == "Bot"
-             and .requestedReviewer.id == $id)' 2>/dev/null) || copilot_present="true"
+             and .requestedReviewer.id == $id)' 2>/dev/null) || copilot_present="unknown"
     if [ "$copilot_present" = "true" ]; then
+        # Hard guard on users_json/teams_json: a jq failure here would
+        # leave the variables unset (or empty under `||`), and falling
+        # back to `[]` while `union:false` is in the mutation body
+        # below would silently drop every human/team reviewer. Treat
+        # any extraction failure as "skip the clear" and rely on the
+        # re-add (which will be deduped, but the dance still exits
+        # cleanly to B_ABORTED on poll-timeout).
         users_json=$(printf '%s' "$reviewer_query" | jq -c \
             '[(.data.node.reviewRequests.nodes // [])[]
               | select(.requestedReviewer.__typename == "User")
-              | .requestedReviewer.id]' 2>/dev/null) || users_json="[]"
+              | .requestedReviewer.id]' 2>/dev/null) || users_json=""
         teams_json=$(printf '%s' "$reviewer_query" | jq -c \
             '[(.data.node.reviewRequests.nodes // [])[]
               | select(.requestedReviewer.__typename == "Team")
-              | .requestedReviewer.id]' 2>/dev/null) || teams_json="[]"
+              | .requestedReviewer.id]' 2>/dev/null) || teams_json=""
+        if [ -z "$users_json" ] || [ -z "$teams_json" ]; then
+            echo "::warning::Step 8.4.5: User/Team extraction failed — skipping clear to preserve reviewers; re-add may be deduped"
+            users_json=""; teams_json=""
+        fi
+    fi
+    if [ "$copilot_present" = "true" ] && [ -n "$users_json" ] && [ -n "$teams_json" ]; then
         # Clear: replay humans + teams with union:false, botIds:[] —
         # drops Copilot AND any other bot reviewers. The cron's pattern
         # makes the same trade-off (search "botIds is explicitly empty"
@@ -839,7 +865,11 @@ if [ "$reviewer_query_ok" = "1" ]; then
             echo "::warning::Step 8.4.5: clear mutation returned errors (exit 0) — re-add may be deduped"
         fi
     else
-        echo "Step 8.4.5: Copilot not in reviewer requests — skipping clear (re-add will fire fresh)"
+        case "$copilot_present" in
+            true) echo "Step 8.4.5: User/Team extraction failed — skipping clear (re-add will be deduped)" ;;
+            unknown) echo "::warning::Step 8.4.5: copilot_present detection failed (jq error) — skipping clear; re-add may be deduped" ;;
+            *) echo "Step 8.4.5: Copilot not in reviewer requests — skipping clear (re-add will fire fresh)" ;;
+        esac
     fi
 else
     echo "::warning::Step 8.4.5: reviewer query failed or returned errors — skipping clear to preserve human reviewers; re-add may be deduped"
@@ -856,13 +886,16 @@ mutation($pr: ID!, $bot: ID!) {
 fi
 
 # 3. Poll Step 8.1 every 30s for up to 5 min. Capture the prior latest
-#    review timestamp first so we can detect a NEW review (not just
-#    re-read the old one). Heartbeat the marker each iteration so the
-#    wait does not let the freshness lock expire.
-PRIOR_REVIEW_AT=$(printf '%s' "$latest" | jq -r '.submitted_at // ""')
+#    review's REST id (not just submitted_at) so we can detect a NEW
+#    review unambiguously — if Copilot ever emits two reviews within
+#    the same second on the same HEAD, a `submitted_at`-only comparison
+#    would miss the second one and the loop would hit the 5-min
+#    timeout. Heartbeat the marker each iteration so the wait does
+#    not let the freshness lock expire.
+PRIOR_REVIEW_ID=$(printf '%s' "$latest" | jq -r '.id // ""' 2>/dev/null) || PRIOR_REVIEW_ID=""
 # Initialize poll-result variables so timeout detection at step 4 below
 # works correctly even if the while loop body never executes (defensive).
-latest_new="$latest"  new_at="$PRIOR_REVIEW_AT"  new_commit="$review_commit"
+latest_new="$latest"  new_id="$PRIOR_REVIEW_ID"  new_commit="$review_commit"
 deadline=$(( $(date +%s) + 300 ))
 while [ "$(date +%s)" -lt "$deadline" ]; do
     sleep 30
@@ -871,9 +904,9 @@ while [ "$(date +%s)" -lt "$deadline" ]; do
     latest_new=$(printf '%s' "$reviews_new" | jq -s '
         add | [.[] | select(.user.login == "copilot-pull-request-reviewer[bot]")]
         | sort_by(.submitted_at) | last' 2>/dev/null) || continue
-    new_at=$(printf '%s' "$latest_new" | jq -r '.submitted_at // ""' 2>/dev/null) || continue
+    new_id=$(printf '%s' "$latest_new" | jq -r '.id // ""' 2>/dev/null) || continue
     new_commit=$(printf '%s' "$latest_new" | jq -r '.commit_id // ""' 2>/dev/null) || continue
-    if [ "$new_at" != "$PRIOR_REVIEW_AT" ] && [ "$new_commit" = "$HEAD_SHA" ]; then
+    if [ "$new_id" != "$PRIOR_REVIEW_ID" ] && [ "$new_commit" = "$HEAD_SHA" ]; then
         break
     fi
 done
@@ -883,7 +916,7 @@ done
 #    even if Copilot re-flagged something but ALSO declared
 #    `generated no new comments`, we treat it as 3a verified.
 new_body=$(printf '%s' "$latest_new" | jq -r '.body // ""')
-if [ "$new_at" = "$PRIOR_REVIEW_AT" ] || [ "$new_commit" != "$HEAD_SHA" ]; then
+if [ "$new_id" = "$PRIOR_REVIEW_ID" ] || [ "$new_commit" != "$HEAD_SHA" ]; then
     # 5-min timeout reached without a fresh review on the current HEAD.
     # Treat as B_ABORTED — cron will retry on its next tick and may
     # succeed where this synchronous wait failed.
@@ -918,7 +951,13 @@ else
     }' --jq '.data.repository.pullRequest.reviewThreads.nodes[]
         | select(.isResolved == false
             and .comments.nodes[0].author.login == "copilot-pull-request-reviewer")')
-    new_cids=$(printf '%s' "$threads_new" | jq -r '.comments.nodes[0].databaseId')
+    # Same `|| ""` guard as PRIOR_THREAD_CIDS extraction at the top of
+    # Step 8.4.5: a bare jq parse error on empty `$threads_new` would
+    # abort under `set -euo pipefail`, masking the 3b operator-clean
+    # path. Empty new_cids ⇒ has_new_finding stays 0 ⇒ falls into the
+    # 3b `B_CLEAN_OPERATOR` branch, the safe default for "Copilot
+    # silently said nothing" cases.
+    new_cids=$(printf '%s' "$threads_new" | jq -r '.comments.nodes[0].databaseId' 2>/dev/null) || new_cids=""
     has_new_finding=0
     for cid in $new_cids; do
         if ! printf '%s\n' "$PRIOR_THREAD_CIDS" | grep -qFx "$cid"; then


### PR DESCRIPTION
## Summary

Port from [vuls-reach PR #44](https://github.com/vuls-saas/vuls-reach/pull/44). Replace the empty-push circuit breaker in `/review-until-clean` with a forced-re-review step (Step 8.4.5) so Copilot adjudicates the WONT_FIX-only state on the current HEAD before Phase B exits, and apply the `copilot-clean` label preemptively on Copilot-verified clean exits.

## What changes

- **Step 8.4.5 (new)**: when Step 8.4 step 4 detects an empty staged diff (every thread WONT_FIX/ALREADY_FIXED), the skill now snapshots the prior thread CIDs, fires the stuck-detector dance to force a fresh Copilot review on the same HEAD, polls 30s × 5 min, and classifies:
  - **3a, B_CLEAN_VERIFIED**: review body matches `generated no (new) comments` → Copilot itself confirms clean
  - **3b, B_CLEAN_OPERATOR**: review re-emits only CIDs already in the prior baseline → cross-round consensus, operator-judged clean only
  - **3c, continue dirty**: at least one new CID surfaces → refresh threads, continue round loop (max-5-rounds breaker still applies)
  - **timeout, B_ABORTED**: no fresh review within 5 min → cron retries
- **Three-state PHASE_B_EXIT_REASON**: `B_CLEAN_VERIFIED` (Step 8.2 OR 8.4.5 3a), `B_CLEAN_OPERATOR` (only Step 8.4.5 3b), `B_ABORTED` (unchanged)
- **`copilot-clean` label apply**: preemptive `gh pr edit --add-label copilot-clean` only on `B_CLEAN_VERIFIED + PHASE_C_OK=1` (cron is the safety net for failures)

## Validation evidence (from the recent port iterations)

This very repo's recent port PR (oss #382 / catalog #227 — depending on which side you're reading) was the empirical case for this change. The catalog port surfaced a real BASE/Step 4 doc-code drift only after a manual stuck-detector dance forced Copilot to adjudicate; without the dance, prior B_CLEAN exits had marked the marker converged with the bug still open. The new flow makes that dance automatic.

Cron workflow `.github/workflows/copilot-clean-label.yml` is unchanged — its label semantics already match `B_CLEAN_VERIFIED` (adds only when Copilot review body matches the literal-clean phrase). The skill's preemptive apply is a latency optimization on the same lifecycle.

## Test plan

- [ ] Smoke test: invoke `/review-until-clean` on this PR. Phase A clean Round 1 (prompt-only diff). Phase B should exit `B_CLEAN_VERIFIED` from Step 8.2 (Copilot's first review on HEAD).
- [ ] Cross-repo consistency: same change applies to vuls-reach and the sister uzomuzo repo via separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)