### PR TITLE
docs(rules): add How/What/Why/Why-not comment placement filter

### DIFF
--- a/.claude/rules/coding-standards.md
+++ b/.claude/rules/coding-standards.md
@@ -55,6 +55,24 @@ A key tenet of idiomatic Go is to make the zero value of a type useful.
 - **Godoc Format**: A comment for `MyFunction` should start with `// MyFunction ...`.
 - **Architectural rationale belongs in ADRs, not comments — reference by ID, do not restate**: The reasoning behind a design decision (why we chose this, which alternatives we rejected, the forces at play) lives in an ADR, which is the single source of truth. Comments / godoc must NOT copy that reasoning; reference the ADR by ID instead (`// See ADR-NNNN.`). The two have different jobs: an ADR is an append-only decision history (it never erases the past), while a comment is a snapshot of what the code does *now*. Writing the rationale in both means a later code change updates only one, they drift apart, and the ADR loses the value that makes it worth keeping — stopping a rejected proposal from being re-proposed. Apply this at authoring time, before the `comment-impl-drift` / `narrative-drift` accumulator catches the drift after the fact. Cite by a stable anchor (ADR ID, function name, heading), never by copying the ADR's prose.
 
+### Where to Write It: How / What / Why / Why Not
+
+Before writing a comment, decide where it belongs using this filter:
+
+- **How** (the mechanics of the implementation) → **the code itself**. Naming and function
+  decomposition should carry this; do not restate it in prose.
+- **What** (what the function does) → **the godoc's one sentence** for exported identifiers,
+  or the test case name.
+- **Why** (why this change was made) → **the commit message** / **PR description**. Design
+  rationale spanning more than one sentence belongs in an ADR, referenced by ID (see the rule
+  above).
+- **Why not** (why an obvious-looking alternative was deliberately avoided) → **the comment**.
+  This is the only case where a comment earns its keep — e.g. why a guard clause exists, why a
+  naive approach was rejected, why a fallback is fail-open instead of fail-closed.
+
+Comments that restate How rot the moment the implementation changes, since nothing forces
+them to be updated in lockstep.
+
 ## API Design and Backward Compatibility
 
 Any exported function, type, or constant is part of our public API. API stability is crucial.

--- a/.github/instructions/coding-standards.instructions.md
+++ b/.github/instructions/coding-standards.instructions.md
@@ -53,6 +53,24 @@ A key tenet of idiomatic Go is to make the zero value of a type useful.
 - **Godoc Format**: A comment for `MyFunction` should start with `// MyFunction ...`.
 - **Architectural rationale belongs in ADRs, not comments — reference by ID, do not restate**: The reasoning behind a design decision (why we chose this, which alternatives we rejected, the forces at play) lives in an ADR, which is the single source of truth. Comments / godoc must NOT copy that reasoning; reference the ADR by ID instead (`// See ADR-NNNN.`). The two have different jobs: an ADR is an append-only decision history (it never erases the past), while a comment is a snapshot of what the code does *now*. Writing the rationale in both means a later code change updates only one, they drift apart, and the ADR loses the value that makes it worth keeping — stopping a rejected proposal from being re-proposed. Apply this at authoring time, before the `comment-impl-drift` / `narrative-drift` accumulator catches the drift after the fact. Cite by a stable anchor (ADR ID, function name, heading), never by copying the ADR's prose.
 
+### Where to Write It: How / What / Why / Why Not
+
+Before writing a comment, decide where it belongs using this filter:
+
+- **How** (the mechanics of the implementation) → **the code itself**. Naming and function
+  decomposition should carry this; do not restate it in prose.
+- **What** (what the function does) → **the godoc's one sentence** for exported identifiers,
+  or the test case name.
+- **Why** (why this change was made) → **the commit message** / **PR description**. Design
+  rationale spanning more than one sentence belongs in an ADR, referenced by ID (see the rule
+  above).
+- **Why not** (why an obvious-looking alternative was deliberately avoided) → **the comment**.
+  This is the only case where a comment earns its keep — e.g. why a guard clause exists, why a
+  naive approach was rejected, why a fallback is fail-open instead of fail-closed.
+
+Comments that restate How rot the moment the implementation changes, since nothing forces
+them to be updated in lockstep.
+
 ## API Design and Backward Compatibility
 
 Any exported function, type, or constant is part of our public API. API stability is crucial.


### PR DESCRIPTION
## What changes

Adds a filter for deciding where a piece of documentation belongs, before writing it: How (implementation mechanics) goes in the code itself, What (what a function does) goes in the godoc sentence or test name, Why (why a change was made) goes in the commit message / PR description, and Why not (why an obvious alternative was deliberately avoided) is the only case that earns a comment.

## The problem

Comments that restate How rot the moment the implementation changes, since nothing forces a comment to track a refactor. This repo already has one instance of the same idea scoped narrowly to ADR references ("architectural rationale belongs in ADRs, not comments"), landed via PR #459. This PR generalizes that pattern into a repo-wide pre-write check, so authors get a quick filter before typing any comment, not just ADR-adjacent ones.

## How it's solved

Added as a new subsection right after the existing ADR-reference bullet in `## Documentation Comments`, in `.github/instructions/coding-standards.instructions.md` (canonical), then regenerated the `.claude/rules/` mirror via `make sync-instructions`.

## Related

- Companion PRs with the same content are open on `uzomuzo-catalog` (English) and `vuls-reach` (Japanese, since that repo's rule docs are JP-first).

<details>
<summary>Test plan</summary>

- [x] Docs-only change, no build/test required
- [x] Ran `make sync-instructions` and confirmed the `.claude/rules/coding-standards.md` mirror matches the canonical source

</details>