### PR TITLE
docs(git-workflow): require runtime-verification evidence in PR bodies

### DIFF
--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -24,7 +24,23 @@ When creating PRs:
 3. Use `git diff [base-branch]...HEAD` to see all changes
 4. Draft comprehensive PR summary
 5. Include test plan with TODOs
-6. Push with `-u` flag if new branch
+6. For behavior-changing PRs, include a **Runtime verification** section with real evidence — see below
+7. Push with `-u` flag if new branch
+
+### Runtime verification — always paste real evidence in the PR body
+
+A behavior-changing PR (new feature, bug fix, or a refactor that alters runtime behavior) must include a
+**"Runtime verification" section** in the PR body that pastes the **actual commands you ran and the output you
+observed** (logs, file/DB state, exit codes, etc.).
+
+- **Unit tests passing plus static analysis alone does NOT count as "verified".** Run the real binary / real
+  environment at least once and observe the headline behavior actually happening.
+- A path that is hard to unit-test because of concrete dependencies can still be observed end-to-end with the
+  **real binary plus a small forced scenario** (e.g., run the target once against a temporary fixture, seed the
+  prior state / input so the target branch is exercised, then inspect the logs and resulting state).
+- Only when runtime verification is genuinely impossible, **state the reason and the residual risk
+  explicitly**. **Do not defer the headline behavior's verification to a runbook and use that as the primary
+  evidence.**
 
 ## Branch Isolation with Git Worktree
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,7 +14,7 @@ See `.github/instructions/` for detailed rules.
 | [testing-performance](instructions/testing-performance.instructions.md) | Table-driven tests, benchmarks, concurrency (how to write Go tests) |
 | [test-design](instructions/test-design.instructions.md) | Pre-PR lens: classical QA techniques, fuzz/PBT policy, DDD layer placement (what to test) |
 | [project-conventions](instructions/project-conventions.instructions.md) | Configuration policy, test data, JSON tooling constraints |
-| [git-workflow](instructions/git-workflow.instructions.md) | Commit messages, PR workflow, TDD |
+| [git-workflow](instructions/git-workflow.instructions.md) | Commit messages, PR workflow, runtime verification, TDD |
 | [security](instructions/security.instructions.md) | Prompt injection defense, credentials, Go security |
 | [agent-orchestration](instructions/agent-orchestration.instructions.md) | Available agents, usage rules, parallel execution |
 

--- a/.github/instructions/git-workflow.instructions.md
+++ b/.github/instructions/git-workflow.instructions.md
@@ -22,7 +22,23 @@ When creating PRs:
 3. Use `git diff [base-branch]...HEAD` to see all changes
 4. Draft comprehensive PR summary
 5. Include test plan with TODOs
-6. Push with `-u` flag if new branch
+6. For behavior-changing PRs, include a **Runtime verification** section with real evidence — see below
+7. Push with `-u` flag if new branch
+
+### Runtime verification — always paste real evidence in the PR body
+
+A behavior-changing PR (new feature, bug fix, or a refactor that alters runtime behavior) must include a
+**"Runtime verification" section** in the PR body that pastes the **actual commands you ran and the output you
+observed** (logs, file/DB state, exit codes, etc.).
+
+- **Unit tests passing plus static analysis alone does NOT count as "verified".** Run the real binary / real
+  environment at least once and observe the headline behavior actually happening.
+- A path that is hard to unit-test because of concrete dependencies can still be observed end-to-end with the
+  **real binary plus a small forced scenario** (e.g., run the target once against a temporary fixture, seed the
+  prior state / input so the target branch is exercised, then inspect the logs and resulting state).
+- Only when runtime verification is genuinely impossible, **state the reason and the residual risk
+  explicitly**. **Do not defer the headline behavior's verification to a runbook and use that as the primary
+  evidence.**
 
 ## Branch Isolation with Git Worktree
 


### PR DESCRIPTION
## What changes

PR authors must now add a **"Runtime verification" section** to the body of any behavior-changing PR, pasting
the **actual commands they ran and the output they observed**. "Unit tests pass" plus static analysis alone no
longer counts as having verified the change.

## Why

A green unit-test suite shows the units behave as written in isolation; it does not show that the headline
behavior actually happens against the real binary in a real environment. Integration wiring and
concrete-dependency paths routinely pass unit tests yet fail — or silently do nothing — when actually run.
Requiring observed evidence in the PR body closes that gap before merge and leaves the proof attached for
review and future debugging.

## What's included

- **`.github/instructions/git-workflow.instructions.md`** (canonical) + **`.claude/rules/git-workflow.md`**
  (generated mirror): the "Pull Request Workflow" list gains step 6 — behavior-changing PRs include a
  "Runtime verification" section — plus a subsection spelling out the requirement:
  1. unit-green + static analysis is not "verified";
  2. a hard-to-unit-test path can still be observed end-to-end with the real binary + a small forced scenario;
  3. only when runtime verification is genuinely impossible, state the reason **and** the residual risk — do
     not substitute a runbook for the primary evidence.
- **`.github/copilot-instructions.md`**: the rule-index row for git-workflow now lists "runtime verification".

## Out of scope / not changed

- No source code (Go) changes. Documentation / instruction files only; runtime behavior is unchanged.

## Runtime verification

This PR is docs-only and changes no runtime behavior (the case the new rule itself flags as "verification
genuinely not applicable"), so verification is a reflection check that the rule landed in both the canonical
file and its generated mirror, and that the changeset is exactly the intended files. All output below is real:

```text
$ git diff --stat origin/main...HEAD
 .claude/rules/git-workflow.md                     | 18 +++++++++++++++++-
 .github/copilot-instructions.md                   |  2 +-
 .github/instructions/git-workflow.instructions.md | 18 +++++++++++++++++-
 3 files changed, 35 insertions(+), 3 deletions(-)

$ grep -n "Runtime verification" .github/instructions/git-workflow.instructions.md
25:6. For behavior-changing PRs, include a **Runtime verification** section with real evidence — see below
28:### Runtime verification — always paste real evidence in the PR body
31:**"Runtime verification" section** in the PR body that pastes the **actual commands you ran and the output you

$ grep -c "Runtime verification" .claude/rules/git-workflow.md   # generated mirror
3

$ grep -n "git-workflow.*runtime verification" .github/copilot-instructions.md
17:| [git-workflow](instructions/git-workflow.instructions.md) | Commit messages, PR workflow, runtime verification, TDD |
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
