### PR TITLE
docs: regenerate juice-shop EOL example for archived→Stalled (#451)

### DIFF
--- a/docs/assets/juice-shop-eol-result.txt
+++ b/docs/assets/juice-shop-eol-result.txt
@@ -1,20 +1,22 @@
 🔄 GitHub GraphQL processing started: 0/1030 repositories (progress every 100)
 🔄 GitHub GraphQL processing: 0/1030 repositories processed
-🔄 GitHub GraphQL progress: 100/1030 (total_cost=98 avg_cost=1.00 remaining=4865 reset=03:16 UTC)
-🔄 GitHub GraphQL progress: 200/1030 (total_cost=198 avg_cost=1.00 remaining=4774 reset=03:16 UTC)
-🔄 GitHub GraphQL progress: 300/1030 (total_cost=297 avg_cost=1.00 remaining=4667 reset=03:16 UTC)
-🔄 GitHub GraphQL progress: 400/1030 (total_cost=396 avg_cost=1.00 remaining=4567 reset=03:16 UTC)
-🔄 GitHub GraphQL progress: 500/1030 (total_cost=495 avg_cost=1.00 remaining=4474 reset=03:16 UTC)
-🔄 GitHub GraphQL progress: 600/1030 (total_cost=595 avg_cost=1.00 remaining=4371 reset=03:16 UTC)
-🔄 GitHub GraphQL progress: 700/1030 (total_cost=693 avg_cost=1.00 remaining=4268 reset=03:16 UTC)
-🔄 GitHub GraphQL progress: 800/1030 (total_cost=793 avg_cost=1.00 remaining=4178 reset=03:16 UTC)
-🔄 GitHub GraphQL progress: 900/1030 (total_cost=892 avg_cost=1.00 remaining=4069 reset=03:16 UTC)
-🔄 GitHub GraphQL progress: 1000/1030 (total_cost=991 avg_cost=1.00 remaining=3971 reset=03:16 UTC)
-🔄 GitHub GraphQL progress: 1030/1030 (total_cost=1021 avg_cost=1.00 remaining=3942 reset=03:16 UTC)
-✅ GitHub GraphQL processing completed: 1030/1030 (total_cost=1021 avg_cost=1.00 remaining=3942 reset=03:16 UTC)
+🔄 GitHub GraphQL progress: 100/1030 (total_cost=98 avg_cost=1.00 remaining=4864 reset=10:16 JST)
+🔄 GitHub GraphQL progress: 200/1030 (total_cost=198 avg_cost=1.00 remaining=4764 reset=10:16 JST)
+🔄 GitHub GraphQL progress: 300/1030 (total_cost=298 avg_cost=1.00 remaining=4668 reset=10:16 JST)
+🔄 GitHub GraphQL progress: 400/1030 (total_cost=398 avg_cost=1.00 remaining=4558 reset=10:16 JST)
+🔄 GitHub GraphQL progress: 500/1030 (total_cost=497 avg_cost=1.00 remaining=4460 reset=10:16 JST)
+🔄 GitHub GraphQL progress: 600/1030 (total_cost=595 avg_cost=1.00 remaining=4363 reset=10:16 JST)
+🔄 GitHub GraphQL progress: 700/1030 (total_cost=695 avg_cost=1.00 remaining=4270 reset=10:16 JST)
+🔄 GitHub GraphQL progress: 800/1030 (total_cost=795 avg_cost=1.00 remaining=4161 reset=10:16 JST)
+🔄 GitHub GraphQL progress: 900/1030 (total_cost=893 avg_cost=1.00 remaining=4063 reset=10:16 JST)
+🔄 GitHub GraphQL progress: 1000/1030 (total_cost=991 avg_cost=1.00 remaining=3966 reset=10:16 JST)
+🔄 GitHub GraphQL progress: 1030/1030 (total_cost=1021 avg_cost=1.00 remaining=3934 reset=10:16 JST)
+✅ GitHub GraphQL processing completed: 1030/1030 (total_cost=1021 avg_cost=1.00 remaining=3934 reset=10:16 JST)
 --- Summary Table ---
 STATUS     PURL                                                   RELATION  LIFECYCLE      BUILD
-🔴 replace  pkg:npm/%40ampproject/remapping@2.2.0                  direct    EOL-Confirmed  —
+🔴 replace  pkg:npm/nw-pre-gyp-module-test@0.0.1                   direct    EOL-Confirmed  —
+🔴 replace  pkg:npm/juice-shop@14.5.1                              direct    EOL-Confirmed  —
+🔴 replace  pkg:npm/%40ampproject/remapping@2.2.0                  direct    Stalled        —
 🔴 replace  pkg:npm/%40humanwhocodes/config-array@0.5.0            direct    EOL-Confirmed  —
 🔴 replace  pkg:npm/%40humanwhocodes/object-schema@1.2.1           direct    EOL-Confirmed  —
 🔴 replace  pkg:npm/%40npmcli/move-file@1.1.2                      direct    EOL-Confirmed  —
@@ -42,8 +44,8 @@ STATUS     PURL                                                   RELATION  LIFE
 🔴 replace  pkg:npm/are-we-there-yet@2.0.0                         direct    EOL-Confirmed  —
 🔴 replace  pkg:npm/are-we-there-yet@3.0.1                         direct    EOL-Confirmed  —
 🔴 replace  pkg:npm/code-point-at@1.1.0                            direct    EOL-Confirmed  —
-🔴 replace  pkg:npm/doctrine@2.1.0                                 direct    EOL-Confirmed  —
-🔴 replace  pkg:npm/doctrine@3.0.0                                 direct    EOL-Confirmed  —
+🔴 replace  pkg:npm/doctrine@2.1.0                                 direct    Stalled        —
+🔴 replace  pkg:npm/doctrine@3.0.0                                 direct    Stalled        —
 🔴 replace  pkg:npm/domexception@2.0.1                             direct    EOL-Confirmed  —
 🔴 replace  pkg:npm/dottie@2.0.3                                   direct    EOL-Confirmed  —
 🔴 replace  pkg:npm/download@8.0.0                                 direct    EOL-Effective  —
@@ -52,34 +54,36 @@ STATUS     PURL                                                   RELATION  LIFE
 🔴 replace  pkg:npm/eslint-config-standard-with-typescript@21.0.1  direct    EOL-Confirmed  —
 🔴 replace  pkg:npm/find-cache-dir@3.3.2                           direct    EOL-Confirmed  —
 🔴 replace  pkg:npm/formatio@1.1.1                                 direct    EOL-Confirmed  —
+🔴 replace  pkg:npm/frontend@14.5.1                                direct    EOL-Effective  —
 🔴 replace  pkg:npm/fstream@1.0.12                                 direct    EOL-Confirmed  —
 🔴 replace  pkg:npm/gauge@2.7.4                                    direct    EOL-Confirmed  —
 🔴 replace  pkg:npm/gauge@3.0.2                                    direct    EOL-Confirmed  —
 🔴 replace  pkg:npm/gauge@4.0.4                                    direct    EOL-Confirmed  —
 🔴 replace  pkg:npm/global-dirs@3.0.1                              direct    EOL-Confirmed  —
-🔴 replace  pkg:npm/grunt-legacy-log@3.0.0                         direct    EOL-Effective  —
-🔴 replace  pkg:npm/grunt-legacy-util@2.0.1                        direct    EOL-Effective  —
 🔴 replace  pkg:npm/grunt-replace-json@0.1.0                       direct    EOL-Effective  —
 🔴 replace  pkg:npm/har-validator@5.1.5                            direct    EOL-Confirmed  —
 🔴 replace  pkg:npm/hoek@5.0.4                                     direct    EOL-Confirmed  —
 🔴 replace  pkg:npm/hoek@6.1.3                                     direct    EOL-Confirmed  —
+🔴 replace  pkg:npm/http-proxy@1.18.1                              direct    EOL-Effective  —
 🔴 replace  pkg:npm/iltorb@2.4.5                                   direct    EOL-Confirmed  —
 🔴 replace  pkg:npm/inflight@1.0.6                                 direct    EOL-Confirmed  —
 🔴 replace  pkg:npm/ip@1.1.8                                       direct    EOL-Effective  —
 🔴 replace  pkg:npm/ip@2.0.0                                       direct    EOL-Effective  —
 🔴 replace  pkg:npm/is-gitpod@2.0.9                                direct    EOL-Confirmed  —
-🔴 replace  pkg:npm/is-windows@1.0.2                               direct    EOL-Confirmed  —
-🔴 replace  pkg:npm/isemail@3.2.0                                  direct    EOL-Confirmed  —
+🔴 replace  pkg:npm/is-windows@1.0.2                               direct    Stalled        —
+🔴 replace  pkg:npm/isemail@3.2.0                                  direct    Stalled        —
+🔴 replace  pkg:npm/jasmine-reporters@2.5.2                        direct    EOL-Effective  —
 🔴 replace  pkg:npm/jest-serializer@26.6.2                         direct    EOL-Confirmed  —
-🔴 replace  pkg:npm/json-buffer@3.0.0                              direct    EOL-Confirmed  —
+🔴 replace  pkg:npm/json-buffer@3.0.0                              direct    Stalled        —
+🔴 replace  pkg:npm/juicy-chat-bot@0.6.6                           direct    Stalled        —
 🔴 replace  pkg:npm/lodash.get@4.4.2                               direct    EOL-Confirmed  —
 🔴 replace  pkg:npm/lolex@1.3.2                                    direct    EOL-Confirmed  —
-🔴 replace  pkg:npm/marsdb@0.6.11                                  direct    EOL-Confirmed  —
+🔴 replace  pkg:npm/marsdb@0.6.11                                  direct    Stalled        —
 🔴 replace  pkg:npm/mimic-fn@2.1.0                                 direct    EOL-Confirmed  —
 🔴 replace  pkg:npm/monorepo-symlink-test@0.0.0                    direct    EOL-Effective  —
-🔴 replace  pkg:npm/node-int64@0.4.0                               direct    EOL-Confirmed  —
+🔴 replace  pkg:npm/node-int64@0.4.0                               direct    Stalled        —
 🔴 replace  pkg:npm/node-pre-gyp@0.15.0                            direct    EOL-Confirmed  —
-🔴 replace  pkg:npm/noop-logger@0.1.1                              direct    EOL-Confirmed  —
+🔴 replace  pkg:npm/noop-logger@0.1.1                              direct    Stalled        —
 🔴 replace  pkg:npm/notevil@1.3.3                                  direct    EOL-Confirmed  —
 🔴 replace  pkg:npm/npmlog@4.1.2                                   direct    EOL-Confirmed  —
 🔴 replace  pkg:npm/npmlog@5.0.1                                   direct    EOL-Confirmed  —
@@ -90,45 +94,72 @@ STATUS     PURL                                                   RELATION  LIFE
 🔴 replace  pkg:npm/osenv@0.1.5                                    direct    EOL-Confirmed  —
 🔴 replace  pkg:npm/p-finally@1.0.0                                direct    EOL-Confirmed  —
 🔴 replace  pkg:npm/path-is-absolute@1.0.1                         direct    EOL-Confirmed  —
-🔴 replace  pkg:npm/peek-readable@4.1.0                            direct    EOL-Confirmed  —
+🔴 replace  pkg:npm/peek-readable@4.1.0                            direct    Stalled        —
 🔴 replace  pkg:npm/pkg-dir@4.2.0                                  direct    EOL-Confirmed  —
 🔴 replace  pkg:npm/prebuild-install@5.3.6                         direct    EOL-Confirmed  —
 🔴 replace  pkg:npm/read-pkg-up@7.0.1                              direct    EOL-Confirmed  —
 🔴 replace  pkg:npm/replace@1.2.2                                  direct    EOL-Effective  —
 🔴 replace  pkg:npm/request@2.88.2                                 direct    EOL-Confirmed  —
-🔴 replace  pkg:npm/require-from-string@2.0.2                      direct    EOL-Confirmed  —
+🔴 replace  pkg:npm/require-from-string@2.0.2                      direct    Stalled        —
 🔴 replace  pkg:npm/resolve-url@0.2.1                              direct    EOL-Confirmed  —
 🔴 replace  pkg:npm/samsam@1.1.2                                   direct    EOL-Confirmed  —
-🔴 replace  pkg:npm/saxes@5.0.1                                    direct    EOL-Confirmed  —
+🔴 replace  pkg:npm/saxes@5.0.1                                    direct    Stalled        —
 🔴 replace  pkg:npm/source-map-resolve@0.5.3                       direct    EOL-Confirmed  —
 🔴 replace  pkg:npm/source-map-url@0.4.1                           direct    EOL-Confirmed  —
 🔴 replace  pkg:npm/strip-eof@1.0.0                                direct    EOL-Confirmed  —
-🔴 replace  pkg:npm/through@2.3.8                                  direct    EOL-Confirmed  —
+🔴 replace  pkg:npm/through@2.3.8                                  direct    Stalled        —
 🔴 replace  pkg:npm/topo@3.0.3                                     direct    EOL-Confirmed  —
-🔴 replace  pkg:npm/ts-node-dev@1.1.8                              direct    EOL-Confirmed  —
+🔴 replace  pkg:npm/ts-node-dev@1.1.8                              direct    Stalled        —
 🔴 replace  pkg:npm/urix@0.1.0                                     direct    EOL-Confirmed  —
 🔴 replace  pkg:npm/w3c-hr-time@1.0.2                              direct    EOL-Confirmed  —
 🔴 replace  pkg:npm/whatwg-encoding@1.0.5                          direct    EOL-Confirmed  —
-🔴 replace  pkg:npm/xmlchars@2.2.0                                 direct    EOL-Confirmed  —
-🔴 replace  pkg:npm/xtend@4.0.2                                    direct    EOL-Confirmed  —
+🔴 replace  pkg:npm/xmlchars@2.2.0                                 direct    Stalled        —
+🔴 replace  pkg:npm/xtend@4.0.2                                    direct    Stalled        —
 
 ── Summary ─────────────────────────────────────────────────
-│ 1555 dependencies | ✅ 1185 ok | ⚠️ 258 caution | 🔴 97 replace | 🔍 15 review | showing 97 of 1555
+│ 1564 dependencies | ✅ 1190 ok | ⚠️ 250 caution | 🔴 101 replace | 🔍 23 review | showing 101 of 1564
 └───────────────────────────────────────────────────────────
 
 --- Detailed Report ---
 
 --- PURL 1 ---
+── pkg:npm/nw-pre-gyp-module-test@0.0.1 ────────────────────
+│ 🔴 EOL-Confirmed: Unpublished in npm registry
+├─ Signals ─────────────────────────────────────────────────
+│ EOL Source: npmjs
+├─ EOL ─────────────────────────────────────────────────────
+│ Evidence (1):
+│   [npmjs] Unpublished in npm registry (confidence 0.95)
+│     ↳ https://registry.npmjs.org/nw-pre-gyp-module-test
+├─ Links ───────────────────────────────────────────────────
+│ deps.dev: https://deps.dev/npm/nw-pre-gyp-module-test
+└───────────────────────────────────────────────────────────
+
+--- PURL 2 ---
+── pkg:npm/juice-shop@14.5.1 ───────────────────────────────
+│ 🔴 EOL-Confirmed: Unpublished in npm registry
+├─ Signals ─────────────────────────────────────────────────
+│ EOL Source: npmjs
+├─ EOL ─────────────────────────────────────────────────────
+│ Evidence (1):
+│   [npmjs] Unpublished in npm registry (confidence 0.95)
+│     ↳ https://registry.npmjs.org/juice-shop
+├─ Links ───────────────────────────────────────────────────
+│ deps.dev: https://deps.dev/npm/juice-shop
+└───────────────────────────────────────────────────────────
+
+--- PURL 3 ---
 ── pkg:npm/%40ampproject/remapping@2.2.0 ───────────────────
 │ Remap sequential sourcemaps through transformations to
 │   point at the original source code
-│ 🔴 EOL-Confirmed: Repository archived or disabled
+│ 🔴 Stalled: Repository archived/disabled but not declared
+│            end-of-life
 ├─ Signals ─────────────────────────────────────────────────
 │ Repo Archived: true
 ├─ Health ──────────────────────────────────────────────────
 │ 📦 Archived
-│ 133 stars
-│ Used by: 77 packages
+│ 135 stars
+│ Used by: 78 packages
 │ Depends on: 2 direct, 3 transitive
 │ Scorecard Overall: 3.1/10  Maintained: 0.0/10
 │ Last Commit: 2025-06-28
@@ -138,15 +169,16 @@ STATUS     PURL                                                   RELATION  LIFE
 ├─ Links ───────────────────────────────────────────────────
 │ Repository: https://github.com/ampproject/remapping
 │ Registry: https://www.npmjs.com/package/@ampproject/remapping
-│ deps.dev: https://deps.dev/npm/@ampproject/remapping
+│ deps.dev: https://deps.dev/npm/@ampproject%2Fremapping
 └───────────────────────────────────────────────────────────
 
---- PURL 2 ---
+--- PURL 4 ---
 ── pkg:npm/%40humanwhocodes/config-array@0.5.0 ─────────────
 │ DEPRECATED. Use eslint/config-array instead
-│ 🔴 EOL-Confirmed: Repository archived or disabled
+│ 🔴 EOL-Confirmed: Deprecated in npm registry; successor:
+│                  @eslint/config-array
 ├─ Signals ─────────────────────────────────────────────────
-│ Repo Archived: true
+│ EOL Source: npmjs
 ├─ EOL ─────────────────────────────────────────────────────
 │ ➡️ Successor: @eslint/config-array
 │ Evidence (1):
@@ -155,7 +187,7 @@ STATUS     PURL                                                   RELATION  LIFE
 ├─ Health ──────────────────────────────────────────────────
 │ 📦 Archived
 │ 30 stars
-│ Used by: 15036 packages
+│ Used by: 15024 packages
 │ Depends on: 3 direct, 4 transitive
 │ Scorecard Overall: 3.7/10  Maintained: 0.0/10
 │ Last Commit: 2024-04-17
@@ -165,15 +197,16 @@ STATUS     PURL                                                   RELATION  LIFE
 ├─ Links ───────────────────────────────────────────────────
 │ Repository: https://github.com/humanwhocodes/config-array
 │ Registry: https://www.npmjs.com/package/@humanwhocodes/config-array
-│ deps.dev: https://deps.dev/npm/@humanwhocodes/config-array
+│ deps.dev: https://deps.dev/npm/@humanwhocodes%2Fconfig-array
 └───────────────────────────────────────────────────────────
 
---- PURL 3 ---
+--- PURL 5 ---
 ── pkg:npm/%40humanwhocodes/object-schema@1.2.1 ────────────
 │ DEPRECATED. Use eslint/object-schema instead.
-│ 🔴 EOL-Confirmed: Repository archived or disabled
+│ 🔴 EOL-Confirmed: Deprecated in npm registry; successor:
+│                  @eslint/object-schema
 ├─ Signals ─────────────────────────────────────────────────
-│ Repo Archived: true
+│ EOL Source: npmjs
 ├─ EOL ─────────────────────────────────────────────────────
 │ ➡️ Successor: @eslint/object-schema
 │ Evidence (1):
@@ -182,7 +215,7 @@ STATUS     PURL                                                   RELATION  LIFE
 ├─ Health ──────────────────────────────────────────────────
 │ 📦 Archived
 │ 33 stars
-│ Used by: 15941 packages
+│ Used by: 15929 packages
 │ Scorecard Overall: 3.2/10  Maintained: 0.0/10
 │ Last Commit: 2024-04-01
 ├─ Releases ────────────────────────────────────────────────
@@ -191,17 +224,18 @@ STATUS     PURL                                                   RELATION  LIFE
 ├─ Links ───────────────────────────────────────────────────
 │ Repository: https://github.com/humanwhocodes/object-schema
 │ Registry: https://www.npmjs.com/package/@humanwhocodes/object-schema
-│ deps.dev: https://deps.dev/npm/@humanwhocodes/object-schema
+│ deps.dev: https://deps.dev/npm/@humanwhocodes%2Fobject-schema
 └───────────────────────────────────────────────────────────
 
---- PURL 4 ---
+--- PURL 6 ---
 ── pkg:npm/%40npmcli/move-file@1.1.2 ───────────────────────
 │ Move a file across devices with support for all node 10
 │   versions (fork of
 │   https://github.com/sindresorhus/move-file)
-│ 🔴 EOL-Confirmed: Repository archived or disabled
+│ 🔴 EOL-Confirmed: Deprecated in npm registry; successor:
+│                  @npmcli/fs
 ├─ Signals ─────────────────────────────────────────────────
-│ Repo Archived: true
+│ EOL Source: npmjs
 ├─ EOL ─────────────────────────────────────────────────────
 │ ➡️ Successor: @npmcli/fs
 │ Evidence (1):
@@ -209,7 +243,7 @@ STATUS     PURL                                                   RELATION  LIFE
 │     ↳ https://registry.npmjs.org/@npmcli%2Fmove-file
 ├─ Health ──────────────────────────────────────────────────
 │ 📦 Archived
-│ Used by: 31253 packages
+│ Used by: 31462 packages
 │ Depends on: 2 direct, 11 transitive
 │ Last Commit: 2022-11-03
 ├─ Releases ────────────────────────────────────────────────
@@ -218,10 +252,10 @@ STATUS     PURL                                                   RELATION  LIFE
 ├─ Links ───────────────────────────────────────────────────
 │ Repository: https://github.com/npm/move-file
 │ Registry: https://www.npmjs.com/package/@npmcli/move-file
-│ deps.dev: https://deps.dev/npm/@npmcli/move-file
+│ deps.dev: https://deps.dev/npm/@npmcli%2Fmove-file
 └───────────────────────────────────────────────────────────
 
---- PURL 5 ---
+--- PURL 7 ---
 ── pkg:npm/%40otplib/plugin-crypto@12.0.1 ──────────────────
 │ One Time Password (OTP) / 2FA for Node.js and Browser -
 │   Supports HOTP, TOTP and Google Authenticator
@@ -233,21 +267,21 @@ STATUS     PURL                                                   RELATION  LIFE
 │   [npmjs] Deprecated in npm registry (confidence 0.90)
 │     ↳ https://registry.npmjs.org/@otplib%2Fplugin-crypto
 ├─ Health ──────────────────────────────────────────────────
-│ 2221 stars
-│ Used by: 678 packages
+│ 2258 stars
+│ Used by: 721 packages
 │ Depends on: 1 direct, 0 transitive
 │ Scorecard Overall: 7.1/10  Maintained: 10.0/10
-│ Last Commit: 2026-04-04
+│ Last Commit: 2026-05-29
 ├─ Releases ────────────────────────────────────────────────
 │ Stable: 12.0.1 (2020-01-24) ⚠️ [DEPRECATED]
 ├─ Links ───────────────────────────────────────────────────
 │ Homepage: https://otplib.yeojz.dev
 │ Repository: https://github.com/yeojz/otplib
 │ Registry: https://www.npmjs.com/package/@otplib/plugin-crypto
-│ deps.dev: https://deps.dev/npm/@otplib/plugin-crypto
+│ deps.dev: https://deps.dev/npm/@otplib%2Fplugin-crypto
 └───────────────────────────────────────────────────────────
 
---- PURL 6 ---
+--- PURL 8 ---
 ── pkg:npm/%40otplib/plugin-thirty-two@12.0.1 ──────────────
 │ One Time Password (OTP) / 2FA for Node.js and Browser -
 │   Supports HOTP, TOTP and Google Authenticator
@@ -259,21 +293,21 @@ STATUS     PURL                                                   RELATION  LIFE
 │   [npmjs] Deprecated in npm registry (confidence 0.90)
 │     ↳ https://registry.npmjs.org/@otplib%2Fplugin-thirty-two
 ├─ Health ──────────────────────────────────────────────────
-│ 2221 stars
-│ Used by: 678 packages
+│ 2258 stars
+│ Used by: 721 packages
 │ Depends on: 2 direct, 0 transitive
 │ Scorecard Overall: 7.1/10  Maintained: 10.0/10
-│ Last Commit: 2026-04-04
+│ Last Commit: 2026-05-29
 ├─ Releases ────────────────────────────────────────────────
 │ Stable: 12.0.1 (2020-01-24) ⚠️ [DEPRECATED]
 ├─ Links ───────────────────────────────────────────────────
 │ Homepage: https://otplib.yeojz.dev
 │ Repository: https://github.com/yeojz/otplib
 │ Registry: https://www.npmjs.com/package/@otplib/plugin-thirty-two
-│ deps.dev: https://deps.dev/npm/@otplib/plugin-thirty-two
+│ deps.dev: https://deps.dev/npm/@otplib%2Fplugin-thirty-two
 └───────────────────────────────────────────────────────────
 
---- PURL 7 ---
+--- PURL 9 ---
 ── pkg:npm/%40otplib/preset-default@12.0.1 ─────────────────
 │ One Time Password (OTP) / 2FA for Node.js and Browser -
 │   Supports HOTP, TOTP and Google Authenticator
@@ -285,26 +319,26 @@ STATUS     PURL                                                   RELATION  LIFE
 │   [npmjs] Deprecated in npm registry (confidence 0.90)
 │     ↳ https://registry.npmjs.org/@otplib%2Fpreset-default
 ├─ Health ──────────────────────────────────────────────────
-│ 2221 stars
-│ Used by: 661 packages
+│ 2258 stars
+│ Used by: 704 packages
 │ Depends on: 3 direct, 1 transitive
 │ Scorecard Overall: 7.1/10  Maintained: 10.0/10
-│ Last Commit: 2026-04-04
+│ Last Commit: 2026-05-29
 ├─ Releases ────────────────────────────────────────────────
 │ Stable: 12.0.1 (2020-01-24) ⚠️ [DEPRECATED]
 ├─ Links ───────────────────────────────────────────────────
 │ Homepage: https://otplib.yeojz.dev
 │ Repository: https://github.com/yeojz/otplib
 │ Registry: https://www.npmjs.com/package/@otplib/preset-default
-│ deps.dev: https://deps.dev/npm/@otplib/preset-default
+│ deps.dev: https://deps.dev/npm/@otplib%2Fpreset-default
 └───────────────────────────────────────────────────────────
 
---- PURL 8 ---
+--- PURL 10 ---
 ── pkg:npm/%40sinonjs/text-encoding@0.7.2 ──────────────────
 │ Polyfill for the Encoding Living Standard's API
-│ 🔴 EOL-Confirmed: Repository archived or disabled
+│ 🔴 EOL-Confirmed: Deprecated in npm registry
 ├─ Signals ─────────────────────────────────────────────────
-│ Repo Archived: true
+│ EOL Source: npmjs
 ├─ EOL ─────────────────────────────────────────────────────
 │ Evidence (1):
 │   [npmjs] Deprecated in npm registry (confidence 0.90)
@@ -321,10 +355,10 @@ STATUS     PURL                                                   RELATION  LIFE
 ├─ Links ───────────────────────────────────────────────────
 │ Repository: https://github.com/sinonjs/text-encoding
 │ Registry: https://www.npmjs.com/package/@sinonjs/text-encoding
-│ deps.dev: https://deps.dev/npm/@sinonjs/text-encoding
+│ deps.dev: https://deps.dev/npm/@sinonjs%2Ftext-encoding
 └───────────────────────────────────────────────────────────
 
---- PURL 9 ---
+--- PURL 11 ---
 ── pkg:npm/%40types/config@0.0.41 ──────────────────────────
 │ The repository for high quality TypeScript type
 │   definitions.
@@ -336,10 +370,10 @@ STATUS     PURL                                                   RELATION  LIFE
 │   [npmjs] Deprecated in npm registry (confidence 0.90)
 │     ↳ https://registry.npmjs.org/@types%2Fconfig
 ├─ Health ──────────────────────────────────────────────────
-│ 51151 stars
+│ 51295 stars
 │ Used by: 22 packages
 │ Scorecard Overall: 6.5/10  Maintained: 10.0/10
-│ Last Commit: 2026-04-05
+│ Last Commit: 2026-06-22
 ├─ Releases ────────────────────────────────────────────────
 │ Stable: 4.4.0 (2026-03-18) ⚠️ [DEPRECATED]
 │ Pre-release: 0.0.28-alpha (2016-07-08)
@@ -347,10 +381,10 @@ STATUS     PURL                                                   RELATION  LIFE
 ├─ Links ───────────────────────────────────────────────────
 │ Repository: https://github.com/definitelytyped/definitelytyped
 │ Registry: https://www.npmjs.com/package/@types/config
-│ deps.dev: https://deps.dev/npm/@types/config
+│ deps.dev: https://deps.dev/npm/@types%2Fconfig
 └───────────────────────────────────────────────────────────
 
---- PURL 10 ---
+--- PURL 12 ---
 ── pkg:npm/%40types/cookie@0.4.1 ───────────────────────────
 │ The repository for high quality TypeScript type
 │   definitions.
@@ -362,10 +396,10 @@ STATUS     PURL                                                   RELATION  LIFE
 │   [npmjs] Deprecated in npm registry (confidence 0.90)
 │     ↳ https://registry.npmjs.org/@types%2Fcookie
 ├─ Health ──────────────────────────────────────────────────
-│ 51151 stars
-│ Used by: 3660 packages
+│ 51295 stars
+│ Used by: 3655 packages
 │ Scorecard Overall: 6.5/10  Maintained: 10.0/10
-│ Last Commit: 2026-04-05
+│ Last Commit: 2026-06-22
 ├─ Releases ────────────────────────────────────────────────
 │ Stable: 1.0.0 (2024-10-29) ⚠️ [DEPRECATED]
 │ Pre-release: 0.1.27-alpha (2016-07-08)
@@ -373,10 +407,10 @@ STATUS     PURL                                                   RELATION  LIFE
 ├─ Links ───────────────────────────────────────────────────
 │ Repository: https://github.com/definitelytyped/definitelytyped
 │ Registry: https://www.npmjs.com/package/@types/cookie
-│ deps.dev: https://deps.dev/npm/@types/cookie
+│ deps.dev: https://deps.dev/npm/@types%2Fcookie
 └───────────────────────────────────────────────────────────
 
---- PURL 11 ---
+--- PURL 13 ---
 ── pkg:npm/%40types/express-jwt@6.0.4 ──────────────────────
 │ The repository for high quality TypeScript type
 │   definitions.
@@ -388,11 +422,11 @@ STATUS     PURL                                                   RELATION  LIFE
 │   [npmjs] Deprecated in npm registry (confidence 0.90)
 │     ↳ https://registry.npmjs.org/@types%2Fexpress-jwt
 ├─ Health ──────────────────────────────────────────────────
-│ 51151 stars
+│ 51295 stars
 │ Used by: 12 packages
 │ Depends on: 2 direct, 11 transitive
 │ Scorecard Overall: 6.5/10  Maintained: 10.0/10
-│ Last Commit: 2026-04-05
+│ Last Commit: 2026-06-22
 ├─ Releases ────────────────────────────────────────────────
 │ Stable: 7.4.4 (2024-10-23) ⚠️ [DEPRECATED]
 │ Pre-release: 0.0.28-alpha (2016-07-08)
@@ -400,10 +434,10 @@ STATUS     PURL                                                   RELATION  LIFE
 ├─ Links ───────────────────────────────────────────────────
 │ Repository: https://github.com/definitelytyped/definitelytyped
 │ Registry: https://www.npmjs.com/package/@types/express-jwt
-│ deps.dev: https://deps.dev/npm/@types/express-jwt
+│ deps.dev: https://deps.dev/npm/@types%2Fexpress-jwt
 └───────────────────────────────────────────────────────────
 
---- PURL 12 ---
+--- PURL 14 ---
 ── pkg:npm/%40types/express-unless@2.0.1 ───────────────────
 │ The repository for high quality TypeScript type
 │   definitions.
@@ -415,10 +449,10 @@ STATUS     PURL                                                   RELATION  LIFE
 │   [npmjs] Deprecated in npm registry (confidence 0.90)
 │     ↳ https://registry.npmjs.org/@types%2Fexpress-unless
 ├─ Health ──────────────────────────────────────────────────
-│ 51151 stars
+│ 51295 stars
 │ Depends on: 1 direct, 0 transitive
 │ Scorecard Overall: 6.5/10  Maintained: 10.0/10
-│ Last Commit: 2026-04-05
+│ Last Commit: 2026-06-22
 ├─ Releases ────────────────────────────────────────────────
 │ Stable: 2.0.3 (2024-10-23) ⚠️ [DEPRECATED]
 │ Pre-release: 0.0.28-alpha (2016-07-08)
@@ -426,10 +460,10 @@ STATUS     PURL                                                   RELATION  LIFE
 ├─ Links ───────────────────────────────────────────────────
 │ Repository: https://github.com/definitelytyped/definitelytyped
 │ Registry: https://www.npmjs.com/package/@types/express-unless
-│ deps.dev: https://deps.dev/npm/@types/express-unless
+│ deps.dev: https://deps.dev/npm/@types%2Fexpress-unless
 └───────────────────────────────────────────────────────────
 
---- PURL 13 ---
+--- PURL 15 ---
 ── pkg:npm/%40types/glob@7.2.0 ─────────────────────────────
 │ The repository for high quality TypeScript type
 │   definitions.
@@ -441,11 +475,11 @@ STATUS     PURL                                                   RELATION  LIFE
 │   [npmjs] Deprecated in npm registry (confidence 0.90)
 │     ↳ https://registry.npmjs.org/@types%2Fglob
 ├─ Health ──────────────────────────────────────────────────
-│ 51151 stars
-│ Used by: 51842 packages
+│ 51295 stars
+│ Used by: 51777 packages
 │ Depends on: 2 direct, 4 transitive
 │ Scorecard Overall: 6.5/10  Maintained: 10.0/10
-│ Last Commit: 2026-04-05
+│ Last Commit: 2026-06-22
 ├─ Releases ────────────────────────────────────────────────
 │ Stable: 9.0.0 (2025-07-01) ⚠️ [DEPRECATED]
 │ Pre-release: 5.0.28-alpha (2016-07-08)
@@ -453,10 +487,10 @@ STATUS     PURL                                                   RELATION  LIFE
 ├─ Links ───────────────────────────────────────────────────
 │ Repository: https://github.com/definitelytyped/definitelytyped
 │ Registry: https://www.npmjs.com/package/@types/glob
-│ deps.dev: https://deps.dev/npm/@types/glob
+│ deps.dev: https://deps.dev/npm/@types%2Fglob
 └───────────────────────────────────────────────────────────
 
---- PURL 14 ---
+--- PURL 16 ---
 ── pkg:npm/%40types/json5@0.0.29 ───────────────────────────
 │ The repository for high quality TypeScript type
 │   definitions.
@@ -468,10 +502,10 @@ STATUS     PURL                                                   RELATION  LIFE
 │   [npmjs] Deprecated in npm registry (confidence 0.90)
 │     ↳ https://registry.npmjs.org/@types%2Fjson5
 ├─ Health ──────────────────────────────────────────────────
-│ 51151 stars
-│ Used by: 77432 packages
+│ 51295 stars
+│ Used by: 77445 packages
 │ Scorecard Overall: 6.5/10  Maintained: 10.0/10
-│ Last Commit: 2026-04-05
+│ Last Commit: 2026-06-22
 ├─ Releases ────────────────────────────────────────────────
 │ Stable: 2.2.0 (2021-02-01) ⚠️ [DEPRECATED]
 │ Pre-release: 0.0.27-alpha (2016-07-08)
@@ -479,10 +513,10 @@ STATUS     PURL                                                   RELATION  LIFE
 ├─ Links ───────────────────────────────────────────────────
 │ Repository: https://github.com/definitelytyped/definitelytyped
 │ Registry: https://www.npmjs.com/package/@types/json5
-│ deps.dev: https://deps.dev/npm/@types/json5
+│ deps.dev: https://deps.dev/npm/@types%2Fjson5
 └───────────────────────────────────────────────────────────
 
---- PURL 15 ---
+--- PURL 17 ---
 ── pkg:npm/%40types/mime@3.0.1 ─────────────────────────────
 │ The repository for high quality TypeScript type
 │   definitions.
@@ -494,10 +528,10 @@ STATUS     PURL                                                   RELATION  LIFE
 │   [npmjs] Deprecated in npm registry (confidence 0.90)
 │     ↳ https://registry.npmjs.org/@types%2Fmime
 ├─ Health ──────────────────────────────────────────────────
-│ 51151 stars
+│ 51295 stars
 │ Used by: 4 packages
 │ Scorecard Overall: 6.5/10  Maintained: 10.0/10
-│ Last Commit: 2026-04-05
+│ Last Commit: 2026-06-22
 ├─ Releases ────────────────────────────────────────────────
 │ Stable: 4.0.0 (2024-03-31) ⚠️ [DEPRECATED]
 │ Pre-release: 0.0.27-alpha (2016-07-08)
@@ -505,10 +539,10 @@ STATUS     PURL                                                   RELATION  LIFE
 ├─ Links ───────────────────────────────────────────────────
 │ Repository: https://github.com/definitelytyped/definitelytyped
 │ Registry: https://www.npmjs.com/package/@types/mime
-│ deps.dev: https://deps.dev/npm/@types/mime
+│ deps.dev: https://deps.dev/npm/@types%2Fmime
 └───────────────────────────────────────────────────────────
 
---- PURL 16 ---
+--- PURL 18 ---
 ── pkg:npm/%40types/minimatch@5.1.2 ────────────────────────
 │ The repository for high quality TypeScript type
 │   definitions.
@@ -520,10 +554,10 @@ STATUS     PURL                                                   RELATION  LIFE
 │   [npmjs] Deprecated in npm registry (confidence 0.90)
 │     ↳ https://registry.npmjs.org/@types%2Fminimatch
 ├─ Health ──────────────────────────────────────────────────
-│ 51151 stars
-│ Used by: 1470 packages
+│ 51295 stars
+│ Used by: 1397 packages
 │ Scorecard Overall: 6.5/10  Maintained: 10.0/10
-│ Last Commit: 2026-04-05
+│ Last Commit: 2026-06-22
 ├─ Releases ────────────────────────────────────────────────
 │ Stable: 6.0.0 (2025-07-01) ⚠️ [DEPRECATED]
 │ Pre-release: 2.0.27-alpha (2016-07-08)
@@ -531,10 +565,10 @@ STATUS     PURL                                                   RELATION  LIFE
 ├─ Links ───────────────────────────────────────────────────
 │ Repository: https://github.com/definitelytyped/definitelytyped
 │ Registry: https://www.npmjs.com/package/@types/minimatch
-│ deps.dev: https://deps.dev/npm/@types/minimatch
+│ deps.dev: https://deps.dev/npm/@types%2Fminimatch
 └───────────────────────────────────────────────────────────
 
---- PURL 17 ---
+--- PURL 19 ---
 ── pkg:npm/%40types/prettier@2.7.2 ─────────────────────────
 │ The repository for high quality TypeScript type
 │   definitions.
@@ -546,20 +580,20 @@ STATUS     PURL                                                   RELATION  LIFE
 │   [npmjs] Deprecated in npm registry (confidence 0.90)
 │     ↳ https://registry.npmjs.org/@types%2Fprettier
 ├─ Health ──────────────────────────────────────────────────
-│ 51151 stars
+│ 51295 stars
 │ Used by: 20 packages
 │ Scorecard Overall: 6.5/10  Maintained: 10.0/10
-│ Last Commit: 2026-04-05
+│ Last Commit: 2026-06-22
 ├─ Releases ────────────────────────────────────────────────
 │ Stable: 3.0.0 (2023-07-29) ⚠️ [DEPRECATED]
 │ Requested: 2.7.2 (2022-12-20)
 ├─ Links ───────────────────────────────────────────────────
 │ Repository: https://github.com/definitelytyped/definitelytyped
 │ Registry: https://www.npmjs.com/package/@types/prettier
-│ deps.dev: https://deps.dev/npm/@types/prettier
+│ deps.dev: https://deps.dev/npm/@types%2Fprettier
 └───────────────────────────────────────────────────────────
 
---- PURL 18 ---
+--- PURL 20 ---
 ── pkg:npm/%40types/sequelize@4.28.14 ──────────────────────
 │ The repository for high quality TypeScript type
 │   definitions.
@@ -571,11 +605,11 @@ STATUS     PURL                                                   RELATION  LIFE
 │   [npmjs] Deprecated in npm registry (confidence 0.90)
 │     ↳ https://registry.npmjs.org/@types%2Fsequelize
 ├─ Health ──────────────────────────────────────────────────
-│ 51151 stars
+│ 51295 stars
 │ Used by: 1 packages
 │ Depends on: 4 direct, 2 transitive
 │ Scorecard Overall: 6.5/10  Maintained: 10.0/10
-│ Last Commit: 2026-04-05
+│ Last Commit: 2026-06-22
 ├─ Releases ────────────────────────────────────────────────
 │ Stable: 6.12.0 (2025-07-10) ⚠️ [DEPRECATED]
 │ Pre-release: 3.4.26-alpha (2016-07-08)
@@ -583,10 +617,10 @@ STATUS     PURL                                                   RELATION  LIFE
 ├─ Links ───────────────────────────────────────────────────
 │ Repository: https://github.com/definitelytyped/definitelytyped
 │ Registry: https://www.npmjs.com/package/@types/sequelize
-│ deps.dev: https://deps.dev/npm/@types/sequelize
+│ deps.dev: https://deps.dev/npm/@types%2Fsequelize
 └───────────────────────────────────────────────────────────
 
---- PURL 19 ---
+--- PURL 21 ---
 ── pkg:npm/%40types/socket.io-client@1.4.36 ────────────────
 │ The repository for high quality TypeScript type
 │   definitions.
@@ -598,10 +632,10 @@ STATUS     PURL                                                   RELATION  LIFE
 │   [npmjs] Deprecated in npm registry (confidence 0.90)
 │     ↳ https://registry.npmjs.org/@types%2Fsocket.io-client
 ├─ Health ──────────────────────────────────────────────────
-│ 51151 stars
-│ Used by: 794 packages
+│ 51295 stars
+│ Used by: 799 packages
 │ Scorecard Overall: 6.5/10  Maintained: 10.0/10
-│ Last Commit: 2026-04-05
+│ Last Commit: 2026-06-22
 ├─ Releases ────────────────────────────────────────────────
 │ Stable: 3.0.0 (2021-05-14) ⚠️ [DEPRECATED]
 │ Pre-release: 1.4.25-alpha (2016-07-08)
@@ -609,10 +643,10 @@ STATUS     PURL                                                   RELATION  LIFE
 ├─ Links ───────────────────────────────────────────────────
 │ Repository: https://github.com/definitelytyped/definitelytyped
 │ Registry: https://www.npmjs.com/package/@types/socket.io-client
-│ deps.dev: https://deps.dev/npm/@types/socket.io-client
+│ deps.dev: https://deps.dev/npm/@types%2Fsocket.io-client
 └───────────────────────────────────────────────────────────
 
---- PURL 20 ---
+--- PURL 22 ---
 ── pkg:npm/%40types/socket.io-parser@3.0.0 ─────────────────
 │ The repository for high quality TypeScript type
 │   definitions.
@@ -624,20 +658,20 @@ STATUS     PURL                                                   RELATION  LIFE
 │   [npmjs] Deprecated in npm registry (confidence 0.90)
 │     ↳ https://registry.npmjs.org/@types%2Fsocket.io-parser
 ├─ Health ──────────────────────────────────────────────────
-│ 51151 stars
+│ 51295 stars
 │ Used by: 528 packages
 │ Depends on: 1 direct, 3 transitive
 │ Scorecard Overall: 6.5/10  Maintained: 10.0/10
-│ Last Commit: 2026-04-05
+│ Last Commit: 2026-06-22
 ├─ Releases ────────────────────────────────────────────────
 │ Stable: 3.0.0 (2021-05-14) ⚠️ [DEPRECATED]
 ├─ Links ───────────────────────────────────────────────────
 │ Repository: https://github.com/definitelytyped/definitelytyped
 │ Registry: https://www.npmjs.com/package/@types/socket.io-parser
-│ deps.dev: https://deps.dev/npm/@types/socket.io-parser
+│ deps.dev: https://deps.dev/npm/@types%2Fsocket.io-parser
 └───────────────────────────────────────────────────────────
 
---- PURL 21 ---
+--- PURL 23 ---
 ── pkg:npm/%40types/socket.io@2.1.13 ───────────────────────
 │ The repository for high quality TypeScript type
 │   definitions.
@@ -649,11 +683,11 @@ STATUS     PURL                                                   RELATION  LIFE
 │   [npmjs] Deprecated in npm registry (confidence 0.90)
 │     ↳ https://registry.npmjs.org/@types%2Fsocket.io
 ├─ Health ──────────────────────────────────────────────────
-│ 51151 stars
+│ 51295 stars
 │ Used by: 529 packages
 │ Depends on: 3 direct, 5 transitive
 │ Scorecard Overall: 6.5/10  Maintained: 10.0/10
-│ Last Commit: 2026-04-05
+│ Last Commit: 2026-06-22
 ├─ Releases ────────────────────────────────────────────────
 │ Stable: 3.0.2 (2021-05-14) ⚠️ [DEPRECATED]
 │ Pre-release: 1.4.25-alpha (2016-07-08)
@@ -661,10 +695,10 @@ STATUS     PURL                                                   RELATION  LIFE
 ├─ Links ───────────────────────────────────────────────────
 │ Repository: https://github.com/definitelytyped/definitelytyped
 │ Registry: https://www.npmjs.com/package/@types/socket.io
-│ deps.dev: https://deps.dev/npm/@types/socket.io
+│ deps.dev: https://deps.dev/npm/@types%2Fsocket.io
 └───────────────────────────────────────────────────────────
 
---- PURL 22 ---
+--- PURL 24 ---
 ── pkg:npm/%40types/strip-bom@3.0.0 ────────────────────────
 │ Strip UTF-8 byte order mark (BOM) from a string
 │ 🔴 EOL-Confirmed: Deprecated in npm registry
@@ -676,7 +710,7 @@ STATUS     PURL                                                   RELATION  LIFE
 │     ↳ https://registry.npmjs.org/@types%2Fstrip-bom
 ├─ Health ──────────────────────────────────────────────────
 │ 112 stars
-│ Used by: 1851 packages
+│ Used by: 1849 packages
 │ Scorecard Overall: 3.6/10  Maintained: 0.0/10
 │ Last Commit: 2021-04-16
 ├─ Releases ────────────────────────────────────────────────
@@ -685,10 +719,10 @@ STATUS     PURL                                                   RELATION  LIFE
 ├─ Links ───────────────────────────────────────────────────
 │ Repository: https://github.com/sindresorhus/strip-bom
 │ Registry: https://www.npmjs.com/package/@types/strip-bom
-│ deps.dev: https://deps.dev/npm/@types/strip-bom
+│ deps.dev: https://deps.dev/npm/@types%2Fstrip-bom
 └───────────────────────────────────────────────────────────
 
---- PURL 23 ---
+--- PURL 25 ---
 ── pkg:npm/%40types/strip-json-comments@0.0.30 ─────────────
 │ Strip comments from JSON. Lets you use comments in your
 │   JSON files!
@@ -700,8 +734,8 @@ STATUS     PURL                                                   RELATION  LIFE
 │   [npmjs] Deprecated in npm registry (confidence 0.90)
 │     ↳ https://registry.npmjs.org/@types%2Fstrip-json-comments
 ├─ Health ──────────────────────────────────────────────────
-│ 625 stars
-│ Used by: 1863 packages
+│ 626 stars
+│ Used by: 1861 packages
 │ Scorecard Overall: 3.7/10  Maintained: 0.0/10
 │ Last Commit: 2025-08-08
 ├─ Releases ────────────────────────────────────────────────
@@ -711,15 +745,16 @@ STATUS     PURL                                                   RELATION  LIFE
 ├─ Links ───────────────────────────────────────────────────
 │ Repository: https://github.com/sindresorhus/strip-json-comments
 │ Registry: https://www.npmjs.com/package/@types/strip-json-comments
-│ deps.dev: https://deps.dev/npm/@types/strip-json-comments
+│ deps.dev: https://deps.dev/npm/@types%2Fstrip-json-comments
 └───────────────────────────────────────────────────────────
 
---- PURL 24 ---
+--- PURL 26 ---
 ── pkg:npm/abab@2.0.6 ──────────────────────────────────────
 │ Perfectly spec-compliant atob and btoa implementations
-│ 🔴 EOL-Confirmed: Repository archived or disabled
+│ 🔴 EOL-Confirmed: Deprecated in npm registry; successor:
+│                  your
 ├─ Signals ─────────────────────────────────────────────────
-│ Repo Archived: true
+│ EOL Source: npmjs
 ├─ EOL ─────────────────────────────────────────────────────
 │ ➡️ Successor: your
 │ Evidence (1):
@@ -728,7 +763,7 @@ STATUS     PURL                                                   RELATION  LIFE
 ├─ Health ──────────────────────────────────────────────────
 │ 📦 Archived
 │ 91 stars
-│ Used by: 81466 packages
+│ Used by: 81423 packages
 │ Scorecard Overall: 3.1/10  Maintained: 0.0/10
 │ Last Commit: 2023-11-26
 ├─ Releases ────────────────────────────────────────────────
@@ -739,21 +774,21 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/abab
 └───────────────────────────────────────────────────────────
 
---- PURL 25 ---
+--- PURL 27 ---
 ── pkg:npm/are-we-there-yet@1.1.7 ──────────────────────────
 │ Track complex hiearchies of asynchronous task completion
 │   statuses.
-│ 🔴 EOL-Confirmed: Repository archived or disabled
+│ 🔴 EOL-Confirmed: Deprecated in npm registry
 ├─ Signals ─────────────────────────────────────────────────
-│ Repo Archived: true
+│ EOL Source: npmjs
 ├─ EOL ─────────────────────────────────────────────────────
 │ Evidence (1):
 │   [npmjs] Deprecated in npm registry (confidence 0.90)
 │     ↳ https://registry.npmjs.org/are-we-there-yet
 ├─ Health ──────────────────────────────────────────────────
 │ 📦 Archived
-│ 182 stars
-│ Used by: 36503 packages
+│ 183 stars
+│ Used by: 19701 packages
 │ Depends on: 2 direct, 4 transitive
 │ Scorecard Overall: 5.5/10  Maintained: 0.0/10
 │ Last Commit: 2024-05-04
@@ -766,21 +801,21 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/are-we-there-yet
 └───────────────────────────────────────────────────────────
 
---- PURL 26 ---
+--- PURL 28 ---
 ── pkg:npm/are-we-there-yet@2.0.0 ──────────────────────────
 │ Track complex hiearchies of asynchronous task completion
 │   statuses.
-│ 🔴 EOL-Confirmed: Repository archived or disabled
+│ 🔴 EOL-Confirmed: Deprecated in npm registry
 ├─ Signals ─────────────────────────────────────────────────
-│ Repo Archived: true
+│ EOL Source: npmjs
 ├─ EOL ─────────────────────────────────────────────────────
 │ Evidence (1):
 │   [npmjs] Deprecated in npm registry (confidence 0.90)
 │     ↳ https://registry.npmjs.org/are-we-there-yet
 ├─ Health ──────────────────────────────────────────────────
 │ 📦 Archived
-│ 182 stars
-│ Used by: 36503 packages
+│ 183 stars
+│ Used by: 19701 packages
 │ Depends on: 2 direct, 4 transitive
 │ Scorecard Overall: 5.5/10  Maintained: 0.0/10
 │ Last Commit: 2024-05-04
@@ -793,21 +828,21 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/are-we-there-yet
 └───────────────────────────────────────────────────────────
 
---- PURL 27 ---
+--- PURL 29 ---
 ── pkg:npm/are-we-there-yet@3.0.1 ──────────────────────────
 │ Track complex hiearchies of asynchronous task completion
 │   statuses.
-│ 🔴 EOL-Confirmed: Repository archived or disabled
+│ 🔴 EOL-Confirmed: Deprecated in npm registry
 ├─ Signals ─────────────────────────────────────────────────
-│ Repo Archived: true
+│ EOL Source: npmjs
 ├─ EOL ─────────────────────────────────────────────────────
 │ Evidence (1):
 │   [npmjs] Deprecated in npm registry (confidence 0.90)
 │     ↳ https://registry.npmjs.org/are-we-there-yet
 ├─ Health ──────────────────────────────────────────────────
 │ 📦 Archived
-│ 182 stars
-│ Used by: 36503 packages
+│ 183 stars
+│ Used by: 19701 packages
 │ Depends on: 2 direct, 4 transitive
 │ Scorecard Overall: 5.5/10  Maintained: 0.0/10
 │ Last Commit: 2024-05-04
@@ -820,12 +855,12 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/are-we-there-yet
 └───────────────────────────────────────────────────────────
 
---- PURL 28 ---
+--- PURL 30 ---
 ── pkg:npm/code-point-at@1.1.0 ─────────────────────────────
 │ ES2015 `String#codePointAt()` ponyfill
-│ 🔴 EOL-Confirmed: Repository archived or disabled
+│ 🔴 EOL-Confirmed: Deprecated in npm registry
 ├─ Signals ─────────────────────────────────────────────────
-│ Repo Archived: true
+│ EOL Source: npmjs
 ├─ EOL ─────────────────────────────────────────────────────
 │ Evidence (1):
 │   [npmjs] Deprecated in npm registry (confidence 0.90)
@@ -833,7 +868,7 @@ STATUS     PURL                                                   RELATION  LIFE
 ├─ Health ──────────────────────────────────────────────────
 │ 📦 Archived
 │ 23 stars
-│ Used by: 177903 packages
+│ Used by: 177914 packages
 │ Scorecard Overall: 3.4/10  Maintained: 0.0/10
 │ Last Commit: 2021-01-01
 ├─ Releases ────────────────────────────────────────────────
@@ -845,16 +880,17 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/code-point-at
 └───────────────────────────────────────────────────────────
 
---- PURL 29 ---
+--- PURL 31 ---
 ── pkg:npm/doctrine@2.1.0 ──────────────────────────────────
 │ JSDoc parser
-│ 🔴 EOL-Confirmed: Repository archived or disabled
+│ 🔴 Stalled: Repository archived/disabled but not declared
+│            end-of-life
 ├─ Signals ─────────────────────────────────────────────────
 │ Repo Archived: true
 ├─ Health ──────────────────────────────────────────────────
 │ 📦 Archived
-│ 459 stars
-│ Used by: 88845 packages
+│ 461 stars
+│ Used by: 88896 packages
 │ Depends on: 1 direct, 0 transitive
 │ Scorecard Overall: 4.5/10  Maintained: 0.0/10
 │ Last Commit: 2018-12-03
@@ -867,16 +903,17 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/doctrine
 └───────────────────────────────────────────────────────────
 
---- PURL 30 ---
+--- PURL 32 ---
 ── pkg:npm/doctrine@3.0.0 ──────────────────────────────────
 │ JSDoc parser
-│ 🔴 EOL-Confirmed: Repository archived or disabled
+│ 🔴 Stalled: Repository archived/disabled but not declared
+│            end-of-life
 ├─ Signals ─────────────────────────────────────────────────
 │ Repo Archived: true
 ├─ Health ──────────────────────────────────────────────────
 │ 📦 Archived
-│ 459 stars
-│ Used by: 88845 packages
+│ 461 stars
+│ Used by: 88896 packages
 │ Depends on: 1 direct, 0 transitive
 │ Scorecard Overall: 4.5/10  Maintained: 0.0/10
 │ Last Commit: 2018-12-03
@@ -888,12 +925,13 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/doctrine
 └───────────────────────────────────────────────────────────
 
---- PURL 31 ---
+--- PURL 33 ---
 ── pkg:npm/domexception@2.0.1 ──────────────────────────────
 │ An implementation of the DOMException class from browsers
-│ 🔴 EOL-Confirmed: Repository archived or disabled
+│ 🔴 EOL-Confirmed: Deprecated in npm registry; successor:
+│                  your
 ├─ Signals ─────────────────────────────────────────────────
-│ Repo Archived: true
+│ EOL Source: npmjs
 ├─ EOL ─────────────────────────────────────────────────────
 │ ➡️ Successor: your
 │ Evidence (1):
@@ -902,7 +940,7 @@ STATUS     PURL                                                   RELATION  LIFE
 ├─ Health ──────────────────────────────────────────────────
 │ 📦 Archived
 │ 22 stars
-│ Used by: 56686 packages
+│ Used by: 56655 packages
 │ Depends on: 1 direct, 0 transitive
 │ Scorecard Overall: 2.5/10  Maintained: 0.0/10
 │ Last Commit: 2023-11-26
@@ -915,22 +953,22 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/domexception
 └───────────────────────────────────────────────────────────
 
---- PURL 32 ---
+--- PURL 34 ---
 ── pkg:npm/dottie@2.0.3 ────────────────────────────────────
 │ Fast and safe nested object access and manipulation in
 │   JavaScript
-│ 🔴 EOL-Confirmed: Repository archived or disabled
+│ 🔴 EOL-Confirmed: Deprecated in npm registry
 ├─ Signals ─────────────────────────────────────────────────
-│ Repo Archived: true
+│ EOL Source: npmjs
 ├─ EOL ─────────────────────────────────────────────────────
 │ Evidence (1):
 │   [npmjs] Deprecated in npm registry (confidence 0.90)
 │     ↳ https://registry.npmjs.org/dottie
 ├─ Health ──────────────────────────────────────────────────
 │ 📦 Archived
-│ 257 stars
+│ 256 stars
 │ Used by: 26 packages
-│ Scorecard Overall: 3.5/10  Maintained: 2.0/10
+│ Scorecard Overall: 3.3/10  Maintained: 0.0/10
 │ Last Commit: 2026-04-05
 ├─ Releases ────────────────────────────────────────────────
 │ Stable: 2.0.7 (2026-02-24) ⚠️ [DEPRECATED]
@@ -941,7 +979,7 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/dottie
 └───────────────────────────────────────────────────────────
 
---- PURL 33 ---
+--- PURL 35 ---
 ── pkg:npm/download@8.0.0 ──────────────────────────────────
 │ Download and extract files
 │ 🔴 EOL-Effective: Unmaintained, unpatched vulnerabilities
@@ -951,8 +989,8 @@ STATUS     PURL                                                   RELATION  LIFE
 │ Advisories: 2
 │ Max Advisory Severity: HIGH 7.5
 ├─ Health ──────────────────────────────────────────────────
-│ 1305 stars
-│ Used by: 1561 packages
+│ 1304 stars
+│ Used by: 1573 packages
 │ Depends on: 11 direct, 128 transitive
 │ Scorecard Overall: 2.3/10  Maintained: 0.0/10
 │ Last Commit: 2020-04-02
@@ -969,7 +1007,7 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/download
 └───────────────────────────────────────────────────────────
 
---- PURL 34 ---
+--- PURL 36 ---
 ── pkg:npm/ecstatic@3.3.2 ──────────────────────────────────
 │ A static file server middleware that works with core http,
 │   express or on the CLI!
@@ -996,7 +1034,7 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/ecstatic
 └───────────────────────────────────────────────────────────
 
---- PURL 35 ---
+--- PURL 37 ---
 ── pkg:npm/eivindfjeldstad-dot@0.0.1 ───────────────────────
 │ Get and set object properties with dot notation
 │ 🔴 EOL-Confirmed: Deprecated in npm registry; successor:
@@ -1021,7 +1059,7 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/eivindfjeldstad-dot
 └───────────────────────────────────────────────────────────
 
---- PURL 36 ---
+--- PURL 38 ---
 ── pkg:npm/eslint-config-standard-with-typescript@21.0.1 ───
 │ A TypeScript ESLint config that loves you
 │ 🔴 EOL-Confirmed: Deprecated in npm registry; successor:
@@ -1034,11 +1072,11 @@ STATUS     PURL                                                   RELATION  LIFE
 │   [npmjs] Deprecated in npm registry (confidence 0.90)
 │     ↳ https://registry.npmjs.org/eslint-config-standard-with-typescript
 ├─ Health ──────────────────────────────────────────────────
-│ 818 stars
+│ 821 stars
 │ Used by: 90 packages
 │ Depends on: 2 direct, 34 transitive
-│ Scorecard Overall: 4.7/10  Maintained: 10.0/10
-│ Last Commit: 2026-03-26
+│ Scorecard Overall: 4.6/10  Maintained: 10.0/10
+│ Last Commit: 2026-06-19
 ├─ Releases ────────────────────────────────────────────────
 │ Stable: 43.0.1 (2024-01-20) ⚠️ [DEPRECATED]
 │ Requested: 21.0.1 (2021-08-31) ⚠️ [DEPRECATED]
@@ -1048,7 +1086,7 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/eslint-config-standard-with-typescript
 └───────────────────────────────────────────────────────────
 
---- PURL 37 ---
+--- PURL 39 ---
 ── pkg:npm/find-cache-dir@3.3.2 ────────────────────────────
 │ Finds the common standard cache directory
 │ 🔴 EOL-Confirmed: Deprecated in npm registry
@@ -1059,8 +1097,8 @@ STATUS     PURL                                                   RELATION  LIFE
 │   [npmjs] Deprecated in npm registry (confidence 0.90)
 │     ↳ https://registry.npmjs.org/find-cache-dir
 ├─ Health ──────────────────────────────────────────────────
-│ 162 stars
-│ Used by: 79664 packages
+│ 163 stars
+│ Used by: 79709 packages
 │ Depends on: 3 direct, 7 transitive
 │ Scorecard Overall: 3.9/10  Maintained: 0.0/10
 │ Last Commit: 2025-04-08
@@ -1073,12 +1111,13 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/find-cache-dir
 └───────────────────────────────────────────────────────────
 
---- PURL 38 ---
+--- PURL 40 ---
 ── pkg:npm/formatio@1.1.1 ──────────────────────────────────
 │ The cheesy object formatter
-│ 🔴 EOL-Confirmed: Repository archived or disabled
+│ 🔴 EOL-Confirmed: Deprecated in npm registry; successor:
+│                  @sinonjs/formatio
 ├─ Signals ─────────────────────────────────────────────────
-│ Repo Archived: true
+│ EOL Source: npmjs
 ├─ EOL ─────────────────────────────────────────────────────
 │ ➡️ Successor: @sinonjs/formatio
 │ Evidence (1):
@@ -1087,7 +1126,7 @@ STATUS     PURL                                                   RELATION  LIFE
 ├─ Health ──────────────────────────────────────────────────
 │ 📦 Archived
 │ 36 stars
-│ Used by: 4790 packages
+│ Used by: 4788 packages
 │ Depends on: 1 direct, 0 transitive
 │ Scorecard Overall: 2.6/10  Maintained: 0.0/10
 │ Last Commit: 2021-01-06
@@ -1101,12 +1140,40 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/formatio
 └───────────────────────────────────────────────────────────
 
---- PURL 39 ---
+--- PURL 41 ---
+── pkg:npm/frontend@14.5.1 ─────────────────────────────────
+│ A Frontend Management System
+│ 🔴 EOL-Effective: Unmaintained, unpatched vulnerabilities
+├─ Signals ─────────────────────────────────────────────────
+│ Last Human Commit: 2019-02-09
+│ Maintained Score: 0/10
+│ Advisories: 27
+│ Max Advisory Severity: HIGH 8.8
+├─ Health ──────────────────────────────────────────────────
+│ Depends on: 9 direct, 519 transitive
+│ Scorecard Overall: 2.0/10  Maintained: 0.0/10
+│ Last Commit: 2019-02-09
+├─ Releases ────────────────────────────────────────────────
+│ Stable: 2.0.0-alpha.4 (2019-02-09)  ⚠️ 27 transitive advisories
+│   Transitive (via tar@2.2.2):
+│     HIGH     (8.8)  GHSA-r6q2-hw4h-h46w
+│     HIGH     (8.2)  GHSA-34x7-hfp2-rc4v
+│     HIGH     (8.2)  GHSA-3jfq-g458-7qm9
+│     ... and 24 more
+│   → https://deps.dev/npm/frontend/2.0.0-alpha.4
+├─ Links ───────────────────────────────────────────────────
+│ Homepage: https://www.npmjs.org/package/frontend
+│ Repository: https://github.com/danieljackson1983/frontend
+│ Registry: https://www.npmjs.com/package/frontend
+│ deps.dev: https://deps.dev/npm/frontend
+└───────────────────────────────────────────────────────────
+
+--- PURL 42 ---
 ── pkg:npm/fstream@1.0.12 ──────────────────────────────────
 │ Advanced FS Streaming for Node
-│ 🔴 EOL-Confirmed: Repository archived or disabled
+│ 🔴 EOL-Confirmed: Deprecated in npm registry
 ├─ Signals ─────────────────────────────────────────────────
-│ Repo Archived: true
+│ EOL Source: npmjs
 ├─ EOL ─────────────────────────────────────────────────────
 │ Evidence (1):
 │   [npmjs] Deprecated in npm registry (confidence 0.90)
@@ -1114,7 +1181,7 @@ STATUS     PURL                                                   RELATION  LIFE
 ├─ Health ──────────────────────────────────────────────────
 │ 📦 Archived
 │ 209 stars
-│ Used by: 46158 packages
+│ Used by: 46488 packages
 │ Depends on: 4 direct, 11 transitive
 │ Scorecard Overall: 2.0/10  Maintained: 0.0/10
 │ Last Commit: 2021-06-01
@@ -1126,21 +1193,21 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/fstream
 └───────────────────────────────────────────────────────────
 
---- PURL 40 ---
+--- PURL 43 ---
 ── pkg:npm/gauge@2.7.4 ─────────────────────────────────────
 │ A terminal based horizontal guage aka, a progress bar
-│ 🔴 EOL-Confirmed: Repository archived or disabled
+│ 🔴 EOL-Confirmed: Deprecated in npm registry
 ├─ Signals ─────────────────────────────────────────────────
-│ Repo Archived: true
+│ EOL Source: npmjs
 ├─ EOL ─────────────────────────────────────────────────────
 │ Evidence (1):
 │   [npmjs] Deprecated in npm registry (confidence 0.90)
 │     ↳ https://registry.npmjs.org/gauge
 ├─ Health ──────────────────────────────────────────────────
 │ 📦 Archived
-│ 322 stars
-│ Used by: 19478 packages
-│ Depends on: 8 direct, 4 transitive
+│ 321 stars
+│ Used by: 19805 packages
+│ Depends on: 8 direct, 3 transitive
 │ Scorecard Overall: 5.5/10  Maintained: 0.0/10
 │ Last Commit: 2024-05-04
 ├─ Releases ────────────────────────────────────────────────
@@ -1152,21 +1219,21 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/gauge
 └───────────────────────────────────────────────────────────
 
---- PURL 41 ---
+--- PURL 44 ---
 ── pkg:npm/gauge@3.0.2 ─────────────────────────────────────
 │ A terminal based horizontal guage aka, a progress bar
-│ 🔴 EOL-Confirmed: Repository archived or disabled
+│ 🔴 EOL-Confirmed: Deprecated in npm registry
 ├─ Signals ─────────────────────────────────────────────────
-│ Repo Archived: true
+│ EOL Source: npmjs
 ├─ EOL ─────────────────────────────────────────────────────
 │ Evidence (1):
 │   [npmjs] Deprecated in npm registry (confidence 0.90)
 │     ↳ https://registry.npmjs.org/gauge
 ├─ Health ──────────────────────────────────────────────────
 │ 📦 Archived
-│ 322 stars
-│ Used by: 19478 packages
-│ Depends on: 8 direct, 4 transitive
+│ 321 stars
+│ Used by: 19805 packages
+│ Depends on: 8 direct, 3 transitive
 │ Scorecard Overall: 5.5/10  Maintained: 0.0/10
 │ Last Commit: 2024-05-04
 ├─ Releases ────────────────────────────────────────────────
@@ -1178,21 +1245,21 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/gauge
 └───────────────────────────────────────────────────────────
 
---- PURL 42 ---
+--- PURL 45 ---
 ── pkg:npm/gauge@4.0.4 ─────────────────────────────────────
 │ A terminal based horizontal guage aka, a progress bar
-│ 🔴 EOL-Confirmed: Repository archived or disabled
+│ 🔴 EOL-Confirmed: Deprecated in npm registry
 ├─ Signals ─────────────────────────────────────────────────
-│ Repo Archived: true
+│ EOL Source: npmjs
 ├─ EOL ─────────────────────────────────────────────────────
 │ Evidence (1):
 │   [npmjs] Deprecated in npm registry (confidence 0.90)
 │     ↳ https://registry.npmjs.org/gauge
 ├─ Health ──────────────────────────────────────────────────
 │ 📦 Archived
-│ 322 stars
-│ Used by: 19478 packages
-│ Depends on: 8 direct, 4 transitive
+│ 321 stars
+│ Used by: 19805 packages
+│ Depends on: 8 direct, 3 transitive
 │ Scorecard Overall: 5.5/10  Maintained: 0.0/10
 │ Last Commit: 2024-05-04
 ├─ Releases ────────────────────────────────────────────────
@@ -1204,7 +1271,7 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/gauge
 └───────────────────────────────────────────────────────────
 
---- PURL 43 ---
+--- PURL 46 ---
 ── pkg:npm/global-dirs@3.0.1 ───────────────────────────────
 │ Get the directory of globally installed packages and
 │   binaries
@@ -1217,9 +1284,9 @@ STATUS     PURL                                                   RELATION  LIFE
 │     ↳ https://registry.npmjs.org/global-dirs
 ├─ Health ──────────────────────────────────────────────────
 │ 77 stars
-│ Used by: 10366 packages
+│ Used by: 10401 packages
 │ Depends on: 1 direct, 0 transitive
-│ Scorecard Overall: 4.3/10  Maintained: 7.0/10
+│ Scorecard Overall: 3.6/10  Maintained: 0.0/10
 │ Last Commit: 2026-02-02
 ├─ Releases ────────────────────────────────────────────────
 │ Stable: 4.0.0 (2023-11-06) ⚠️ [DEPRECATED]
@@ -1230,63 +1297,7 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/global-dirs
 └───────────────────────────────────────────────────────────
 
---- PURL 44 ---
-── pkg:npm/grunt-legacy-log@3.0.0 ──────────────────────────
-│ The Grunt logger.
-│ 🔴 EOL-Effective: Unmaintained, unpatched vulnerabilities
-├─ Signals ─────────────────────────────────────────────────
-│ Last Human Commit: 2020-07-27
-│ Maintained Score: 0/10
-│ Advisories: 2
-│ Max Advisory Severity: HIGH 8.1
-├─ Health ──────────────────────────────────────────────────
-│ 6 stars
-│ Used by: 1157 packages
-│ Depends on: 4 direct, 6 transitive
-│ Scorecard Overall: 3.0/10  Maintained: 0.0/10
-│ Last Commit: 2020-07-27
-├─ Releases ────────────────────────────────────────────────
-│ Stable: 3.0.0 (2020-07-27)  ⚠️ 2 transitive advisories
-│   Transitive (via lodash@4.17.23):
-│     HIGH     (8.1)  GHSA-r5fr-rjxr-66jc
-│     MEDIUM   (6.5)  GHSA-f23m-r3pf-42rh
-│   → https://deps.dev/npm/grunt-legacy-log/3.0.0
-│ Pre-release: 1.0.0-rc1 (2016-02-11)
-├─ Links ───────────────────────────────────────────────────
-│ Repository: https://github.com/gruntjs/grunt-legacy-log
-│ Registry: https://www.npmjs.com/package/grunt-legacy-log
-│ deps.dev: https://deps.dev/npm/grunt-legacy-log
-└───────────────────────────────────────────────────────────
-
---- PURL 45 ---
-── pkg:npm/grunt-legacy-util@2.0.1 ─────────────────────────
-│ deprecated utility methods
-│ 🔴 EOL-Effective: Unmaintained, unpatched vulnerabilities
-├─ Signals ─────────────────────────────────────────────────
-│ Last Human Commit: 2021-04-22
-│ Maintained Score: 0/10
-│ Advisories: 2
-│ Max Advisory Severity: HIGH 8.1
-├─ Health ──────────────────────────────────────────────────
-│ 5 stars
-│ Used by: 1157 packages
-│ Depends on: 7 direct, 3 transitive
-│ Scorecard Overall: 3.2/10  Maintained: 0.0/10
-│ Last Commit: 2021-04-22
-├─ Releases ────────────────────────────────────────────────
-│ Stable: 2.0.1 (2021-04-22)  ⚠️ 2 transitive advisories
-│   Transitive (via lodash@4.17.23):
-│     HIGH     (8.1)  GHSA-r5fr-rjxr-66jc
-│     MEDIUM   (6.5)  GHSA-f23m-r3pf-42rh
-│   → https://deps.dev/npm/grunt-legacy-util/2.0.1
-│ Pre-release: 1.0.0-rc1 (2016-02-11)
-├─ Links ───────────────────────────────────────────────────
-│ Repository: https://github.com/gruntjs/grunt-legacy-util
-│ Registry: https://www.npmjs.com/package/grunt-legacy-util
-│ deps.dev: https://deps.dev/npm/grunt-legacy-util
-└───────────────────────────────────────────────────────────
-
---- PURL 46 ---
+--- PURL 47 ---
 ── pkg:npm/grunt-replace-json@0.1.0 ────────────────────────
 │ Updates attributes of json files
 │ 🔴 EOL-Effective: Unmaintained, unpatched vulnerabilities
@@ -1310,7 +1321,7 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/grunt-replace-json
 └───────────────────────────────────────────────────────────
 
---- PURL 47 ---
+--- PURL 48 ---
 ── pkg:npm/har-validator@5.1.5 ─────────────────────────────
 │ Extremely fast HTTP Archive (HAR) validator using JSON
 │   Schema
@@ -1323,7 +1334,7 @@ STATUS     PURL                                                   RELATION  LIFE
 │     ↳ https://registry.npmjs.org/har-validator
 ├─ Health ──────────────────────────────────────────────────
 │ 63 stars
-│ Used by: 190515 packages
+│ Used by: 190693 packages
 │ Depends on: 2 direct, 5 transitive
 │ Scorecard Overall: 4.2/10  Maintained: 0.0/10
 │ Last Commit: 2023-08-09
@@ -1335,7 +1346,7 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/har-validator
 └───────────────────────────────────────────────────────────
 
---- PURL 48 ---
+--- PURL 49 ---
 ── pkg:npm/hoek@5.0.4 ──────────────────────────────────────
 │ Node utilities shared among the extended hapi universe
 │ 🔴 EOL-Confirmed: Deprecated in npm registry
@@ -1346,8 +1357,8 @@ STATUS     PURL                                                   RELATION  LIFE
 │   [npmjs] Deprecated in npm registry (confidence 0.90)
 │     ↳ https://registry.npmjs.org/hoek
 ├─ Health ──────────────────────────────────────────────────
-│ 484 stars
-│ Used by: 5967 packages
+│ 483 stars
+│ Used by: 5962 packages
 │ Scorecard Overall: 3.9/10  Maintained: 0.0/10
 │ Last Commit: 2025-03-12
 ├─ Releases ────────────────────────────────────────────────
@@ -1361,7 +1372,7 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/hoek
 └───────────────────────────────────────────────────────────
 
---- PURL 49 ---
+--- PURL 50 ---
 ── pkg:npm/hoek@6.1.3 ──────────────────────────────────────
 │ Node utilities shared among the extended hapi universe
 │ 🔴 EOL-Confirmed: Deprecated in npm registry
@@ -1372,8 +1383,8 @@ STATUS     PURL                                                   RELATION  LIFE
 │   [npmjs] Deprecated in npm registry (confidence 0.90)
 │     ↳ https://registry.npmjs.org/hoek
 ├─ Health ──────────────────────────────────────────────────
-│ 484 stars
-│ Used by: 5967 packages
+│ 483 stars
+│ Used by: 5962 packages
 │ Scorecard Overall: 3.9/10  Maintained: 0.0/10
 │ Last Commit: 2025-03-12
 ├─ Releases ────────────────────────────────────────────────
@@ -1386,13 +1397,39 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/hoek
 └───────────────────────────────────────────────────────────
 
---- PURL 50 ---
+--- PURL 51 ---
+── pkg:npm/http-proxy@1.18.1 ───────────────────────────────
+│ A full-featured http proxy for node.js
+│ 🔴 EOL-Effective: Unmaintained, unpatched vulnerabilities
+├─ Signals ─────────────────────────────────────────────────
+│ Last Human Commit: 2020-05-17
+│ Maintained Score: 0/10
+│ Advisories: 1
+├─ Health ──────────────────────────────────────────────────
+│ 14135 stars
+│ Used by: 92604 packages
+│ Depends on: 3 direct, 0 transitive
+│ Scorecard Overall: 3.1/10  Maintained: 0.0/10
+│ Last Commit: 2020-05-17
+├─ Releases ────────────────────────────────────────────────
+│ Stable: 1.18.1 (2020-05-17)  ⚠️ 1 transitive advisory
+│   Transitive (via follow-redirects@1.15.11):
+│                     GHSA-r4q5-vmmm-2653
+│   → https://deps.dev/npm/http-proxy/1.18.1
+├─ Links ───────────────────────────────────────────────────
+│ Homepage: https://github.com/http-party/node-http-proxy
+│ Repository: https://github.com/http-party/node-http-proxy
+│ Registry: https://www.npmjs.com/package/http-proxy
+│ deps.dev: https://deps.dev/npm/http-proxy
+└───────────────────────────────────────────────────────────
+
+--- PURL 52 ---
 ── pkg:npm/iltorb@2.4.5 ────────────────────────────────────
 │ Node.js module for brotli compression/decompression with
 │   native bindings
-│ 🔴 EOL-Confirmed: Repository archived or disabled
+│ 🔴 EOL-Confirmed: Deprecated in npm registry; successor: it
 ├─ Signals ─────────────────────────────────────────────────
-│ Repo Archived: true
+│ EOL Source: npmjs
 ├─ EOL ─────────────────────────────────────────────────────
 │ ➡️ Successor: it
 │ Evidence (1):
@@ -1413,13 +1450,13 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/iltorb
 └───────────────────────────────────────────────────────────
 
---- PURL 51 ---
+--- PURL 53 ---
 ── pkg:npm/inflight@1.0.6 ──────────────────────────────────
 │ Add callbacks to requests in flight to avoid async
 │   duplication
-│ 🔴 EOL-Confirmed: Repository archived or disabled
+│ 🔴 EOL-Confirmed: Deprecated in npm registry; successor: it
 ├─ Signals ─────────────────────────────────────────────────
-│ Repo Archived: true
+│ EOL Source: npmjs
 ├─ EOL ─────────────────────────────────────────────────────
 │ ➡️ Successor: it
 │ Evidence (1):
@@ -1428,7 +1465,7 @@ STATUS     PURL                                                   RELATION  LIFE
 ├─ Health ──────────────────────────────────────────────────
 │ 📦 Archived
 │ 76 stars
-│ Used by: 556917 packages
+│ Used by: 557347 packages
 │ Depends on: 2 direct, 0 transitive
 │ Scorecard Overall: 2.9/10  Maintained: 0.0/10
 │ Last Commit: 2024-05-23
@@ -1440,7 +1477,7 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/inflight
 └───────────────────────────────────────────────────────────
 
---- PURL 52 ---
+--- PURL 54 ---
 ── pkg:npm/ip@1.1.8 ────────────────────────────────────────
 │ IP address tools for node.js
 │ 🔴 EOL-Effective: Unmaintained, unpatched vulnerabilities
@@ -1450,7 +1487,7 @@ STATUS     PURL                                                   RELATION  LIFE
 │ Advisories: 1
 │ Max Advisory Severity: HIGH 8.1
 ├─ Health ──────────────────────────────────────────────────
-│ 1545 stars
+│ 1542 stars
 │ Used by: 7 packages
 │ Scorecard Overall: 2.6/10  Maintained: 0.0/10
 │ Last Commit: 2024-02-19
@@ -1465,7 +1502,7 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/ip
 └───────────────────────────────────────────────────────────
 
---- PURL 53 ---
+--- PURL 55 ---
 ── pkg:npm/ip@2.0.0 ────────────────────────────────────────
 │ IP address tools for node.js
 │ 🔴 EOL-Effective: Unmaintained, unpatched vulnerabilities
@@ -1475,7 +1512,7 @@ STATUS     PURL                                                   RELATION  LIFE
 │ Advisories: 1
 │ Max Advisory Severity: HIGH 8.1
 ├─ Health ──────────────────────────────────────────────────
-│ 1545 stars
+│ 1542 stars
 │ Used by: 7 packages
 │ Scorecard Overall: 2.6/10  Maintained: 0.0/10
 │ Last Commit: 2024-02-19
@@ -1490,12 +1527,12 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/ip
 └───────────────────────────────────────────────────────────
 
---- PURL 54 ---
+--- PURL 56 ---
 ── pkg:npm/is-gitpod@2.0.9 ─────────────────────────────────
 │ Checks if we are in Gitpod.
-│ 🔴 EOL-Confirmed: Repository archived or disabled
+│ 🔴 EOL-Confirmed: Deprecated in npm registry
 ├─ Signals ─────────────────────────────────────────────────
-│ Repo Archived: true
+│ EOL Source: npmjs
 ├─ EOL ─────────────────────────────────────────────────────
 │ Evidence (1):
 │   [npmjs] Deprecated in npm registry (confidence 0.90)
@@ -1514,17 +1551,18 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/is-gitpod
 └───────────────────────────────────────────────────────────
 
---- PURL 55 ---
+--- PURL 57 ---
 ── pkg:npm/is-windows@1.0.2 ────────────────────────────────
 │ Returns true if the platform is Windows (and Cygwin or
 │   MSYS/MinGW for unit tests)
-│ 🔴 EOL-Confirmed: Repository archived or disabled
+│ 🔴 Stalled: Repository archived/disabled but not declared
+│            end-of-life
 ├─ Signals ─────────────────────────────────────────────────
 │ Repo Archived: true
 ├─ Health ──────────────────────────────────────────────────
 │ 📦 Archived
 │ 48 stars
-│ Used by: 175490 packages
+│ Used by: 175780 packages
 │ Scorecard Overall: 2.1/10  Maintained: 0.0/10
 │ Last Commit: 2018-02-14
 ├─ Releases ────────────────────────────────────────────────
@@ -1536,17 +1574,18 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/is-windows
 └───────────────────────────────────────────────────────────
 
---- PURL 56 ---
+--- PURL 58 ---
 ── pkg:npm/isemail@3.2.0 ───────────────────────────────────
 │ validate an email address according to RFCs 5321, 5322,
 │   and others
-│ 🔴 EOL-Confirmed: Repository archived or disabled
+│ 🔴 Stalled: Repository archived/disabled but not declared
+│            end-of-life
 ├─ Signals ─────────────────────────────────────────────────
 │ Repo Archived: true
 ├─ Health ──────────────────────────────────────────────────
 │ 📦 Archived
 │ 258 stars
-│ Used by: 7967 packages
+│ Used by: 7968 packages
 │ Depends on: 1 direct, 0 transitive
 │ Scorecard Overall: 2.6/10  Maintained: 0.0/10
 │ Last Commit: 2024-10-02
@@ -1558,7 +1597,37 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/isemail
 └───────────────────────────────────────────────────────────
 
---- PURL 57 ---
+--- PURL 59 ---
+── pkg:npm/jasmine-reporters@2.5.2 ─────────────────────────
+│ Reporter classes for the jasmine test framework. Includes
+│   JUnitXmlReporter for generating junit xml output for
+│   running in CI environments like Jenkin…
+│ 🔴 EOL-Effective: Unmaintained, unpatched vulnerabilities
+├─ Signals ─────────────────────────────────────────────────
+│ Last Human Commit: 2022-11-04
+│ Maintained Score: 0/10
+│ Advisories: 4
+├─ Health ──────────────────────────────────────────────────
+│ 395 stars
+│ Used by: 221 packages
+│ Depends on: 2 direct, 0 transitive
+│ Scorecard Overall: 2.8/10  Maintained: 0.0/10
+│ Last Commit: 2022-11-04
+├─ Releases ────────────────────────────────────────────────
+│ Stable: 2.5.2 (2022-11-04)  ⚠️ 4 transitive advisories
+│   Transitive (via @xmldom/xmldom@0.8.12):
+│                     GHSA-2v35-w6hq-6mfw
+│                     GHSA-f6ww-3ggp-fr8h
+│                     GHSA-j759-j44w-7fr8
+│     ... and 1 more
+│   → https://deps.dev/npm/jasmine-reporters/2.5.2
+├─ Links ───────────────────────────────────────────────────
+│ Repository: https://github.com/larrymyers/jasmine-reporters
+│ Registry: https://www.npmjs.com/package/jasmine-reporters
+│ deps.dev: https://deps.dev/npm/jasmine-reporters
+└───────────────────────────────────────────────────────────
+
+--- PURL 60 ---
 ── pkg:npm/jest-serializer@26.6.2 ──────────────────────────
 │ Delightful JavaScript Testing.
 │ 🔴 EOL-Confirmed: Deprecated in npm registry; successor:
@@ -1571,11 +1640,11 @@ STATUS     PURL                                                   RELATION  LIFE
 │   [npmjs] Deprecated in npm registry (confidence 0.90)
 │     ↳ https://registry.npmjs.org/jest-serializer
 ├─ Health ──────────────────────────────────────────────────
-│ 45334 stars
-│ Used by: 13989 packages
+│ 45460 stars
+│ Used by: 13976 packages
 │ Depends on: 2 direct, 1 transitive
-│ Scorecard Overall: 6.4/10  Maintained: 10.0/10
-│ Last Commit: 2026-03-10
+│ Scorecard Overall: 6.3/10  Maintained: 10.0/10
+│ Last Commit: 2026-06-21
 ├─ Releases ────────────────────────────────────────────────
 │ Stable: 28.0.0 (2022-04-25) ⚠️ [DEPRECATED]
 │ Pre-release: 28.0.0-alpha.6 (2022-03-01) ⚠️ [DEPRECATED]
@@ -1587,15 +1656,16 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/jest-serializer
 └───────────────────────────────────────────────────────────
 
---- PURL 58 ---
+--- PURL 61 ---
 ── pkg:npm/json-buffer@3.0.0 ───────────────────────────────
-│ 🔴 EOL-Confirmed: Repository archived or disabled
+│ 🔴 Stalled: Repository archived/disabled but not declared
+│            end-of-life
 ├─ Signals ─────────────────────────────────────────────────
 │ Repo Archived: true
 ├─ Health ──────────────────────────────────────────────────
 │ 📦 Archived
 │ 41 stars
-│ Used by: 50418 packages
+│ Used by: 50465 packages
 │ Scorecard Overall: 2.1/10  Maintained: 0.0/10
 │ Last Commit: 2018-09-10
 ├─ Releases ────────────────────────────────────────────────
@@ -1607,7 +1677,29 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/json-buffer
 └───────────────────────────────────────────────────────────
 
---- PURL 59 ---
+--- PURL 62 ---
+── pkg:npm/juicy-chat-bot@0.6.6 ────────────────────────────
+│ Smart, friendly and helpful chat bot for OWASP Juice Shop
+│ 🔴 Stalled: Repository archived/disabled but not declared
+│            end-of-life
+├─ Signals ─────────────────────────────────────────────────
+│ Repo Archived: true
+├─ Health ──────────────────────────────────────────────────
+│ 📦 Archived
+│ 11 stars
+│ Depends on: 9 direct, 66 transitive
+│ Scorecard Overall: 3.2/10  Maintained: 0.0/10
+│ Last Commit: 2025-09-01
+├─ Releases ────────────────────────────────────────────────
+│ Stable: 0.9.0 (2025-09-01)
+│ Requested: 0.6.6 (2022-10-12)
+├─ Links ───────────────────────────────────────────────────
+│ Repository: https://github.com/juice-shop/juicy-chat-bot
+│ Registry: https://www.npmjs.com/package/juicy-chat-bot
+│ deps.dev: https://deps.dev/npm/juicy-chat-bot
+└───────────────────────────────────────────────────────────
+
+--- PURL 63 ---
 ── pkg:npm/lodash.get@4.4.2 ────────────────────────────────
 │ A modern JavaScript utility library delivering modularity,
 │   performance, & extras.
@@ -1621,10 +1713,10 @@ STATUS     PURL                                                   RELATION  LIFE
 │   [npmjs] Deprecated in npm registry (confidence 0.90)
 │     ↳ https://registry.npmjs.org/lodash.get
 ├─ Health ──────────────────────────────────────────────────
-│ 61517 stars
-│ Used by: 57934 packages
-│ Scorecard Overall: 7.1/10  Maintained: 9.0/10
-│ Last Commit: 2026-04-01
+│ 61232 stars
+│ Used by: 54541 packages
+│ Scorecard Overall: 7.7/10  Maintained: 10.0/10
+│ Last Commit: 2026-05-08
 ├─ Releases ────────────────────────────────────────────────
 │ Stable: 4.4.2 (2016-08-13) ⚠️ [DEPRECATED]
 ├─ Links ───────────────────────────────────────────────────
@@ -1634,7 +1726,7 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/lodash.get
 └───────────────────────────────────────────────────────────
 
---- PURL 60 ---
+--- PURL 64 ---
 ── pkg:npm/lolex@1.3.2 ─────────────────────────────────────
 │ Fake setTimeout and friends (collectively known as
 │   "timers"). Useful in your JavaScript tests. Extracted
@@ -1649,10 +1741,10 @@ STATUS     PURL                                                   RELATION  LIFE
 │   [npmjs] Deprecated in npm registry (confidence 0.90)
 │     ↳ https://registry.npmjs.org/lolex
 ├─ Health ──────────────────────────────────────────────────
-│ 858 stars
-│ Used by: 4704 packages
-│ Scorecard Overall: 5.8/10  Maintained: 10.0/10
-│ Last Commit: 2026-04-02
+│ 859 stars
+│ Used by: 4702 packages
+│ Scorecard Overall: 5.7/10  Maintained: 10.0/10
+│ Last Commit: 2026-05-05
 ├─ Releases ────────────────────────────────────────────────
 │ Stable: 6.0.0 (2020-02-04) ⚠️ [DEPRECATED]
 │ Requested: 1.3.2 (2015-09-22)
@@ -1662,11 +1754,12 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/lolex
 └───────────────────────────────────────────────────────────
 
---- PURL 61 ---
+--- PURL 65 ---
 ── pkg:npm/marsdb@0.6.11 ───────────────────────────────────
 │ MarsDB is a Promise based lightweight database with
 │   MongoDB query syntax, written on ES6
-│ 🔴 EOL-Confirmed: Repository archived or disabled
+│ 🔴 Stalled: Repository archived/disabled but not declared
+│            end-of-life
 ├─ Signals ─────────────────────────────────────────────────
 │ Repo Archived: true
 ├─ Health ──────────────────────────────────────────────────
@@ -1686,7 +1779,7 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/marsdb
 └───────────────────────────────────────────────────────────
 
---- PURL 62 ---
+--- PURL 66 ---
 ── pkg:npm/mimic-fn@2.1.0 ──────────────────────────────────
 │ Make a function mimic another one
 │ 🔴 EOL-Confirmed: Deprecated in npm registry
@@ -1697,8 +1790,8 @@ STATUS     PURL                                                   RELATION  LIFE
 │   [npmjs] Deprecated in npm registry (confidence 0.90)
 │     ↳ https://registry.npmjs.org/mimic-fn
 ├─ Health ──────────────────────────────────────────────────
-│ 96 stars
-│ Used by: 278632 packages
+│ 95 stars
+│ Used by: 285282 packages
 │ Scorecard Overall: 4.2/10  Maintained: 0.0/10
 │ Last Commit: 2024-10-28
 ├─ Releases ────────────────────────────────────────────────
@@ -1710,14 +1803,14 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/mimic-fn
 └───────────────────────────────────────────────────────────
 
---- PURL 63 ---
+--- PURL 67 ---
 ── pkg:npm/monorepo-symlink-test@0.0.0 ─────────────────────
 │ 🔴 EOL-Effective: Unpatched vulnerabilities, no recent
 │                  releases
 ├─ Signals ─────────────────────────────────────────────────
 │ Last Human Commit: (unavailable)
 │ Maintained Score: (unavailable)
-│ Days Since Release: 1587
+│ Days Since Release: 1665
 │ Advisories: 1
 ├─ Releases ────────────────────────────────────────────────
 │ Stable: 0.0.1-security (2021-11-30)  ⚠️ 1 advisory
@@ -1729,16 +1822,17 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/monorepo-symlink-test
 └───────────────────────────────────────────────────────────
 
---- PURL 64 ---
+--- PURL 68 ---
 ── pkg:npm/node-int64@0.4.0 ────────────────────────────────
 │ Support for representing 64-bit integers in JavaScript
-│ 🔴 EOL-Confirmed: Repository archived or disabled
+│ 🔴 Stalled: Repository archived/disabled but not declared
+│            end-of-life
 ├─ Signals ─────────────────────────────────────────────────
 │ Repo Archived: true
 ├─ Health ──────────────────────────────────────────────────
 │ 📦 Archived
 │ 205 stars
-│ Used by: 100979 packages
+│ Used by: 101463 packages
 │ Scorecard Overall: 2.3/10  Maintained: 0.0/10
 │ Last Commit: 2019-06-06
 ├─ Releases ────────────────────────────────────────────────
@@ -1749,7 +1843,7 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/node-int64
 └───────────────────────────────────────────────────────────
 
---- PURL 65 ---
+--- PURL 69 ---
 ── pkg:npm/node-pre-gyp@0.15.0 ─────────────────────────────
 │ Node.js tool for easy binary deployment of C++ addons
 │ 🔴 EOL-Confirmed: Deprecated in npm registry
@@ -1760,10 +1854,10 @@ STATUS     PURL                                                   RELATION  LIFE
 │   [npmjs] Deprecated in npm registry (confidence 0.90)
 │     ↳ https://registry.npmjs.org/node-pre-gyp
 ├─ Health ──────────────────────────────────────────────────
-│ 1147 stars
+│ 1152 stars
 │ Used by: 318 packages
 │ Depends on: 10 direct, 56 transitive
-│ Scorecard Overall: 6.2/10  Maintained: 3.0/10
+│ Scorecard Overall: 5.8/10  Maintained: 0.0/10
 │ Last Commit: 2026-02-21
 ├─ Releases ────────────────────────────────────────────────
 │ Stable: 0.17.0 (2020-12-07) ⚠️ [DEPRECATED]
@@ -1775,10 +1869,11 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/node-pre-gyp
 └───────────────────────────────────────────────────────────
 
---- PURL 66 ---
+--- PURL 70 ---
 ── pkg:npm/noop-logger@0.1.1 ───────────────────────────────
 │ A logger that does exactly nothing.
-│ 🔴 EOL-Confirmed: Repository archived or disabled
+│ 🔴 Stalled: Repository archived/disabled but not declared
+│            end-of-life
 ├─ Signals ─────────────────────────────────────────────────
 │ Repo Archived: true
 ├─ Health ──────────────────────────────────────────────────
@@ -1795,13 +1890,13 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/noop-logger
 └───────────────────────────────────────────────────────────
 
---- PURL 67 ---
+--- PURL 71 ---
 ── pkg:npm/notevil@1.3.3 ───────────────────────────────────
 │ Evalulate javascript like the built-in javascript eval()
 │   method but safely.
-│ 🔴 EOL-Confirmed: Repository archived or disabled
+│ 🔴 EOL-Confirmed: Deprecated in npm registry
 ├─ Signals ─────────────────────────────────────────────────
-│ Repo Archived: true
+│ EOL Source: npmjs
 ├─ EOL ─────────────────────────────────────────────────────
 │ Evidence (1):
 │   [npmjs] Deprecated in npm registry (confidence 0.90)
@@ -1823,20 +1918,20 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/notevil
 └───────────────────────────────────────────────────────────
 
---- PURL 68 ---
+--- PURL 72 ---
 ── pkg:npm/npmlog@4.1.2 ────────────────────────────────────
 │ The logger that npm uses
-│ 🔴 EOL-Confirmed: Repository archived or disabled
+│ 🔴 EOL-Confirmed: Deprecated in npm registry
 ├─ Signals ─────────────────────────────────────────────────
-│ Repo Archived: true
+│ EOL Source: npmjs
 ├─ EOL ─────────────────────────────────────────────────────
 │ Evidence (1):
 │   [npmjs] Deprecated in npm registry (confidence 0.90)
 │     ↳ https://registry.npmjs.org/npmlog
 ├─ Health ──────────────────────────────────────────────────
 │ 📦 Archived
-│ 440 stars
-│ Used by: 19016 packages
+│ 439 stars
+│ Used by: 19339 packages
 │ Depends on: 4 direct, 16 transitive
 │ Scorecard Overall: 5.5/10  Maintained: 0.0/10
 │ Last Commit: 2024-05-03
@@ -1849,20 +1944,20 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/npmlog
 └───────────────────────────────────────────────────────────
 
---- PURL 69 ---
+--- PURL 73 ---
 ── pkg:npm/npmlog@5.0.1 ────────────────────────────────────
 │ The logger that npm uses
-│ 🔴 EOL-Confirmed: Repository archived or disabled
+│ 🔴 EOL-Confirmed: Deprecated in npm registry
 ├─ Signals ─────────────────────────────────────────────────
-│ Repo Archived: true
+│ EOL Source: npmjs
 ├─ EOL ─────────────────────────────────────────────────────
 │ Evidence (1):
 │   [npmjs] Deprecated in npm registry (confidence 0.90)
 │     ↳ https://registry.npmjs.org/npmlog
 ├─ Health ──────────────────────────────────────────────────
 │ 📦 Archived
-│ 440 stars
-│ Used by: 19016 packages
+│ 439 stars
+│ Used by: 19339 packages
 │ Depends on: 4 direct, 16 transitive
 │ Scorecard Overall: 5.5/10  Maintained: 0.0/10
 │ Last Commit: 2024-05-03
@@ -1875,20 +1970,20 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/npmlog
 └───────────────────────────────────────────────────────────
 
---- PURL 70 ---
+--- PURL 74 ---
 ── pkg:npm/npmlog@6.0.2 ────────────────────────────────────
 │ The logger that npm uses
-│ 🔴 EOL-Confirmed: Repository archived or disabled
+│ 🔴 EOL-Confirmed: Deprecated in npm registry
 ├─ Signals ─────────────────────────────────────────────────
-│ Repo Archived: true
+│ EOL Source: npmjs
 ├─ EOL ─────────────────────────────────────────────────────
 │ Evidence (1):
 │   [npmjs] Deprecated in npm registry (confidence 0.90)
 │     ↳ https://registry.npmjs.org/npmlog
 ├─ Health ──────────────────────────────────────────────────
 │ 📦 Archived
-│ 440 stars
-│ Used by: 19016 packages
+│ 439 stars
+│ Used by: 19339 packages
 │ Depends on: 4 direct, 16 transitive
 │ Scorecard Overall: 5.5/10  Maintained: 0.0/10
 │ Last Commit: 2024-05-03
@@ -1901,12 +1996,12 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/npmlog
 └───────────────────────────────────────────────────────────
 
---- PURL 71 ---
+--- PURL 75 ---
 ── pkg:npm/number-is-nan@1.0.1 ─────────────────────────────
 │ ES2015 Number.isNaN() ponyfill
-│ 🔴 EOL-Confirmed: Repository archived or disabled
+│ 🔴 EOL-Confirmed: Deprecated in npm registry
 ├─ Signals ─────────────────────────────────────────────────
-│ Repo Archived: true
+│ EOL Source: npmjs
 ├─ EOL ─────────────────────────────────────────────────────
 │ Evidence (1):
 │   [npmjs] Deprecated in npm registry (confidence 0.90)
@@ -1914,7 +2009,7 @@ STATUS     PURL                                                   RELATION  LIFE
 ├─ Health ──────────────────────────────────────────────────
 │ 📦 Archived
 │ 30 stars
-│ Used by: 187362 packages
+│ Used by: 187378 packages
 │ Scorecard Overall: 3.1/10  Maintained: 0.0/10
 │ Last Commit: 2024-05-02
 ├─ Releases ────────────────────────────────────────────────
@@ -1926,20 +2021,20 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/number-is-nan
 └───────────────────────────────────────────────────────────
 
---- PURL 72 ---
+--- PURL 76 ---
 ── pkg:npm/os-homedir@1.0.2 ────────────────────────────────
 │ [DEPRECATED] Node.js `os.homedir()` ponyfill
-│ 🔴 EOL-Confirmed: Repository archived or disabled
+│ 🔴 EOL-Confirmed: Deprecated in npm registry
 ├─ Signals ─────────────────────────────────────────────────
-│ Repo Archived: true
+│ EOL Source: npmjs
 ├─ EOL ─────────────────────────────────────────────────────
 │ Evidence (1):
 │   [npmjs] Deprecated in npm registry (confidence 0.90)
 │     ↳ https://registry.npmjs.org/os-homedir
 ├─ Health ──────────────────────────────────────────────────
 │ 📦 Archived
-│ 61 stars
-│ Used by: 158873 packages
+│ 60 stars
+│ Used by: 158127 packages
 │ Scorecard Overall: 3.0/10  Maintained: 0.0/10
 │ Last Commit: 2019-05-31
 ├─ Releases ────────────────────────────────────────────────
@@ -1951,12 +2046,12 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/os-homedir
 └───────────────────────────────────────────────────────────
 
---- PURL 73 ---
+--- PURL 77 ---
 ── pkg:npm/os-tmpdir@1.0.2 ─────────────────────────────────
 │ [DEPRECATED] Node.js os.tmpdir() ponyfill
-│ 🔴 EOL-Confirmed: Repository archived or disabled
+│ 🔴 EOL-Confirmed: Deprecated in npm registry
 ├─ Signals ─────────────────────────────────────────────────
-│ Repo Archived: true
+│ EOL Source: npmjs
 ├─ EOL ─────────────────────────────────────────────────────
 │ Evidence (1):
 │   [npmjs] Deprecated in npm registry (confidence 0.90)
@@ -1964,7 +2059,7 @@ STATUS     PURL                                                   RELATION  LIFE
 ├─ Health ──────────────────────────────────────────────────
 │ 📦 Archived
 │ 37 stars
-│ Used by: 227827 packages
+│ Used by: 228057 packages
 │ Scorecard Overall: 3.0/10  Maintained: 0.0/10
 │ Last Commit: 2019-05-31
 ├─ Releases ────────────────────────────────────────────────
@@ -1976,13 +2071,13 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/os-tmpdir
 └───────────────────────────────────────────────────────────
 
---- PURL 74 ---
+--- PURL 78 ---
 ── pkg:npm/osenv@0.1.5 ─────────────────────────────────────
 │ Look up environment settings specific to different
 │   operating systems.
-│ 🔴 EOL-Confirmed: Repository archived or disabled
+│ 🔴 EOL-Confirmed: Deprecated in npm registry
 ├─ Signals ─────────────────────────────────────────────────
-│ Repo Archived: true
+│ EOL Source: npmjs
 ├─ EOL ─────────────────────────────────────────────────────
 │ Evidence (1):
 │   [npmjs] Deprecated in npm registry (confidence 0.90)
@@ -1990,7 +2085,7 @@ STATUS     PURL                                                   RELATION  LIFE
 ├─ Health ──────────────────────────────────────────────────
 │ 📦 Archived
 │ 138 stars
-│ Used by: 59722 packages
+│ Used by: 58811 packages
 │ Depends on: 2 direct, 0 transitive
 │ Scorecard Overall: 2.0/10  Maintained: 0.0/10
 │ Last Commit: 2019-02-08
@@ -2002,13 +2097,13 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/osenv
 └───────────────────────────────────────────────────────────
 
---- PURL 75 ---
+--- PURL 79 ---
 ── pkg:npm/p-finally@1.0.0 ─────────────────────────────────
 │ `Promise#finally()` ponyfill - Invoked when the promise is
 │   settled regardless of outcome
-│ 🔴 EOL-Confirmed: Repository archived or disabled
+│ 🔴 EOL-Confirmed: Deprecated in npm registry
 ├─ Signals ─────────────────────────────────────────────────
-│ Repo Archived: true
+│ EOL Source: npmjs
 ├─ EOL ─────────────────────────────────────────────────────
 │ Evidence (1):
 │   [npmjs] Deprecated in npm registry (confidence 0.90)
@@ -2016,7 +2111,7 @@ STATUS     PURL                                                   RELATION  LIFE
 ├─ Health ──────────────────────────────────────────────────
 │ 📦 Archived
 │ 47 stars
-│ Used by: 157676 packages
+│ Used by: 161088 packages
 │ Scorecard Overall: 3.6/10  Maintained: 0.0/10
 │ Last Commit: 2021-04-09
 ├─ Releases ────────────────────────────────────────────────
@@ -2028,12 +2123,12 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/p-finally
 └───────────────────────────────────────────────────────────
 
---- PURL 76 ---
+--- PURL 80 ---
 ── pkg:npm/path-is-absolute@1.0.1 ──────────────────────────
 │ Node.js 0.12 path.isAbsolute() ponyfill
-│ 🔴 EOL-Confirmed: Repository archived or disabled
+│ 🔴 EOL-Confirmed: Deprecated in npm registry
 ├─ Signals ─────────────────────────────────────────────────
-│ Repo Archived: true
+│ EOL Source: npmjs
 ├─ EOL ─────────────────────────────────────────────────────
 │ Evidence (1):
 │   [npmjs] Deprecated in npm registry (confidence 0.90)
@@ -2041,7 +2136,7 @@ STATUS     PURL                                                   RELATION  LIFE
 ├─ Health ──────────────────────────────────────────────────
 │ 📦 Archived
 │ 43 stars
-│ Used by: 553138 packages
+│ Used by: 553733 packages
 │ Scorecard Overall: 3.0/10  Maintained: 0.0/10
 │ Last Commit: 2019-05-31
 ├─ Releases ────────────────────────────────────────────────
@@ -2053,18 +2148,19 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/path-is-absolute
 └───────────────────────────────────────────────────────────
 
---- PURL 77 ---
+--- PURL 81 ---
 ── pkg:npm/peek-readable@4.1.0 ─────────────────────────────
 │ A promise based asynchronous stream reader, which makes
 │   reading from a stream easy.
-│ 🔴 EOL-Confirmed: Repository archived or disabled
+│ 🔴 Stalled: Repository archived/disabled but not declared
+│            end-of-life
 ├─ Signals ─────────────────────────────────────────────────
 │ Repo Archived: true
 ├─ Health ──────────────────────────────────────────────────
 │ 📦 Archived
 │ 9 stars
-│ Used by: 18387 packages
-│ Scorecard Overall: 3.4/10  Maintained: 0.0/10
+│ Used by: 18414 packages
+│ Scorecard Overall: 2.8/10  Maintained: 0.0/10
 │ Last Commit: 2025-07-17
 ├─ Releases ────────────────────────────────────────────────
 │ Stable: 7.0.0 (2025-03-09)
@@ -2076,7 +2172,7 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/peek-readable
 └───────────────────────────────────────────────────────────
 
---- PURL 78 ---
+--- PURL 82 ---
 ── pkg:npm/pkg-dir@4.2.0 ───────────────────────────────────
 │ Find the root directory of a Node.js project or npm
 │   package
@@ -2089,9 +2185,9 @@ STATUS     PURL                                                   RELATION  LIFE
 │     ↳ https://registry.npmjs.org/pkg-dir
 ├─ Health ──────────────────────────────────────────────────
 │ 252 stars
-│ Used by: 107216 packages
+│ Used by: 107328 packages
 │ Depends on: 1 direct, 5 transitive
-│ Scorecard Overall: 3.8/10  Maintained: 1.0/10
+│ Scorecard Overall: 3.7/10  Maintained: 0.0/10
 │ Last Commit: 2026-02-01
 ├─ Releases ────────────────────────────────────────────────
 │ Stable: 9.0.0 (2025-06-05) ⚠️ [DEPRECATED]
@@ -2102,12 +2198,12 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/pkg-dir
 └───────────────────────────────────────────────────────────
 
---- PURL 79 ---
+--- PURL 83 ---
 ── pkg:npm/prebuild-install@5.3.6 ──────────────────────────
 │ Deprecated. Minimal install client for prebuilds.
-│ 🔴 EOL-Confirmed: Repository archived or disabled
+│ 🔴 EOL-Confirmed: Deprecated in npm registry
 ├─ Signals ─────────────────────────────────────────────────
-│ Repo Archived: true
+│ EOL Source: npmjs
 ├─ EOL ─────────────────────────────────────────────────────
 │ Evidence (1):
 │   [npmjs] Deprecated in npm registry (confidence 0.90)
@@ -2115,7 +2211,7 @@ STATUS     PURL                                                   RELATION  LIFE
 ├─ Health ──────────────────────────────────────────────────
 │ 📦 Archived
 │ 115 stars
-│ Used by: 5331 packages
+│ Used by: 5336 packages
 │ Depends on: 15 direct, 43 transitive
 │ Scorecard Overall: 3.5/10  Maintained: 0.0/10
 │ Last Commit: 2026-02-19
@@ -2128,7 +2224,7 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/prebuild-install
 └───────────────────────────────────────────────────────────
 
---- PURL 80 ---
+--- PURL 84 ---
 ── pkg:npm/read-pkg-up@7.0.1 ───────────────────────────────
 │ Read the closest package.json file
 │ 🔴 EOL-Confirmed: Deprecated in npm registry
@@ -2140,8 +2236,8 @@ STATUS     PURL                                                   RELATION  LIFE
 │     ↳ https://registry.npmjs.org/read-pkg-up
 ├─ Health ──────────────────────────────────────────────────
 │ 268 stars
-│ Used by: 40726 packages
-│ Depends on: 3 direct, 30 transitive
+│ Used by: 40798 packages
+│ Depends on: 3 direct, 31 transitive
 │ Scorecard Overall: 3.6/10  Maintained: 0.0/10
 │ Last Commit: 2025-11-07
 ├─ Releases ────────────────────────────────────────────────
@@ -2153,7 +2249,7 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/read-pkg-up
 └───────────────────────────────────────────────────────────
 
---- PURL 81 ---
+--- PURL 85 ---
 ── pkg:npm/replace@1.2.2 ───────────────────────────────────
 │ Command line search and replace utility
 │ 🔴 EOL-Effective: Unmaintained, unpatched vulnerabilities
@@ -2165,7 +2261,7 @@ STATUS     PURL                                                   RELATION  LIFE
 ├─ Health ──────────────────────────────────────────────────
 │ ⚠️ Fork of harthur/replace
 │ 62 stars
-│ Used by: 420 packages
+│ Used by: 421 packages
 │ Depends on: 3 direct, 34 transitive
 │ Scorecard Overall: 3.2/10  Maintained: 0.0/10
 │ Last Commit: 2022-10-23
@@ -2182,7 +2278,7 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/replace
 └───────────────────────────────────────────────────────────
 
---- PURL 82 ---
+--- PURL 86 ---
 ── pkg:npm/request@2.88.2 ──────────────────────────────────
 │ 🏊🏾 Simplified HTTP request client.
 │ 🔴 EOL-Confirmed: Deprecated in npm registry
@@ -2193,18 +2289,19 @@ STATUS     PURL                                                   RELATION  LIFE
 │   [npmjs] Deprecated in npm registry (confidence 0.90)
 │     ↳ https://registry.npmjs.org/request
 ├─ Health ──────────────────────────────────────────────────
-│ 25577 stars
-│ Used by: 186349 packages
+│ 25545 stars
+│ Used by: 186442 packages
 │ Depends on: 20 direct, 26 transitive
-│ Scorecard Overall: 3.6/10  Maintained: 0.0/10
+│ Scorecard Overall: 3.4/10  Maintained: 0.0/10
 │ Last Commit: 2020-02-11
 ├─ Releases ────────────────────────────────────────────────
-│ Stable: 2.88.2 (2020-02-11)  ⚠️ 1 advisory (+ 3 transitive) ⚠️ [DEPRECATED]
+│ Stable: 2.88.2 (2020-02-11)  ⚠️ 1 advisory (+ 5 transitive) ⚠️ [DEPRECATED]
 │   MEDIUM   (6.1)  GHSA-p8p7-x288-28g6
-│   Transitive (via tough-cookie@2.5.0, qs@6.5.5, form-data@2.3.3):
+│   Transitive (via form-data@2.3.3, uuid@3.4.0, tough-cookie@2.5.0):
+│     HIGH     (7.5)  GHSA-hmw2-7cc7-3qxx
+│     HIGH     (7.5)  GHSA-w5hq-g745-h8pq
 │     MEDIUM   (6.5)  GHSA-72xf-g2v4-qvf3
-│     LOW      (3.7)  GHSA-6rw7-vpxm-498p
-│                     GHSA-fjxv-7rqg-78g4
+│     ... and 2 more
 │   → https://deps.dev/npm/request/2.88.2
 ├─ Links ───────────────────────────────────────────────────
 │ Repository: https://github.com/request/request
@@ -2212,16 +2309,17 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/request
 └───────────────────────────────────────────────────────────
 
---- PURL 83 ---
+--- PURL 87 ---
 ── pkg:npm/require-from-string@2.0.2 ───────────────────────
 │ Load module from string
-│ 🔴 EOL-Confirmed: Repository archived or disabled
+│ 🔴 Stalled: Repository archived/disabled but not declared
+│            end-of-life
 ├─ Signals ─────────────────────────────────────────────────
 │ Repo Archived: true
 ├─ Health ──────────────────────────────────────────────────
 │ 📦 Archived
 │ 298 stars
-│ Used by: 201523 packages
+│ Used by: 227728 packages
 │ Scorecard Overall: 2.3/10  Maintained: 0.0/10
 │ Last Commit: 2018-04-09
 ├─ Releases ────────────────────────────────────────────────
@@ -2232,21 +2330,21 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/require-from-string
 └───────────────────────────────────────────────────────────
 
---- PURL 84 ---
+--- PURL 88 ---
 ── pkg:npm/resolve-url@0.2.1 ───────────────────────────────
 │ [DEPRECATED] Like Node.js’ `path.resolve`/`url.resolve`
 │   for the browser.
-│ 🔴 EOL-Confirmed: Repository archived or disabled
+│ 🔴 EOL-Confirmed: Deprecated in npm registry
 ├─ Signals ─────────────────────────────────────────────────
-│ Repo Archived: true
+│ EOL Source: npmjs
 ├─ EOL ─────────────────────────────────────────────────────
 │ Evidence (1):
 │   [npmjs] Deprecated in npm registry (confidence 0.90)
 │     ↳ https://registry.npmjs.org/resolve-url
 ├─ Health ──────────────────────────────────────────────────
 │ 📦 Archived
-│ 54 stars
-│ Used by: 159528 packages
+│ 53 stars
+│ Used by: 159472 packages
 │ Scorecard Overall: 2.0/10  Maintained: 0.0/10
 │ Last Commit: 2022-01-11
 ├─ Releases ────────────────────────────────────────────────
@@ -2257,7 +2355,7 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/resolve-url
 └───────────────────────────────────────────────────────────
 
---- PURL 85 ---
+--- PURL 89 ---
 ── pkg:npm/samsam@1.1.2 ────────────────────────────────────
 │ Value identification and comparison functions
 │ 🔴 EOL-Confirmed: Deprecated in npm registry
@@ -2268,10 +2366,10 @@ STATUS     PURL                                                   RELATION  LIFE
 │   [npmjs] Deprecated in npm registry (confidence 0.90)
 │     ↳ https://registry.npmjs.org/samsam
 ├─ Health ──────────────────────────────────────────────────
-│ 27 stars
-│ Used by: 4738 packages
-│ Scorecard Overall: 5.8/10  Maintained: 10.0/10
-│ Last Commit: 2026-03-20
+│ 28 stars
+│ Used by: 4736 packages
+│ Scorecard Overall: 5.7/10  Maintained: 10.0/10
+│ Last Commit: 2026-04-11
 ├─ Releases ────────────────────────────────────────────────
 │ Stable: 1.3.0 (2017-10-03) ⚠️ [DEPRECATED]
 │ Requested: 1.1.2 (2014-12-11) ⚠️ [DEPRECATED]
@@ -2282,16 +2380,17 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/samsam
 └───────────────────────────────────────────────────────────
 
---- PURL 86 ---
+--- PURL 90 ---
 ── pkg:npm/saxes@5.0.1 ─────────────────────────────────────
 │ An evented streaming XML parser in JavaScript
-│ 🔴 EOL-Confirmed: Repository archived or disabled
+│ 🔴 Stalled: Repository archived/disabled but not declared
+│            end-of-life
 ├─ Signals ─────────────────────────────────────────────────
 │ Repo Archived: true
 ├─ Health ──────────────────────────────────────────────────
 │ 📦 Archived
 │ 84 stars
-│ Used by: 62324 packages
+│ Used by: 62750 packages
 │ Depends on: 1 direct, 0 transitive
 │ Scorecard Overall: 2.9/10  Maintained: 0.0/10
 ├─ Releases ────────────────────────────────────────────────
@@ -2304,21 +2403,21 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/saxes
 └───────────────────────────────────────────────────────────
 
---- PURL 87 ---
+--- PURL 91 ---
 ── pkg:npm/source-map-resolve@0.5.3 ────────────────────────
 │ [DEPRECATED] Resolve the source map and/or sources for a
 │   generated file.
-│ 🔴 EOL-Confirmed: Repository archived or disabled
+│ 🔴 EOL-Confirmed: Deprecated in npm registry
 ├─ Signals ─────────────────────────────────────────────────
-│ Repo Archived: true
+│ EOL Source: npmjs
 ├─ EOL ─────────────────────────────────────────────────────
 │ Evidence (1):
 │   [npmjs] Deprecated in npm registry (confidence 0.90)
 │     ↳ https://registry.npmjs.org/source-map-resolve
 ├─ Health ──────────────────────────────────────────────────
 │ 📦 Archived
-│ 94 stars
-│ Used by: 158252 packages
+│ 93 stars
+│ Used by: 158186 packages
 │ Depends on: 5 direct, 0 transitive
 │ Scorecard Overall: 3.0/10  Maintained: 0.0/10
 │ Last Commit: 2022-01-11
@@ -2331,21 +2430,21 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/source-map-resolve
 └───────────────────────────────────────────────────────────
 
---- PURL 88 ---
+--- PURL 92 ---
 ── pkg:npm/source-map-url@0.4.1 ────────────────────────────
 │ [DEPRECATED] Tools for working with sourceMappingURL
 │   comments.
-│ 🔴 EOL-Confirmed: Repository archived or disabled
+│ 🔴 EOL-Confirmed: Deprecated in npm registry
 ├─ Signals ─────────────────────────────────────────────────
-│ Repo Archived: true
+│ EOL Source: npmjs
 ├─ EOL ─────────────────────────────────────────────────────
 │ Evidence (1):
 │   [npmjs] Deprecated in npm registry (confidence 0.90)
 │     ↳ https://registry.npmjs.org/source-map-url
 ├─ Health ──────────────────────────────────────────────────
 │ 📦 Archived
-│ 46 stars
-│ Used by: 158941 packages
+│ 45 stars
+│ Used by: 158877 packages
 │ Scorecard Overall: 2.0/10  Maintained: 0.0/10
 │ Last Commit: 2022-01-11
 ├─ Releases ────────────────────────────────────────────────
@@ -2356,7 +2455,7 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/source-map-url
 └───────────────────────────────────────────────────────────
 
---- PURL 89 ---
+--- PURL 93 ---
 ── pkg:npm/strip-eof@1.0.0 ─────────────────────────────────
 │ Strip the final newline character from a string/buffer
 │ 🔴 EOL-Confirmed: Deprecated in npm registry
@@ -2368,7 +2467,7 @@ STATUS     PURL                                                   RELATION  LIFE
 │     ↳ https://registry.npmjs.org/strip-eof
 ├─ Health ──────────────────────────────────────────────────
 │ 38 stars
-│ Used by: 113429 packages
+│ Used by: 113474 packages
 │ Scorecard Overall: 3.8/10  Maintained: 0.0/10
 │ Last Commit: 2024-10-28
 ├─ Releases ────────────────────────────────────────────────
@@ -2380,16 +2479,17 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/strip-eof
 └───────────────────────────────────────────────────────────
 
---- PURL 90 ---
+--- PURL 94 ---
 ── pkg:npm/through@2.3.8 ───────────────────────────────────
 │ simple way to create a ReadableWritable stream that works
-│ 🔴 EOL-Confirmed: Repository archived or disabled
+│ 🔴 Stalled: Repository archived/disabled but not declared
+│            end-of-life
 ├─ Signals ─────────────────────────────────────────────────
 │ Repo Archived: true
 ├─ Health ──────────────────────────────────────────────────
 │ 📦 Archived
 │ 670 stars
-│ Used by: 262445 packages
+│ Used by: 263562 packages
 │ Scorecard Overall: 2.1/10  Maintained: 0.0/10
 │ Last Commit: 2015-07-03
 ├─ Releases ────────────────────────────────────────────────
@@ -2400,7 +2500,7 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/through
 └───────────────────────────────────────────────────────────
 
---- PURL 91 ---
+--- PURL 95 ---
 ── pkg:npm/topo@3.0.3 ──────────────────────────────────────
 │ Topological sorting with grouping support
 │ 🔴 EOL-Confirmed: Deprecated in npm registry
@@ -2411,8 +2511,8 @@ STATUS     PURL                                                   RELATION  LIFE
 │   [npmjs] Deprecated in npm registry (confidence 0.90)
 │     ↳ https://registry.npmjs.org/topo
 ├─ Health ──────────────────────────────────────────────────
-│ 108 stars
-│ Used by: 4639 packages
+│ 109 stars
+│ Used by: 4633 packages
 │ Depends on: 1 direct, 0 transitive
 │ Scorecard Overall: 3.7/10  Maintained: 0.0/10
 │ Last Commit: 2024-10-23
@@ -2427,17 +2527,18 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/topo
 └───────────────────────────────────────────────────────────
 
---- PURL 92 ---
+--- PURL 96 ---
 ── pkg:npm/ts-node-dev@1.1.8 ───────────────────────────────
 │ Compiles your TS app and restarts when files are modified.
-│ 🔴 EOL-Confirmed: Repository archived or disabled
+│ 🔴 Stalled: Repository archived/disabled but not declared
+│            end-of-life
 ├─ Signals ─────────────────────────────────────────────────
 │ Repo Archived: true
 ├─ Health ──────────────────────────────────────────────────
 │ 📦 Archived
-│ 3451 stars
-│ Used by: 483 packages
-│ Depends on: 10 direct, 42 transitive
+│ 3440 stars
+│ Used by: 482 packages
+│ Depends on: 10 direct, 43 transitive
 │ Scorecard Overall: 2.0/10  Maintained: 0.0/10
 │ Last Commit: 2022-05-26
 ├─ Releases ────────────────────────────────────────────────
@@ -2450,21 +2551,21 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/ts-node-dev
 └───────────────────────────────────────────────────────────
 
---- PURL 93 ---
+--- PURL 97 ---
 ── pkg:npm/urix@0.1.0 ──────────────────────────────────────
 │ [DEPRECATED] Makes Windows-style paths more unix and URI
 │   friendly.
-│ 🔴 EOL-Confirmed: Repository archived or disabled
+│ 🔴 EOL-Confirmed: Deprecated in npm registry
 ├─ Signals ─────────────────────────────────────────────────
-│ Repo Archived: true
+│ EOL Source: npmjs
 ├─ EOL ─────────────────────────────────────────────────────
 │ Evidence (1):
 │   [npmjs] Deprecated in npm registry (confidence 0.90)
 │     ↳ https://registry.npmjs.org/urix
 ├─ Health ──────────────────────────────────────────────────
 │ 📦 Archived
-│ 62 stars
-│ Used by: 159109 packages
+│ 63 stars
+│ Used by: 159045 packages
 │ Scorecard Overall: 2.1/10  Maintained: 0.0/10
 │ Last Commit: 2022-01-11
 ├─ Releases ────────────────────────────────────────────────
@@ -2475,13 +2576,14 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/urix
 └───────────────────────────────────────────────────────────
 
---- PURL 94 ---
+--- PURL 98 ---
 ── pkg:npm/w3c-hr-time@1.0.2 ───────────────────────────────
 │ An implementation of the W3C High Resolution Time Level 2
 │   specification.
-│ 🔴 EOL-Confirmed: Repository archived or disabled
+│ 🔴 EOL-Confirmed: Deprecated in npm registry; successor:
+│                  your
 ├─ Signals ─────────────────────────────────────────────────
-│ Repo Archived: true
+│ EOL Source: npmjs
 ├─ EOL ─────────────────────────────────────────────────────
 │ ➡️ Successor: your
 │ Evidence (1):
@@ -2490,7 +2592,7 @@ STATUS     PURL                                                   RELATION  LIFE
 ├─ Health ──────────────────────────────────────────────────
 │ 📦 Archived
 │ 11 stars
-│ Used by: 76565 packages
+│ Used by: 76534 packages
 │ Depends on: 1 direct, 0 transitive
 │ Scorecard Overall: 2.5/10  Maintained: 0.0/10
 │ Last Commit: 2022-10-16
@@ -2502,12 +2604,13 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/w3c-hr-time
 └───────────────────────────────────────────────────────────
 
---- PURL 95 ---
+--- PURL 99 ---
 ── pkg:npm/whatwg-encoding@1.0.5 ───────────────────────────
 │ Decode strings according to the WHATWG Encoding Standard
-│ 🔴 EOL-Confirmed: Repository archived or disabled
+│ 🔴 EOL-Confirmed: Deprecated in npm registry; successor:
+│                  @exodus/bytes
 ├─ Signals ─────────────────────────────────────────────────
-│ Repo Archived: true
+│ EOL Source: npmjs
 ├─ EOL ─────────────────────────────────────────────────────
 │ ➡️ Successor: @exodus/bytes
 │ Evidence (1):
@@ -2516,7 +2619,7 @@ STATUS     PURL                                                   RELATION  LIFE
 ├─ Health ──────────────────────────────────────────────────
 │ 📦 Archived
 │ 27 stars
-│ Used by: 81541 packages
+│ Used by: 81496 packages
 │ Depends on: 1 direct, 1 transitive
 │ Scorecard Overall: 2.6/10  Maintained: 0.0/10
 │ Last Commit: 2025-12-28
@@ -2529,17 +2632,18 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/whatwg-encoding
 └───────────────────────────────────────────────────────────
 
---- PURL 96 ---
+--- PURL 100 ---
 ── pkg:npm/xmlchars@2.2.0 ──────────────────────────────────
 │ Utilities for determining if characters belong to
 │   character classes defined by the XML specs.
-│ 🔴 EOL-Confirmed: Repository archived or disabled
+│ 🔴 Stalled: Repository archived/disabled but not declared
+│            end-of-life
 ├─ Signals ─────────────────────────────────────────────────
 │ Repo Archived: true
 ├─ Health ──────────────────────────────────────────────────
 │ 📦 Archived
 │ 3 stars
-│ Used by: 83812 packages
+│ Used by: 84935 packages
 │ Scorecard Overall: 3.0/10  Maintained: 0.0/10
 │ Last Commit: 2021-11-07
 ├─ Releases ────────────────────────────────────────────────
@@ -2550,16 +2654,17 @@ STATUS     PURL                                                   RELATION  LIFE
 │ deps.dev: https://deps.dev/npm/xmlchars
 └───────────────────────────────────────────────────────────
 
---- PURL 97 ---
+--- PURL 101 ---
 ── pkg:npm/xtend@4.0.2 ─────────────────────────────────────
 │ extend like a boss
-│ 🔴 EOL-Confirmed: Repository archived or disabled
+│ 🔴 Stalled: Repository archived/disabled but not declared
+│            end-of-life
 ├─ Signals ─────────────────────────────────────────────────
 │ Repo Archived: true
 ├─ Health ──────────────────────────────────────────────────
 │ 📦 Archived
 │ 306 stars
-│ Used by: 329276 packages
+│ Used by: 332830 packages
 │ Scorecard Overall: 2.8/10  Maintained: 0.0/10
 │ Last Commit: 2020-08-10
 ├─ Releases ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Follow-up to #455 (merged). Regenerates `docs/assets/juice-shop-eol-result.txt` so the large trivy+SBOM example reflects the shipped behavior: **archived/disabled repositories without an explicit primary-source EOL signal now classify as `Stalled`** (previously `EOL-Confirmed`).

This asset is normally refreshed out-of-band by the `workflow_dispatch` `doc-examples` job; #455 intentionally deferred it, and this PR does that refresh.

## What changed

- **52** old `EOL-Confirmed: Repository archived or disabled` renderings → **0**.
- Archived packages that still carry a `replace` verdict (archived repos trigger `replace` per ADR-0012) now render with the corrected `Stalled: Repository archived/disabled but not declared end-of-life` label — **17** such entries.
- Genuine primary-source EOL entries (npm `deprecated`, etc.) are **unchanged**.

The remaining diff (562+/457−) is expected non-deterministic drift inherent to this example: star counts, last-commit dates, advisory counts, and the GitHub GraphQL progress lines' `total_cost`/`remaining`/`reset` values.

## How it was generated

```
trivy image --format cyclonedx bkimminich/juice-shop:v14.5.1 \
  | uzomuzo scan --sbom - --fail-on eol-confirmed,eol-effective --format detailed --show-only replace
```

- `trivy` v0.69.3 (matches CI), `GITHUB_TOKEN` set (Path A enrichment).
- Same command embedded in `scripts/update-doc-examples/commands.json` (`id: juice-shop`); output is the command's raw stdout, matching the generator's `output_file` write.

## Note (not addressed here)

For >100-repo scans, `internal/infrastructure/github/batch_states.go` prints GraphQL batch progress (🔄/✅) to **stdout** (`fmt.Printf`), so those lines land in this captured asset. They are already present in the committed file, so this is pre-existing, not introduced here. Routing them to stderr would be a reasonable separate cleanup.

Refs #451, #455