### PR TITLE
fix: guard nil packageResp in buildBasicResult

### DIFF
--- a/internal/infrastructure/depsdev/batch_details.go
+++ b/internal/infrastructure/depsdev/batch_details.go
@@ -485,13 +485,14 @@ func (c *DepsDevClient) buildFinalResults(purls []string, packageInfoMap map[str
 
 // buildBasicResult creates a BatchResult with basic package information only
 func (c *DepsDevClient) buildBasicResult(purl string, packageResp *PackageResponse) *BatchResult {
-	return &BatchResult{
-		PURL: purl,
-		Package: &Package{
+	result := &BatchResult{PURL: purl}
+	if packageResp != nil {
+		result.Package = &Package{
 			PURL:     packageResp.Version.PURL,
 			Versions: []Version{packageResp.Version},
-		},
+		}
 	}
+	return result
 }
 
 // buildCompleteResult creates a BatchResult with all available information

--- a/internal/infrastructure/depsdev/issue443_verify_test.go
+++ b/internal/infrastructure/depsdev/issue443_verify_test.go
@@ -1,0 +1,72 @@
+package depsdev
+
+import (
+	"testing"
+
+	"github.com/future-architect/uzomuzo-oss/internal/domain/config"
+)
+
+// TestBuildBasicResultNilPackageResp covers the case where buildBasicResult is
+// called with a nil *PackageResponse, which happens in buildFinalResults when
+// packageInfoMap[purl] misses (the key is absent for PURLs whose package info
+// could not be fetched). Before the nil guard, dereferencing packageResp.Version
+// panicked. The result should now carry no Package, matching buildCompleteResult.
+func TestBuildBasicResultNilPackageResp(t *testing.T) {
+	c := NewDepsDevClient(&config.DepsDevConfig{BaseURL: "http://localhost"})
+
+	res := c.buildBasicResult("pkg:npm/left-pad@1.3.0", nil)
+	if res == nil {
+		t.Fatal("buildBasicResult returned nil")
+	}
+	if res.PURL != "pkg:npm/left-pad@1.3.0" {
+		t.Errorf("PURL = %q, want pkg:npm/left-pad@1.3.0", res.PURL)
+	}
+	if res.Package != nil {
+		t.Errorf("Package = %+v, want nil for missing package info", res.Package)
+	}
+}
+
+// TestBuildBasicResultPopulatesPackage confirms the non-nil path is unchanged:
+// a present *PackageResponse still yields a populated Package.
+func TestBuildBasicResultPopulatesPackage(t *testing.T) {
+	c := NewDepsDevClient(&config.DepsDevConfig{BaseURL: "http://localhost"})
+
+	pkg := &PackageResponse{Version: Version{
+		PURL:       "pkg:npm/left-pad@1.3.0",
+		VersionKey: VersionKey{System: "npm", Name: "left-pad", Version: "1.3.0"},
+	}}
+	res := c.buildBasicResult("pkg:npm/left-pad@1.3.0", pkg)
+	if res.Package == nil {
+		t.Fatal("Package = nil, want populated")
+	}
+	if res.Package.PURL != "pkg:npm/left-pad@1.3.0" {
+		t.Errorf("Package.PURL = %q, want pkg:npm/left-pad@1.3.0", res.Package.PURL)
+	}
+	if len(res.Package.Versions) != 1 {
+		t.Errorf("len(Versions) = %d, want 1", len(res.Package.Versions))
+	}
+}
+
+// TestBuildFinalResultsNoRepoNoPackageInfo exercises the integrated path that
+// triggered the panic: a PURL in purlsWithoutRepo with no entry in packageInfoMap.
+func TestBuildFinalResultsNoRepoNoPackageInfo(t *testing.T) {
+	c := NewDepsDevClient(&config.DepsDevConfig{BaseURL: "http://localhost"})
+
+	purl := "pkg:golang/example.com/missing@v0.0.0"
+	results := c.buildFinalResults(
+		[]string{purl},
+		map[string]*PackageResponse{}, // packageInfoMap miss -> nil packageResp
+		[]string{purl},                // purlsWithoutRepo
+		map[string][]string{},
+		map[string]*Project{},
+		map[string]ReleaseInfo{},
+	)
+
+	res, ok := results[purl]
+	if !ok {
+		t.Fatalf("no result for %q", purl)
+	}
+	if res.Package != nil {
+		t.Errorf("Package = %+v, want nil", res.Package)
+	}
+}

--- a/internal/infrastructure/depsdev/issue443_verify_test.go
+++ b/internal/infrastructure/depsdev/issue443_verify_test.go
@@ -49,18 +49,20 @@ func TestBuildBasicResultPopulatesPackage(t *testing.T) {
 }
 
 // TestBuildFinalResultsNoRepoNoPackageInfo exercises buildFinalResults' integrated
-// assembly for a PURL in purlsWithoutRepo whose packageInfoMap entry is missing, so
-// buildBasicResult receives a nil packageResp. The state is constructed directly (it
-// is not produced by resolveRepoURLsBatch, which only emits purlsWithoutRepo entries
-// that have a packageInfoMap key) to lock in the guard behavior end-to-end.
+// assembly for a PURL in purlsWithoutRepo whose packageInfoMap value is nil, so
+// buildBasicResult receives a nil packageResp. resolveRepoURLsBatch only emits
+// purlsWithoutRepo entries that are packageInfoMap keys, so the key is supplied
+// (present) with a nil value to mirror that invariant while still exercising the
+// defensive nil guard. (In production only successful fetches are stored, so the
+// value is non-nil there; the nil value is the case the guard protects against.)
 func TestBuildFinalResultsNoRepoNoPackageInfo(t *testing.T) {
 	c := NewDepsDevClient(&config.DepsDevConfig{BaseURL: "http://localhost"})
 
 	purl := "pkg:golang/example.com/missing@v0.0.0"
 	results := c.buildFinalResults(
 		[]string{purl},
-		map[string]*PackageResponse{}, // packageInfoMap miss -> nil packageResp
-		[]string{purl},                // purlsWithoutRepo
+		map[string]*PackageResponse{purl: nil}, // key present, nil value -> nil packageResp
+		[]string{purl},                         // purlsWithoutRepo (always a packageInfoMap key)
 		map[string][]string{},
 		map[string]*Project{},
 		map[string]ReleaseInfo{},

--- a/internal/infrastructure/depsdev/issue443_verify_test.go
+++ b/internal/infrastructure/depsdev/issue443_verify_test.go
@@ -6,11 +6,12 @@ import (
 	"github.com/future-architect/uzomuzo-oss/internal/domain/config"
 )
 
-// TestBuildBasicResultNilPackageResp covers the case where buildBasicResult is
-// called with a nil *PackageResponse, which happens in buildFinalResults when
-// packageInfoMap[purl] misses (the key is absent for PURLs whose package info
-// could not be fetched). Before the nil guard, dereferencing packageResp.Version
-// panicked. The result should now carry no Package, matching buildCompleteResult.
+// TestBuildBasicResultNilPackageResp covers buildBasicResult being called with a
+// nil *PackageResponse. Before the guard, dereferencing packageResp.Version would
+// panic; the guard now leaves Package nil, mirroring the sibling buildCompleteResult.
+// The nil input is defensive: the only current caller (buildFinalResults over
+// purlsWithoutRepo) always has a packageInfoMap entry, but the guard protects any
+// future caller that passes a nil packageResp.
 func TestBuildBasicResultNilPackageResp(t *testing.T) {
 	c := NewDepsDevClient(&config.DepsDevConfig{BaseURL: "http://localhost"})
 
@@ -47,8 +48,11 @@ func TestBuildBasicResultPopulatesPackage(t *testing.T) {
 	}
 }
 
-// TestBuildFinalResultsNoRepoNoPackageInfo exercises the integrated path that
-// triggered the panic: a PURL in purlsWithoutRepo with no entry in packageInfoMap.
+// TestBuildFinalResultsNoRepoNoPackageInfo exercises buildFinalResults' integrated
+// assembly for a PURL in purlsWithoutRepo whose packageInfoMap entry is missing, so
+// buildBasicResult receives a nil packageResp. The state is constructed directly (it
+// is not produced by resolveRepoURLsBatch, which only emits purlsWithoutRepo entries
+// that have a packageInfoMap key) to lock in the guard behavior end-to-end.
 func TestBuildFinalResultsNoRepoNoPackageInfo(t *testing.T) {
 	c := NewDepsDevClient(&config.DepsDevConfig{BaseURL: "http://localhost"})
 
@@ -66,7 +70,15 @@ func TestBuildFinalResultsNoRepoNoPackageInfo(t *testing.T) {
 	if !ok {
 		t.Fatalf("no result for %q", purl)
 	}
+	if res.PURL != purl {
+		t.Errorf("PURL = %q, want %q", res.PURL, purl)
+	}
 	if res.Package != nil {
 		t.Errorf("Package = %+v, want nil", res.Package)
+	}
+	// The PURL is handled by the purlsWithoutRepo branch, not the "mark not
+	// found" branch, so Error must stay nil — pins which branch produced it.
+	if res.Error != nil {
+		t.Errorf("Error = %q, want nil", *res.Error)
 	}
 }


### PR DESCRIPTION
Closes #443.

`buildBasicResult` dereferenced `packageResp.Version` with no nil check, while its sibling `buildCompleteResult` already guards with `if packageResp != nil` — the asymmetry flagged in #443. This change mirrors the existing guard so a nil `packageResp` leaves `Package` nil instead of dereferencing, and adds tests covering the nil path.

**Note on reachability (defensive guard).** `buildBasicResult`'s only caller — `buildFinalResults` over `purlsWithoutRepo` — is fed entries that `resolveRepoURLsBatch` derives by iterating `packageInfoMap` keys, and `fetchPackageInfoBatch` (via `collectBounded`) stores only successful, non-nil fetches. So in production `packageResp` is never nil at that call site; the guard is defensive hardening against a future caller and restores symmetry with `buildCompleteResult`. The integrated test constructs the nil state directly — a *present* `packageInfoMap` key with a nil value — to respect the `purlsWithoutRepo ⊆ keys(packageInfoMap)` invariant while still driving the guard.

## Runtime verification

The nil path is unreachable through the real binary (see the note above), so it is verified by the targeted tests that drive `buildBasicResult` with a nil `packageResp` directly — the exact `packageResp.Version.PURL` dereference that panicked before the guard:

```
$ go test ./internal/infrastructure/depsdev/ -run 'TestBuildBasicResult|TestBuildFinalResultsNoRepoNoPackageInfo' -v -count=1
=== RUN   TestBuildBasicResultNilPackageResp
--- PASS: TestBuildBasicResultNilPackageResp (0.00s)
=== RUN   TestBuildBasicResultPopulatesPackage
--- PASS: TestBuildBasicResultPopulatesPackage (0.00s)
=== RUN   TestBuildFinalResultsNoRepoNoPackageInfo
--- PASS: TestBuildFinalResultsNoRepoNoPackageInfo (0.00s)
PASS
ok  	github.com/future-architect/uzomuzo-oss/internal/infrastructure/depsdev	0.007s

$ go test ./internal/infrastructure/depsdev/ -count=1
ok  	github.com/future-architect/uzomuzo-oss/internal/infrastructure/depsdev	0.038s
```

Residual risk: none — pure defensive hardening with no production behavior change. The populated path is byte-for-byte unchanged and covered by `TestBuildBasicResultPopulatesPackage`.
