### PR TITLE
docs(review): add a Generic Correctness layer to the review checklist

### DIFF
--- a/.github/agents/code-reviewer.agent.md
+++ b/.github/agents/code-reviewer.agent.md
@@ -14,6 +14,27 @@ When invoked:
 
 ## Review Checklist
 
+The checklist has two layers. The **Generic Correctness** perspectives below are the
+language- and architecture-agnostic foundation; the repo-specific sections that follow
+(DDD Layer Compliance / Language Policy / Security / ...) build on top. Read the generic
+perspectives first, then apply the repo-specific ones.
+
+### Generic Correctness
+
+Correctness foundation. The generic perspectives are numbered ①–⑥; **③ backward
+compatibility is intentionally out of scope while the project is experimental** (so ③ is
+skipped). Read the remaining ①②④⑤⑥ (5 perspectives) before the repo-specific sections.
+Severity: ①②④ are CRITICAL-level; ⑤⑥ are delegated to the Testing (HIGH) section below.
+
+- **① Correctness**: logic errors, nil dereferences, type mismatches, boundary-value behavior.
+  - **Range variable pointer**: never take `&e` where `e` is a `for _, e := range` variable and pass/store the pointer; use an index loop `for i := range` with `&slice[i]`.
+  - **Nil receiver/field**: a method dereferencing possibly-nil fields must guard with a descriptive error before the dereference.
+- **② Edge cases / error paths**: missed failure handling — empty input, malformed input, mid-operation failure; not crashing and not silently swallowing errors (detail in the Error Handling section below).
+- **④ Functional loss**: does this change break or silently drop an existing capability, path, or output?
+  - Scope it to the **caller-observable surface only**: CLI flags / subcommands, output-format fields, supported data sources / formats, declared interfaces, documented behavior. **Internal unexported refactors are out of scope** (the Code Reuse reviewer / `/deadcode` skill / `refactor-cleaner` agent handle those).
+  - Judge from the **actual code**: a `switch` case removed and made unreachable, a handler no longer wired, a dropped output field, a silently changed contract. Flag it even if the PR body mentions it ("PR body vs diff mismatch" is the PR Hygiene reviewer's job, not this).
+- **⑤ Test sufficiency / ⑥ Unit-test coverage**: judged in the Testing (HIGH) section below (new code has tests; normal / abnormal / boundary cases covered).
+
 ### DDD Layer Compliance (CRITICAL)
 
 - **Layer violations**: Code in correct DDD layer (`Interfaces → Application → Domain ← Infrastructure`)
@@ -38,9 +59,8 @@ When invoked:
 - Receiver names: short, consistent (not `this` or `self`)
 - Package names: short, lowercase, no underscores
 - No stuttering: `config.Config` is fine, `config.ConfigManager` is not
-- **Range variable pointer**: Never take `&e` where `e` is a `for _, e := range` variable and pass/store the pointer. Use index loop `for i := range` with `&slice[i]` instead
 - **flag.FlagSet output**: When using `flag.NewFlagSet` with `ContinueOnError`, call `fs.SetOutput(io.Discard)` to suppress duplicate error/usage output (check existing patterns in the codebase)
-- **Nil receiver/field panic**: If a struct method dereferences fields that could be nil at runtime, add a nil guard returning a descriptive error before the dereference
+- Nil safety / range-variable-pointer are covered by Generic Correctness ① (Correctness) above
 
 ### Error Handling (CRITICAL)
 
@@ -77,7 +97,7 @@ if err != nil {
 - `io.Writer` / `io.Reader` instead of concrete os.Stdout/os.Stdin
 - No unnecessary new env vars or CLI flags (see project-conventions)
 
-### Testing (HIGH)
+### Testing (HIGH) — Generic Correctness ⑤ Test sufficiency / ⑥ Unit-test coverage
 
 - New code has table-driven tests
 - Test function names: `TestFuncName_scenario`

--- a/.github/prompts/review-until-clean.prompt.md
+++ b/.github/prompts/review-until-clean.prompt.md
@@ -144,13 +144,14 @@ The named subagent_types invocable here are `code-reviewer`, `architect`, and (w
 
 #### Agent 1: subagent_type=`code-reviewer` (named)
 
-Code quality, Go idioms, error handling, security. Returns CRITICAL / HIGH / MEDIUM / LOW + file + line + suggested fix.
+Generic correctness (Generic Correctness ①②④⑤⑥), Go idioms, error handling, security. Returns CRITICAL / HIGH / MEDIUM / LOW + file + line + suggested fix.
 
-Focus areas:
+Owns the generic correctness perspectives (correctness / edge-case / functional-loss / test sufficiency + coverage) — see the `## Review Checklist` → `Generic Correctness` section of `.github/agents/code-reviewer.agent.md`. Focus areas:
 
 - error handling: silenced errors (`_ = err`), missing error wrapping, inconsistent patterns
 - resource cleanup: `t.Cleanup` for process-global state AND explicit error-checked close on the normal path (both required, not either/or)
-- API contracts, nil safety, race conditions
+- API contracts, nil safety, race conditions, logic errors, boundary values
+- functional loss (④): apply the caller-observable-surface checklist in `.github/agents/code-reviewer.agent.md`'s Generic Correctness ④ (single source of truth). Cross-agent boundary: internal unexported churn is out of scope (the Code Reuse reviewer / `/deadcode` skill / `refactor-cleaner` agent handle it), and "PR body vs diff mismatch" is Agent 5's job, not this.
 
 #### Agent 2: subagent_type=`architect` (named)
 
@@ -171,7 +172,7 @@ DDD layer compliance, dependency direction, package structure. Returns CRITICAL 
 - redundant state, parameter sprawl, copy-paste with variation
 - leaky abstractions, stringly-typed code
 - unnecessary comments (WHAT not WHY)
-- bugs: nil dereference, panics, edge cases
+- correctness bugs (nil deref / panics / edge cases) — Agent 1's Generic Correctness ①② (correctness / edge-case), not duplicated here
 
 #### Agent 5: general-purpose with "PR Hygiene" prompt
 


### PR DESCRIPTION
## Background

Port of the review-perspective reorganization done in the sibling **vuls-reach** repo. The code-review perspectives were scattered and partly duplicated across the `code-reviewer` agent and the `Code Quality` reviewer, and there was no explicit "did this change silently drop a capability" perspective.

This separates the **generic correctness** perspectives (language- and architecture-agnostic) from the repo-specific DDD / security / language sections, gives them a single owner, and removes the duplication.

## Changes

### `.github/agents/code-reviewer.agent.md`
- New **Generic Correctness** section at the top of the Review Checklist: ① correctness, ② edge cases / error paths, ④ functional loss, ⑤⑥ tests.
- **③ backward compatibility is intentionally skipped** while the project is experimental (so ③ is a deliberate numbering gap, documented inline).
- Nil-safety / range-variable-pointer footguns moved from Go Idioms into ① (single location, with a pointer left in Go Idioms).
- Testing (HIGH) heading annotated as the home of ⑤⑥.

### `.github/prompts/review-until-clean.prompt.md`
- Agent 1 (`code-reviewer`) named as owner of the generic perspectives; gains the **④ functional-loss** focus, scoped to the caller-observable surface only (internal unexported churn → Code Reuse reviewer / `/deadcode` skill / `refactor-cleaner` agent; PR-body-vs-diff → Agent 5).
- Agent 4 (Code Quality) drops the duplicated nil/edge-case bullet, pointing to Agent 1's ①② instead.

## Scope / safety
- Docs/config only; no Go changes, no build/test impact.
- Written in English per the repo's language policy; the content is generic review guidance with nothing repo-private, safe for a public repo.
- `.github/agents/code-reviewer.agent.md` is the canonical agent spec; the `.claude/agents/` shim is a delegation pointer and needs no change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)