### PR TITLE
docs(rules): reference ADR rationale by ID, don't restate it in comments

### DIFF
--- a/.claude/rules/coding-standards.md
+++ b/.claude/rules/coding-standards.md
@@ -53,6 +53,7 @@ A key tenet of idiomatic Go is to make the zero value of a type useful.
 
 - **Exported Identifiers**: All exported functions, types, constants, and variables MUST have a `godoc` comment.
 - **Godoc Format**: A comment for `MyFunction` should start with `// MyFunction ...`.
+- **Architectural rationale belongs in ADRs, not comments — reference by ID, do not restate**: The reasoning behind a design decision (why we chose this, which alternatives we rejected, the forces at play) lives in an ADR, which is the single source of truth. Comments / godoc must NOT copy that reasoning; reference the ADR by ID instead (`// See ADR-NNNN.`). The two have different jobs: an ADR is an append-only decision history (it never erases the past), while a comment is a snapshot of what the code does *now*. Writing the rationale in both means a later code change updates only one, they drift apart, and the ADR loses the value that makes it worth keeping — stopping a rejected proposal from being re-proposed. Apply this at authoring time, before the `comment-impl-drift` / `narrative-drift` accumulator catches the drift after the fact. Cite by a stable anchor (ADR ID, function name, heading), never by copying the ADR's prose.
 
 ## API Design and Backward Compatibility
 

--- a/.github/instructions/coding-standards.instructions.md
+++ b/.github/instructions/coding-standards.instructions.md
@@ -51,6 +51,7 @@ A key tenet of idiomatic Go is to make the zero value of a type useful.
 
 - **Exported Identifiers**: All exported functions, types, constants, and variables MUST have a `godoc` comment.
 - **Godoc Format**: A comment for `MyFunction` should start with `// MyFunction ...`.
+- **Architectural rationale belongs in ADRs, not comments — reference by ID, do not restate**: The reasoning behind a design decision (why we chose this, which alternatives we rejected, the forces at play) lives in an ADR, which is the single source of truth. Comments / godoc must NOT copy that reasoning; reference the ADR by ID instead (`// See ADR-NNNN.`). The two have different jobs: an ADR is an append-only decision history (it never erases the past), while a comment is a snapshot of what the code does *now*. Writing the rationale in both means a later code change updates only one, they drift apart, and the ADR loses the value that makes it worth keeping — stopping a rejected proposal from being re-proposed. Apply this at authoring time, before the `comment-impl-drift` / `narrative-drift` accumulator catches the drift after the fact. Cite by a stable anchor (ADR ID, function name, heading), never by copying the ADR's prose.
 
 ## API Design and Backward Compatibility
 


### PR DESCRIPTION
## Background

A recurring LLM failure mode: when a design decision is recorded in an ADR, the model also copies the full rationale into a code comment / godoc. The two then drift — a later change updates only one — and the ADR loses the very value that makes it worth keeping: stopping a rejected proposal from being re-proposed.

This repo had no authoring-time rule against it; the only guard was the after-the-fact `comment-impl-drift` / `narrative-drift` accumulator. The sibling repo **uzomuzo-catalog already carries this rule** (Coding Standards § Minimalism); this PR brings uzomuzo-oss to parity.

Role split being encoded:

| | Holds | Nature |
|---|---|---|
| ADR | why we decided, rejected alternatives, the forces at play | append-only decision history; never erases the past |
| comment / godoc | what the code does **now** | latest snapshot only |

## Change

One bullet added to **Coding Standards § Documentation Comments**: rationale belongs in an ADR (the SSOT); comments reference it by `// See ADR-NNNN.` and must not copy the prose. Cite by stable anchor (ADR ID, function name, heading), never by duplicating ADR text.

- Edited the canonical source `.github/instructions/coding-standards.instructions.md`.
- Regenerated the `.claude/rules/coding-standards.md` mirror via `make sync-instructions` (so both Copilot and Claude Code agents see it).

Note: `coding-standards` is intentionally excluded from the oss↔catalog file sync, so this is a standalone oss-side change; catalog already has the equivalent rule.

## Verification

Docs-only (one rule bullet; canonical + regenerated mirror). No runtime behavior changes. Confirmed the mirror picked up the rule (`grep` hit in `.claude/rules/coding-standards.md`) and that the diff is exactly the two intended files (unrelated `go.sum` dirt excluded from the commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)