### PR TITLE
fix: a yanked cargo release is not the stable version (#494)

### DIFF
--- a/docs/adr/0024-cargo-yank-from-depsdev.md
+++ b/docs/adr/0024-cargo-yank-from-depsdev.md
@@ -1,0 +1,121 @@
+# 0024. deps.dev reports cargo yanks, and they bound stable selection
+
+Date: 2026-09-02
+Status: Accepted
+
+## Context
+
+[ADR-0023](0023-stable-version-source.md) stopped a yanked PyPI release from being
+selected as `StableVersion`, by bounding selection with the version PyPI itself
+presents as current. It named cargo as the remaining gap and said cargo would need
+a different, more expensive mechanism, because `pickStableDevAndMax`
+(`internal/infrastructure/depsdev/selection.go`) takes deps.dev's `isDefault=true`
+unconditionally and deps.dev was believed to hold no yank data.
+
+That belief is wrong for cargo. Both ADR-0021 and ADR-0023 state that deps.dev
+publishes no yank data for any ecosystem; ADR-0023 says so explicitly ("deps.dev
+publishes no yank data at all, for any ecosystem") and ADR-0021 makes the
+equivalent claim that `IsDeprecated` is a different signal. deps.dev does publish
+cargo yanks, in the same versions payload we already fetch, under
+`deprecatedReason`.
+
+Observed 2026-09-01 on `pkg:cargo/promptforge-gateway-config`, from
+`/v3alpha/systems/cargo/packages/promptforge-gateway-config`:
+
+```
+1.1.0   isDefault=true    isDeprecated=true   deprecatedReason="yanked"
+0.2.0   isDefault=false   isDeprecated=false  deprecatedReason=""
+```
+
+crates.io agrees that 1.1.0 is yanked and reports `max_stable_version: "0.2.0"`.
+deps.dev nonetheless marks the yanked 1.1.0 as the default version, so stable
+selection returned it — the same class of bug ADR-0023 fixed for pypi, with the
+same downstream consequences: the internal deps.dev package lookup, direct and
+transitive advisory aggregates, and the lifecycle assessor all described a release
+nobody should install.
+
+The field was invisible to us only because the decode struct in `fetchLatestRelease`
+(`internal/infrastructure/depsdev/release.go`) enumerated four fields and
+`deprecatedReason` was not among them.
+
+`deprecatedReason` is not documented to carry "yanked". The deps.dev v3alpha
+reference defines `isDeprecated` as "If true, this version has been marked as
+deprecated" and `deprecatedReason` as "The reason why this version is deprecated",
+with no ecosystem-specific statement. The value was therefore established by
+measurement. Across 17 crates and 2819 versions — including crates with substantial
+yank history (`clap` 92, `num` 35, `futures` 23, `chrono` 22, `syn` 17) — deps.dev
+`isDeprecated` and crates.io `yanked` disagreed on **zero** versions.
+
+The correspondence is cargo-specific. On `pkg:pypi/pydantic-extra-types`, whose
+2.11.2 release PyPI has yanked (the specimen in ADR-0023), deps.dev reports
+`isDeprecated=false` for every version. PyPI yanks are invisible to deps.dev, so
+ADR-0023's PyPI bound remains necessary and is not superseded.
+
+## Decision
+
+For cargo, a release deps.dev marks `isDeprecated` with `deprecatedReason`
+"yanked" is excluded from Stable selection.
+
+`Version` carries `DeprecatedReason`, decoded from the payload we already fetch.
+`pickStableDevAndMax` partitions candidates through `withdrawnFromStable` before
+any Stable rule runs, so the exclusion applies to the `preferredStable` bound, to
+`isDefault`, and to the `purl.IsStableVersion` fallback alike. When every stable
+release is withdrawn, Stable is left empty rather than falling back to a yanked
+release — the same choice ADR-0023 made when its bound excludes every candidate,
+and the same answer crates.io gives, which reports `max_stable_version: null` for
+such crates (observed on `gap` and `minae-term`).
+
+The reason string is matched with `strings.EqualFold` after trimming. A cargo
+release that is `isDeprecated` with an **unrecognised** reason is logged at WARN
+and treated as not withdrawn. The string is an observed value, not a contract: if
+deps.dev renames it, the filter must degrade to the previous behaviour audibly
+rather than going quiet. A unit test pins the literal so the same drift fails CI.
+
+Dev and `MaxSemverVersion` keep the unfiltered candidate list. Max's purpose is
+"highest version that exists", and a yanked release does still exist — that
+reasoning is ADR-0023's and is unchanged here.
+
+## Rejected alternatives
+
+**Bound cargo with crates.io `max_stable_version`, mirroring the pypi mechanism.**
+This was the path the follow-up issue anticipated, and it works: `max_stable_version`
+does exclude yanked releases, confirmed in the crates.io source on both code paths
+that build it (`Krate::top_versions` filters `versions.yanked = false`;
+`controllers/krate/metadata.rs` filters `!v.yanked` before constructing
+`TopVersions`, which itself only drops pre-releases). It was rejected because it
+costs one HTTP request per cargo package, a new `crates.Client.GetCrate`, a new
+client dependency on `DepsDevClient` and its wiring, and a cache policy — to obtain
+data already present in a response we had already parsed. Its one genuine advantage,
+independence from deps.dev's indexing lag, is largely illusory: the candidate list
+being filtered comes from deps.dev regardless, so a package deps.dev has not
+re-indexed is stale in both designs.
+
+It would also have inherited a defect. `pickByRegistryStable` orders the bound and
+the candidates with `pep440.Parse`, which is correct for pypi but not for cargo:
+a semver build-metadata version such as `1.2.3+build` fails to parse and would be
+silently dropped from the bound comparison, and a hint that fails to parse turns
+the bound off entirely, reopening the hole being closed. Adopting deps.dev's own
+flag needs no version ordering at all and avoids the question.
+
+**Filter on `isDeprecated` alone, ignoring the reason.** `isDeprecated` is
+deps.dev's ecosystem-general deprecation signal — npm deprecation is the common
+case — and conflating "the author deprecated this" with "the registry withdrew
+this" would change the meaning of Stable for reasons unrelated to yanking. Keying
+on the reason keeps the rule to the signal actually measured, and gives the
+unknown-value branch somewhere to report.
+
+## Not addressed here
+
+- **The premise in ADR-0021 and ADR-0023.** Both state that deps.dev holds no yank
+  data. That is now known to be wrong for cargo and correct for pypi. The
+  corrections are tracked separately; the decisions themselves are unaffected.
+  ADR-0021's conclusion — a version yank is not package-level EOL — does not depend
+  on where the yank data comes from. ADR-0023's PyPI bound is still required,
+  because deps.dev does not see PyPI yanks.
+- **`MaxSemverVersion` can still be a yanked release**, in cargo as in every other
+  ecosystem. See ADR-0023's "Not addressed here".
+- **Ecosystems other than cargo.** Whether deps.dev's `deprecatedReason` carries
+  registry-withdrawal values for any other system was not surveyed beyond the pypi
+  check above.
+- **RubyGems.** RubyGems.org exposes `yanked`, but our own client surfaces none of
+  it and deps.dev was not measured for gem yanks here.

--- a/docs/adr/0024-cargo-yank-from-depsdev.md
+++ b/docs/adr/0024-cargo-yank-from-depsdev.md
@@ -27,12 +27,17 @@ Observed 2026-09-01 on `pkg:cargo/promptforge-gateway-config`, from
 0.2.0   isDefault=false   isDeprecated=false  deprecatedReason=""
 ```
 
-crates.io agrees that 1.1.0 is yanked and reports `max_stable_version: "0.2.0"`.
-deps.dev nonetheless marks the yanked 1.1.0 as the default version, so stable
+crates.io agreed that 1.1.0 was yanked and reported `max_stable_version: "0.2.0"`.
+deps.dev nonetheless marked the yanked 1.1.0 as the default version, so stable
 selection returned it — the same class of bug ADR-0023 fixed for pypi, with the
 same downstream consequences: the internal deps.dev package lookup, direct and
 transitive advisory aggregates, and the lifecycle assessor all described a release
 nobody should install.
+
+0.2.0 was itself yanked on 2026-09-02, hours after this observation, leaving the
+crate with no un-yanked release. It therefore appears in the tests only as the
+all-yanked specimen; the ordinary case is pinned with `owo-colors`, whose 5.0.0 is
+`isDefault` and yanked while 4.4.0 is clean.
 
 The field was invisible to us only because the decode struct in `fetchLatestRelease`
 (`internal/infrastructure/depsdev/release.go`) enumerated four fields and
@@ -69,7 +74,9 @@ The reason string is matched with `strings.EqualFold` after trimming. A cargo
 release that is `isDeprecated` with an **unrecognised** reason is logged at WARN
 and treated as not withdrawn. The string is an observed value, not a contract: if
 deps.dev renames it, the filter must degrade to the previous behaviour audibly
-rather than going quiet. A unit test pins the literal so the same drift fails CI.
+rather than going quiet. The WARN log is what surfaces that drift at runtime; the
+unit tests pin our reading of the string against accidental local edits, but they
+run on fixtures and cannot observe upstream change.
 
 Dev and `MaxSemverVersion` keep the unfiltered candidate list. Max's purpose is
 "highest version that exists", and a yanked release does still exist — that

--- a/docs/adr/0024-cargo-yank-from-depsdev.md
+++ b/docs/adr/0024-cargo-yank-from-depsdev.md
@@ -120,7 +120,14 @@ unknown-value branch somewhere to report.
   on where the yank data comes from. ADR-0023's PyPI bound is still required,
   because deps.dev does not see PyPI yanks.
 - **`MaxSemverVersion` can still be a yanked release**, in cargo as in every other
-  ecosystem. See ADR-0023's "Not addressed here".
+  ecosystem. See ADR-0023's "Not addressed here". This bounds what an empty Stable
+  buys on its own: `batch_details.go` resolves the effective PURL as
+  Stable -> MaxSemver -> PreRelease -> original, so for a crate whose every release
+  is yanked, resolution still lands on the yanked max-semver release. That is not a
+  regression — before this change the same crate selected the yanked release as
+  Stable outright — but closing it needs the max-semver decision ADR-0023 deferred,
+  not this one. Where an un-yanked release exists, which is the common case, Stable
+  now selects it and the fallback never runs.
 - **Ecosystems other than cargo.** Whether deps.dev's `deprecatedReason` carries
   registry-withdrawal values for any other system was not surveyed beyond the pypi
   check above.

--- a/docs/data-flow.md
+++ b/docs/data-flow.md
@@ -83,7 +83,7 @@ Returns Project info for each projectKey (e.g., github.com/owner/repo):
 
 #### deps.dev — Releases (GET /v3alpha/systems/{ecosystem}/packages/{name})
 
-- Returns: Versions list (`versionKey.version`, `publishedAt`, `isDefault`, `isDeprecated`) — no yank data, see [ADR-0023](adr/0023-stable-version-source.md)
+- Returns: Versions list (`versionKey.version`, `publishedAt`, `isDefault`, `isDeprecated`, `deprecatedReason`) — no yank data except cargo, which reports yanks as `isDeprecated` with `deprecatedReason` `"yanked"`; see [ADR-0024](adr/0024-cargo-yank-from-depsdev.md) and [ADR-0023](adr/0023-stable-version-source.md)
 - Purpose: Identify latest stable/dev/requested version and freshness
 - Code: `DepsDevClient.fetchLatestRelease`, `DepsDevClient.fetchReleaseInfoBatch` (`internal/infrastructure/depsdev/release.go`)
 - Docs: <https://docs.deps.dev/api/v3alpha/>

--- a/internal/infrastructure/depsdev/api_types.go
+++ b/internal/infrastructure/depsdev/api_types.go
@@ -167,6 +167,7 @@ type Version struct {
 	PublishedAt         time.Time            `json:"publishedAt"`
 	IsDefault           bool                 `json:"isDefault"`
 	IsDeprecated        bool                 `json:"isDeprecated"`
+	DeprecatedReason    string               `json:"deprecatedReason"`
 	Licenses            []string             `json:"licenses"`
 	LicenseDetails      []LicenseDetail      `json:"licenseDetails"`
 	AdvisoryKeys        []AdvisoryKey        `json:"advisoryKeys"`

--- a/internal/infrastructure/depsdev/release.go
+++ b/internal/infrastructure/depsdev/release.go
@@ -133,9 +133,10 @@ func (c *DepsDevClient) fetchLatestRelease(ctx context.Context, purlStr string) 
 			VersionKey struct {
 				Version string `json:"version"`
 			} `json:"versionKey"`
-			PublishedAt  string `json:"publishedAt"`
-			IsDefault    bool   `json:"isDefault"`
-			IsDeprecated bool   `json:"isDeprecated"`
+			PublishedAt      string `json:"publishedAt"`
+			IsDefault        bool   `json:"isDefault"`
+			IsDeprecated     bool   `json:"isDeprecated"`
+			DeprecatedReason string `json:"deprecatedReason"`
 		} `json:"versions"`
 	}
 
@@ -195,6 +196,7 @@ func (c *DepsDevClient) fetchLatestRelease(ctx context.Context, purlStr string) 
 		// carry flags
 		versionInfo.IsDefault = version.IsDefault
 		versionInfo.IsDeprecated = version.IsDeprecated
+		versionInfo.DeprecatedReason = version.DeprecatedReason
 
 		if version.VersionKey.Version == requestedVersion {
 			releaseInfo.RequestedVersion = versionInfo

--- a/internal/infrastructure/depsdev/release_cargo_yank_test.go
+++ b/internal/infrastructure/depsdev/release_cargo_yank_test.go
@@ -1,0 +1,95 @@
+package depsdev
+
+import (
+	"context"
+	"testing"
+)
+
+// This file exercises the ADR-0024 contract end to end through
+// fetchLatestRelease: the deps.dev versions payload is decoded (including
+// deprecatedReason), carried onto Version, and consumed by Stable selection.
+// The unit tests in selection_yanked_test.go build Version literals directly
+// and so cannot catch a break in the decode or carry step. Everything here is
+// httptest-local; nothing touches the network.
+//
+// Fixture mirrors pkg:cargo/owo-colors as observed 2026-09-02: deps.dev marks
+// the yanked 5.0.0 isDefault=true with deprecatedReason "yanked", while
+// crates.io reports max_stable_version 4.4.0.
+const owoColorsVersionsJSON = `{
+  "versions": [
+    {"versionKey": {"version": "4.4.0"}, "publishedAt": "2026-08-27T00:00:00Z", "isDefault": false, "isDeprecated": false, "deprecatedReason": ""},
+    {"versionKey": {"version": "5.0.0"}, "publishedAt": "2024-09-10T00:00:00Z", "isDefault": true,  "isDeprecated": true,  "deprecatedReason": "yanked"}
+  ]
+}`
+
+// allYankedVersionsJSON mirrors pkg:cargo/promptforge-gateway-config as observed
+// 2026-09-02, after every release had been yanked. crates.io reports
+// max_stable_version null for such crates.
+const allYankedVersionsJSON = `{
+  "versions": [
+    {"versionKey": {"version": "0.2.0"}, "publishedAt": "2026-08-31T16:02:26Z", "isDefault": false, "isDeprecated": true, "deprecatedReason": "yanked"},
+    {"versionKey": {"version": "1.1.0"}, "publishedAt": "2026-08-31T15:42:53Z", "isDefault": true,  "isDeprecated": true, "deprecatedReason": "yanked"}
+  ]
+}`
+
+// unknownReasonVersionsJSON is the upstream-drift case: deps.dev still marks the
+// release deprecated but with a reason we do not recognise. The release must stay
+// eligible (previous behaviour) rather than being silently dropped.
+const unknownReasonVersionsJSON = `{
+  "versions": [
+    {"versionKey": {"version": "1.0.0"}, "publishedAt": "2026-01-01T00:00:00Z", "isDefault": false, "isDeprecated": false, "deprecatedReason": ""},
+    {"versionKey": {"version": "2.0.0"}, "publishedAt": "2026-02-01T00:00:00Z", "isDefault": true,  "isDeprecated": true,  "deprecatedReason": "withdrawn"}
+  ]
+}`
+
+func TestFetchLatestRelease_CargoYankedDefaultIsNotStable(t *testing.T) {
+	srv := newDepsDevTestServer(t, "/v3alpha/systems/cargo/packages/owo-colors", owoColorsVersionsJSON)
+	c := newDepsDevClient(srv)
+
+	info, err := c.fetchLatestRelease(context.Background(), "pkg:cargo/owo-colors")
+	if err != nil {
+		t.Fatalf("fetchLatestRelease: %v", err)
+	}
+
+	if got, want := info.StableVersion.VersionKey.Version, "4.4.0"; got != want {
+		t.Errorf("StableVersion = %q, want %q (the yanked isDefault release must not win)", got, want)
+	}
+	// The reason must survive decoding, or the filter above it is inert.
+	if got, want := info.MaxSemverVersion.VersionKey.Version, "5.0.0"; got != want {
+		t.Errorf("MaxSemverVersion = %q, want %q (Max is deliberately unfiltered)", got, want)
+	}
+	if got, want := info.MaxSemverVersion.DeprecatedReason, "yanked"; got != want {
+		t.Errorf("MaxSemverVersion.DeprecatedReason = %q, want %q (decode/carry regression)", got, want)
+	}
+	if !info.MaxSemverVersion.IsDeprecated {
+		t.Error("MaxSemverVersion.IsDeprecated = false, want true")
+	}
+}
+
+func TestFetchLatestRelease_CargoAllReleasesYanked(t *testing.T) {
+	srv := newDepsDevTestServer(t, "/v3alpha/systems/cargo/packages/promptforge-gateway-config", allYankedVersionsJSON)
+	c := newDepsDevClient(srv)
+
+	info, err := c.fetchLatestRelease(context.Background(), "pkg:cargo/promptforge-gateway-config")
+	if err != nil {
+		t.Fatalf("fetchLatestRelease: %v", err)
+	}
+
+	if got := info.StableVersion.VersionKey.Version; got != "" {
+		t.Errorf("StableVersion = %q, want empty when every release is yanked", got)
+	}
+}
+
+func TestFetchLatestRelease_CargoUnknownDeprecatedReasonStaysEligible(t *testing.T) {
+	srv := newDepsDevTestServer(t, "/v3alpha/systems/cargo/packages/example", unknownReasonVersionsJSON)
+	c := newDepsDevClient(srv)
+
+	info, err := c.fetchLatestRelease(context.Background(), "pkg:cargo/example")
+	if err != nil {
+		t.Fatalf("fetchLatestRelease: %v", err)
+	}
+
+	if got, want := info.StableVersion.VersionKey.Version, "2.0.0"; got != want {
+		t.Errorf("StableVersion = %q, want %q (an unrecognised reason must not withdraw a release)", got, want)
+	}
+}

--- a/internal/infrastructure/depsdev/release_cargo_yank_test.go
+++ b/internal/infrastructure/depsdev/release_cargo_yank_test.go
@@ -17,8 +17,8 @@ import (
 // crates.io reports max_stable_version 4.4.0.
 const owoColorsVersionsJSON = `{
   "versions": [
-    {"versionKey": {"version": "4.4.0"}, "publishedAt": "2026-08-27T00:00:00Z", "isDefault": false, "isDeprecated": false, "deprecatedReason": ""},
-    {"versionKey": {"version": "5.0.0"}, "publishedAt": "2024-09-10T00:00:00Z", "isDefault": true,  "isDeprecated": true,  "deprecatedReason": "yanked"}
+    {"versionKey": {"version": "4.4.0"}, "publishedAt": "2026-08-27T17:55:12Z", "isDefault": false, "isDeprecated": false, "deprecatedReason": ""},
+    {"versionKey": {"version": "5.0.0"}, "publishedAt": "2024-09-10T16:07:38Z", "isDefault": true,  "isDeprecated": true,  "deprecatedReason": "yanked"}
   ]
 }`
 
@@ -77,6 +77,11 @@ func TestFetchLatestRelease_CargoAllReleasesYanked(t *testing.T) {
 
 	if got := info.StableVersion.VersionKey.Version; got != "" {
 		t.Errorf("StableVersion = %q, want empty when every release is yanked", got)
+	}
+	// batch_details.go falls back to MaxSemverVersion when StableVersion is
+	// empty, so an all-yanked crate must still surface one.
+	if got, want := info.MaxSemverVersion.VersionKey.Version, "1.1.0"; got != want {
+		t.Errorf("MaxSemverVersion = %q, want %q", got, want)
 	}
 }
 

--- a/internal/infrastructure/depsdev/release_cargo_yank_test.go
+++ b/internal/infrastructure/depsdev/release_cargo_yank_test.go
@@ -86,6 +86,8 @@ func TestFetchLatestRelease_CargoAllReleasesYanked(t *testing.T) {
 }
 
 func TestFetchLatestRelease_CargoUnknownDeprecatedReasonStaysEligible(t *testing.T) {
+	quietWarnLogs(t)
+
 	srv := newDepsDevTestServer(t, "/v3alpha/systems/cargo/packages/example", unknownReasonVersionsJSON)
 	c := newDepsDevClient(srv)
 

--- a/internal/infrastructure/depsdev/selection.go
+++ b/internal/infrastructure/depsdev/selection.go
@@ -1,13 +1,23 @@
 package depsdev
 
 import (
+	"log/slog"
+	"strings"
+
 	"github.com/Masterminds/semver/v3"
 	pep440 "github.com/aquasecurity/go-pep440-version"
 
 	"github.com/future-architect/uzomuzo-oss/internal/common/purl"
 )
 
+// depsDevYankedReason is the deps.dev deprecatedReason value marking a cargo
+// release the registry has withdrawn. See ADR-0024.
+const depsDevYankedReason = "yanked"
+
 // pickStableDevAndMax selects Stable, Dev, and the maximum SemVer version from the list.
+//
+// Versions the registry has withdrawn are excluded from Stable selection before
+// any rule below applies; see withdrawnFromStable. Dev and Max are unaffected.
 //
 // preferredStable is the version the package's own registry presents as current,
 // empty when unavailable. It is an upper bound on Stable:
@@ -34,14 +44,21 @@ func pickStableDevAndMax(versions []Version, preferredStable string) (stable Ver
 
 	var defaults, stables, nonStables []Version
 	var semverCandidates []Version
+	// Stable is chosen only from releases the registry still stands behind.
+	// Dev and Max keep the full list: a withdrawn release does still exist.
+	stableEligible := make([]Version, 0, len(versions))
 
 	for _, v := range versions {
-		if v.IsDefault {
-			defaults = append(defaults, v)
+		if !withdrawnFromStable(v) {
+			stableEligible = append(stableEligible, v)
+			if v.IsDefault {
+				defaults = append(defaults, v)
+			}
+			if purl.IsStableVersion(v.VersionKey.Version) {
+				stables = append(stables, v)
+			}
 		}
-		if purl.IsStableVersion(v.VersionKey.Version) {
-			stables = append(stables, v)
-		} else {
+		if !purl.IsStableVersion(v.VersionKey.Version) {
 			nonStables = append(nonStables, v)
 		}
 
@@ -52,7 +69,7 @@ func pickStableDevAndMax(versions []Version, preferredStable string) (stable Ver
 
 	// Stable selection. A zero picked with governs=true is intended: the bound
 	// applies and excludes every candidate, so Stable stays empty.
-	if picked, governs := pickByRegistryStable(versions, preferredStable); governs {
+	if picked, governs := pickByRegistryStable(stableEligible, preferredStable); governs {
 		stable = picked
 	} else if len(defaults) > 0 {
 		stable = latestByPublishedAt(defaults)
@@ -121,6 +138,29 @@ func pickByRegistryStable(versions []Version, preferredStable string) (picked Ve
 		}
 	}
 	return best.raw, true
+}
+
+// withdrawnFromStable reports whether the registry has withdrawn v, making it
+// ineligible as Stable.
+//
+// deps.dev reports cargo yanks as IsDeprecated with a deprecatedReason of
+// "yanked"; no other ecosystem we consume reports yanks through this field, so
+// the check is cargo-scoped. An unrecognised reason on a deprecated cargo
+// release is logged and treated as not withdrawn, so a change in the upstream
+// string degrades to the previous behaviour loudly rather than silently.
+// See ADR-0024.
+func withdrawnFromStable(v Version) bool {
+	if !v.IsDeprecated || !strings.EqualFold(v.VersionKey.System, "cargo") {
+		return false
+	}
+	if strings.EqualFold(strings.TrimSpace(v.DeprecatedReason), depsDevYankedReason) {
+		return true
+	}
+	slog.Warn("depsdev_cargo_unknown_deprecated_reason",
+		"name", v.VersionKey.Name,
+		"version", v.VersionKey.Version,
+		"deprecated_reason", v.DeprecatedReason)
+	return false
 }
 
 // stableCandidate pairs a deps.dev version with its parsed PEP 440 form so the

--- a/internal/infrastructure/depsdev/selection.go
+++ b/internal/infrastructure/depsdev/selection.go
@@ -36,7 +36,7 @@ const depsDevYankedReason = "yanked"
 // Max:
 //   - Highest SemVer using Masterminds semver; if none are valid SemVer, fallback to latest by PublishedAt
 //
-// See ADR-0023.
+// See ADR-0023 and ADR-0024.
 func pickStableDevAndMax(versions []Version, preferredStable string) (stable Version, dev Version, max Version) {
 	if len(versions) == 0 {
 		return Version{}, Version{}, Version{}

--- a/internal/infrastructure/depsdev/selection.go
+++ b/internal/infrastructure/depsdev/selection.go
@@ -44,21 +44,20 @@ func pickStableDevAndMax(versions []Version, preferredStable string) (stable Ver
 
 	var defaults, stables, nonStables []Version
 	var semverCandidates []Version
-	// Stable is chosen only from releases the registry still stands behind.
-	// Dev and Max keep the full list: a withdrawn release does still exist.
 	stableEligible := make([]Version, 0, len(versions))
 
 	for _, v := range versions {
+		isStable := purl.IsStableVersion(v.VersionKey.Version)
 		if !withdrawnFromStable(v) {
 			stableEligible = append(stableEligible, v)
 			if v.IsDefault {
 				defaults = append(defaults, v)
 			}
-			if purl.IsStableVersion(v.VersionKey.Version) {
+			if isStable {
 				stables = append(stables, v)
 			}
 		}
-		if !purl.IsStableVersion(v.VersionKey.Version) {
+		if !isStable {
 			nonStables = append(nonStables, v)
 		}
 
@@ -143,11 +142,9 @@ func pickByRegistryStable(versions []Version, preferredStable string) (picked Ve
 // withdrawnFromStable reports whether the registry has withdrawn v, making it
 // ineligible as Stable.
 //
-// deps.dev reports cargo yanks as IsDeprecated with a deprecatedReason of
-// "yanked"; no other ecosystem we consume reports yanks through this field, so
-// the check is cargo-scoped. An unrecognised reason on a deprecated cargo
-// release is logged and treated as not withdrawn, so a change in the upstream
-// string degrades to the previous behaviour loudly rather than silently.
+// Only cargo is covered: deps.dev reports a cargo yank as IsDeprecated with a
+// deprecatedReason of depsDevYankedReason. An unrecognised reason on a
+// deprecated cargo release is logged and treated as not withdrawn.
 // See ADR-0024.
 func withdrawnFromStable(v Version) bool {
 	if !v.IsDeprecated || !strings.EqualFold(v.VersionKey.System, "cargo") {

--- a/internal/infrastructure/depsdev/selection_yanked_test.go
+++ b/internal/infrastructure/depsdev/selection_yanked_test.go
@@ -6,14 +6,15 @@ import (
 )
 
 // cargoVersion builds a cargo deps.dev version entry.
-func cargoVersion(version, publishedAt string, isDefault, isDeprecated bool, reason string) Version {
-	t, err := time.Parse(time.RFC3339, publishedAt)
+func cargoVersion(t testing.TB, version, publishedAt string, isDefault, isDeprecated bool, reason string) Version {
+	t.Helper()
+	published, err := time.Parse(time.RFC3339, publishedAt)
 	if err != nil {
-		panic(err)
+		t.Fatalf("parse publishedAt %q: %v", publishedAt, err)
 	}
 	return Version{
 		VersionKey:       VersionKey{System: "cargo", Name: "example", Version: version},
-		PublishedAt:      t,
+		PublishedAt:      published,
 		IsDefault:        isDefault,
 		IsDeprecated:     isDeprecated,
 		DeprecatedReason: reason,
@@ -21,21 +22,21 @@ func cargoVersion(version, publishedAt string, isDefault, isDeprecated bool, rea
 }
 
 // TestPickStableDevAndMax_CargoYankedDefaultIsNotStable mirrors
-// pkg:cargo/promptforge-gateway-config as observed 2026-09-01: deps.dev marks the
-// yanked 1.1.0 isDefault=true, so the pre-fix selection returned it as Stable.
+// pkg:cargo/owo-colors as observed 2026-09-02: deps.dev marks the yanked 5.0.0
+// isDefault=true, so the pre-fix selection returned it as Stable.
 func TestPickStableDevAndMax_CargoYankedDefaultIsNotStable(t *testing.T) {
 	versions := []Version{
-		cargoVersion("0.2.0", "2026-08-31T16:02:26Z", false, false, ""),
-		cargoVersion("1.1.0", "2026-08-31T15:42:53Z", true, true, "yanked"),
+		cargoVersion(t, "4.4.0", "2026-08-27T17:55:12Z", false, false, ""),
+		cargoVersion(t, "5.0.0", "2024-09-10T16:07:38Z", true, true, "yanked"),
 	}
 
 	stable, _, max := pickStableDevAndMax(versions, "")
 
-	if got, want := stable.VersionKey.Version, "0.2.0"; got != want {
+	if got, want := stable.VersionKey.Version, "4.4.0"; got != want {
 		t.Errorf("Stable = %q, want %q (the yanked isDefault release must not win)", got, want)
 	}
-	// Max is deliberately unbounded: a yanked release still exists. See ADR-0024.
-	if got, want := max.VersionKey.Version, "1.1.0"; got != want {
+	// Max is deliberately unfiltered. See ADR-0024.
+	if got, want := max.VersionKey.Version, "5.0.0"; got != want {
 		t.Errorf("Max = %q, want %q (Max is not filtered)", got, want)
 	}
 }
@@ -44,7 +45,7 @@ func TestPickStableDevAndMax_CargoYankedDefaultIsNotStable(t *testing.T) {
 // (observed on gap and minae-term, where crates.io reports max_stable_version=null).
 func TestPickStableDevAndMax_CargoAllStableYanked(t *testing.T) {
 	versions := []Version{
-		cargoVersion("0.1.0", "2026-08-31T10:00:00Z", true, true, "yanked"),
+		cargoVersion(t, "0.1.0", "2026-08-31T10:00:00Z", true, true, "yanked"),
 	}
 
 	stable, _, max := pickStableDevAndMax(versions, "")
@@ -57,9 +58,10 @@ func TestPickStableDevAndMax_CargoAllStableYanked(t *testing.T) {
 	}
 }
 
-// TestWithdrawnFromStable pins the deps.dev deprecatedReason contract. The literal
-// "yanked" is an observed, undocumented upstream value: if deps.dev changes it,
-// this test fails rather than the filter silently going quiet. See ADR-0024.
+// TestWithdrawnFromStable pins our reading of the deps.dev deprecatedReason
+// value. The fixtures are local, so this cannot detect an upstream rename — the
+// WARN branch does that at runtime. It guards the literal against local edits.
+// See ADR-0024.
 func TestWithdrawnFromStable(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -68,32 +70,32 @@ func TestWithdrawnFromStable(t *testing.T) {
 	}{
 		{
 			name:    "cargo yanked",
-			version: cargoVersion("1.0.0", "2026-01-01T00:00:00Z", false, true, "yanked"),
+			version: cargoVersion(t, "1.0.0", "2026-01-01T00:00:00Z", false, true, "yanked"),
 			want:    true,
 		},
 		{
 			name:    "cargo yanked, mixed case",
-			version: cargoVersion("1.0.0", "2026-01-01T00:00:00Z", false, true, "Yanked"),
+			version: cargoVersion(t, "1.0.0", "2026-01-01T00:00:00Z", false, true, "Yanked"),
 			want:    true,
 		},
 		{
 			name:    "cargo yanked, surrounding whitespace",
-			version: cargoVersion("1.0.0", "2026-01-01T00:00:00Z", false, true, " yanked "),
+			version: cargoVersion(t, "1.0.0", "2026-01-01T00:00:00Z", false, true, " yanked "),
 			want:    true,
 		},
 		{
 			name:    "cargo deprecated for an unknown reason is not withdrawn",
-			version: cargoVersion("1.0.0", "2026-01-01T00:00:00Z", false, true, "retired"),
+			version: cargoVersion(t, "1.0.0", "2026-01-01T00:00:00Z", false, true, "retired"),
 			want:    false,
 		},
 		{
 			name:    "cargo deprecated with no reason is not withdrawn",
-			version: cargoVersion("1.0.0", "2026-01-01T00:00:00Z", false, true, ""),
+			version: cargoVersion(t, "1.0.0", "2026-01-01T00:00:00Z", false, true, ""),
 			want:    false,
 		},
 		{
 			name:    "cargo not deprecated",
-			version: cargoVersion("1.0.0", "2026-01-01T00:00:00Z", false, false, ""),
+			version: cargoVersion(t, "1.0.0", "2026-01-01T00:00:00Z", false, false, ""),
 			want:    false,
 		},
 		{

--- a/internal/infrastructure/depsdev/selection_yanked_test.go
+++ b/internal/infrastructure/depsdev/selection_yanked_test.go
@@ -1,0 +1,158 @@
+package depsdev
+
+import (
+	"testing"
+	"time"
+)
+
+// cargoVersion builds a cargo deps.dev version entry.
+func cargoVersion(version, publishedAt string, isDefault, isDeprecated bool, reason string) Version {
+	t, err := time.Parse(time.RFC3339, publishedAt)
+	if err != nil {
+		panic(err)
+	}
+	return Version{
+		VersionKey:       VersionKey{System: "cargo", Name: "example", Version: version},
+		PublishedAt:      t,
+		IsDefault:        isDefault,
+		IsDeprecated:     isDeprecated,
+		DeprecatedReason: reason,
+	}
+}
+
+// TestPickStableDevAndMax_CargoYankedDefaultIsNotStable mirrors
+// pkg:cargo/promptforge-gateway-config as observed 2026-09-01: deps.dev marks the
+// yanked 1.1.0 isDefault=true, so the pre-fix selection returned it as Stable.
+func TestPickStableDevAndMax_CargoYankedDefaultIsNotStable(t *testing.T) {
+	versions := []Version{
+		cargoVersion("0.2.0", "2026-08-31T16:02:26Z", false, false, ""),
+		cargoVersion("1.1.0", "2026-08-31T15:42:53Z", true, true, "yanked"),
+	}
+
+	stable, _, max := pickStableDevAndMax(versions, "")
+
+	if got, want := stable.VersionKey.Version, "0.2.0"; got != want {
+		t.Errorf("Stable = %q, want %q (the yanked isDefault release must not win)", got, want)
+	}
+	// Max is deliberately unbounded: a yanked release still exists. See ADR-0024.
+	if got, want := max.VersionKey.Version, "1.1.0"; got != want {
+		t.Errorf("Max = %q, want %q (Max is not filtered)", got, want)
+	}
+}
+
+// TestPickStableDevAndMax_CargoAllStableYanked pins the fully-yanked crate case
+// (observed on gap and minae-term, where crates.io reports max_stable_version=null).
+func TestPickStableDevAndMax_CargoAllStableYanked(t *testing.T) {
+	versions := []Version{
+		cargoVersion("0.1.0", "2026-08-31T10:00:00Z", true, true, "yanked"),
+	}
+
+	stable, _, max := pickStableDevAndMax(versions, "")
+
+	if stable.VersionKey.Version != "" {
+		t.Errorf("Stable = %q, want empty when every stable release is yanked", stable.VersionKey.Version)
+	}
+	if got, want := max.VersionKey.Version, "0.1.0"; got != want {
+		t.Errorf("Max = %q, want %q", got, want)
+	}
+}
+
+// TestWithdrawnFromStable pins the deps.dev deprecatedReason contract. The literal
+// "yanked" is an observed, undocumented upstream value: if deps.dev changes it,
+// this test fails rather than the filter silently going quiet. See ADR-0024.
+func TestWithdrawnFromStable(t *testing.T) {
+	tests := []struct {
+		name    string
+		version Version
+		want    bool
+	}{
+		{
+			name:    "cargo yanked",
+			version: cargoVersion("1.0.0", "2026-01-01T00:00:00Z", false, true, "yanked"),
+			want:    true,
+		},
+		{
+			name:    "cargo yanked, mixed case",
+			version: cargoVersion("1.0.0", "2026-01-01T00:00:00Z", false, true, "Yanked"),
+			want:    true,
+		},
+		{
+			name:    "cargo yanked, surrounding whitespace",
+			version: cargoVersion("1.0.0", "2026-01-01T00:00:00Z", false, true, " yanked "),
+			want:    true,
+		},
+		{
+			name:    "cargo deprecated for an unknown reason is not withdrawn",
+			version: cargoVersion("1.0.0", "2026-01-01T00:00:00Z", false, true, "retired"),
+			want:    false,
+		},
+		{
+			name:    "cargo deprecated with no reason is not withdrawn",
+			version: cargoVersion("1.0.0", "2026-01-01T00:00:00Z", false, true, ""),
+			want:    false,
+		},
+		{
+			name:    "cargo not deprecated",
+			version: cargoVersion("1.0.0", "2026-01-01T00:00:00Z", false, false, ""),
+			want:    false,
+		},
+		{
+			name: "npm deprecation is not a yank",
+			version: Version{
+				VersionKey:       VersionKey{System: "npm", Name: "example", Version: "1.0.0"},
+				IsDeprecated:     true,
+				DeprecatedReason: "yanked",
+			},
+			want: false,
+		},
+		{
+			name: "pypi deprecation is not a yank",
+			version: Version{
+				VersionKey:       VersionKey{System: "pypi", Name: "example", Version: "1.0.0"},
+				IsDeprecated:     true,
+				DeprecatedReason: "yanked",
+			},
+			want: false,
+		},
+		{
+			name: "cargo ecosystem match is case-insensitive",
+			version: Version{
+				VersionKey:       VersionKey{System: "CARGO", Name: "example", Version: "1.0.0"},
+				IsDeprecated:     true,
+				DeprecatedReason: "yanked",
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := withdrawnFromStable(tt.version); got != tt.want {
+				t.Errorf("withdrawnFromStable() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestPickStableDevAndMax_NonCargoDeprecatedUnaffected guards the pypi path added
+// in ADR-0023: deps.dev does not report pypi yanks through isDeprecated, so a
+// deprecated pypi release must still be selectable as Stable.
+func TestPickStableDevAndMax_NonCargoDeprecatedUnaffected(t *testing.T) {
+	published, err := time.Parse(time.RFC3339, "2026-01-01T00:00:00Z")
+	if err != nil {
+		t.Fatalf("parse time: %v", err)
+	}
+	versions := []Version{{
+		VersionKey:       VersionKey{System: "pypi", Name: "example", Version: "1.0.0"},
+		PublishedAt:      published,
+		IsDefault:        true,
+		IsDeprecated:     true,
+		DeprecatedReason: "yanked",
+	}}
+
+	stable, _, _ := pickStableDevAndMax(versions, "")
+
+	if got, want := stable.VersionKey.Version, "1.0.0"; got != want {
+		t.Errorf("Stable = %q, want %q (non-cargo must be unaffected)", got, want)
+	}
+}

--- a/internal/infrastructure/depsdev/selection_yanked_test.go
+++ b/internal/infrastructure/depsdev/selection_yanked_test.go
@@ -58,10 +58,8 @@ func TestPickStableDevAndMax_CargoAllStableYanked(t *testing.T) {
 	}
 }
 
-// TestWithdrawnFromStable pins our reading of the deps.dev deprecatedReason
-// value. The fixtures are local, so this cannot detect an upstream rename — the
-// WARN branch does that at runtime. It guards the literal against local edits.
-// See ADR-0024.
+// TestWithdrawnFromStable pins the reason-string match against local edits.
+// See ADR-0024 for what the literal is and how upstream drift surfaces.
 func TestWithdrawnFromStable(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/infrastructure/depsdev/selection_yanked_test.go
+++ b/internal/infrastructure/depsdev/selection_yanked_test.go
@@ -1,9 +1,21 @@
 package depsdev
 
 import (
+	"io"
+	"log/slog"
 	"testing"
 	"time"
 )
+
+// quietWarnLogs silences slog for a test that deliberately exercises a WARN
+// branch, so a passing -v run stays readable. Safe because these tests do not
+// call t.Parallel and so cannot race on the process-global default logger.
+func quietWarnLogs(t testing.TB) {
+	t.Helper()
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+}
 
 // cargoVersion builds a cargo deps.dev version entry.
 func cargoVersion(t testing.TB, version, publishedAt string, isDefault, isDeprecated bool, reason string) Version {
@@ -61,6 +73,8 @@ func TestPickStableDevAndMax_CargoAllStableYanked(t *testing.T) {
 // TestWithdrawnFromStable pins the reason-string match against local edits.
 // See ADR-0024 for what the literal is and how upstream drift surfaces.
 func TestWithdrawnFromStable(t *testing.T) {
+	quietWarnLogs(t)
+
 	tests := []struct {
 		name    string
 		version Version


### PR DESCRIPTION
## A yanked cargo release is no longer selected as the stable version

Closes #494. Follows #493, which closed the same gap for pypi.

> **ADR numbering.** This decision is ADR-**0024**. 0022 is still reserved for `docs/adr/0022-all-releases-yanked-is-not-eol.md` on the unmerged branch `feat/detect-all-releases-yanked`; `main` has 0021 and 0023.

## The issue's premise was wrong, and that changed the fix

#494 was written expecting the pypi mechanism to be ported: call crates.io for `max_stable_version`, pass it to `pickStableDevAndMax` as a bound. The first task was to establish whether `max_stable_version` excludes yanked releases, since that is undocumented.

It does — confirmed in the crates.io source on both code paths that build it, and live. But while confirming it, the more useful fact turned up: **deps.dev already publishes cargo yanks**, in the versions payload `fetchLatestRelease` was already fetching.

```
$ curl .../v3alpha/systems/cargo/packages/owo-colors
  4.4.0   isDefault=false  isDeprecated=false  deprecatedReason=""
  5.0.0   isDefault=true   isDeprecated=true   deprecatedReason="yanked"
```

ADR-0021 and ADR-0023 both state that deps.dev holds no yank data for any ecosystem. That is wrong for cargo. It was invisible only because the decode struct in `release.go` enumerated four fields and `deprecatedReason` was not among them.

So the bug is not missing data. deps.dev hands us both the yank flag and, in the same response, an `isDefault` pointing at the yanked release — and `pickStableDevAndMax` took `isDefault` unconditionally.

```mermaid
flowchart LR
    dd["deps.dev versions payload<br>(one request, already made)<br>4.4.0 clean · 5.0.0 isDefault + yanked"]
    subgraph before["before"]
        b1["take isDefault<br>unconditionally"] --> b2["Stable = 5.0.0<br>(yanked)"]
    end
    subgraph after["after"]
        a1["drop deprecatedReason<br>= yanked"] --> a2["then take isDefault,<br>else IsStableVersion"] --> a3["Stable = 4.4.0"]
    end
    dd -- "same bytes" --> b1
    dd -- "same bytes" --> a1
    b2 -- "keys advisory aggregates, licences,<br>lifecycle signals, dependency graph" --> harm["every version-linked answer<br>describes a retired release"]
    a3 -. "agrees with crates.io<br>max_stable_version" .-> ok["4.4.0"]
```

As in #493 the damage is not cosmetic: stable selection picks the version used for the internal deps.dev package lookup, so advisory counts, max CVSS and the lifecycle signals all described a release nobody should install, and for an unversioned PURL the dependency graph follows.

## Why not the crates.io call the issue anticipated

It works, but it costs one HTTP request per cargo package, a new `crates.Client.GetCrate`, a new client dependency on `DepsDevClient` plus wiring, and a cache policy — to fetch data already sitting in a response we had parsed. Its one real advantage, independence from deps.dev's indexing lag, is largely illusory: the candidate list being filtered comes from deps.dev either way.

It would also have inherited a defect. `pickByRegistryStable` orders bound and candidates with `pep440.Parse`, which is right for pypi and wrong for cargo — a semver build-metadata version like `1.2.3+build` fails to parse and would be silently dropped, and a hint that fails to parse turns the bound off entirely, reopening the hole. Using deps.dev's own flag needs no version ordering at all.

## The evidence for an undocumented string

`deprecatedReason` is documented only as "The reason why this version is deprecated" — no mention of yanks or of cargo. So the value was measured. Across **17 crates and 2819 versions**, including crates with heavy yank history (`clap` 92, `num` 35, `futures` 23, `chrono` 22, `syn` 17), deps.dev `isDeprecated` and crates.io `yanked` disagreed on **zero** versions.

The correspondence is cargo-specific. On `pkg:pypi/pydantic-extra-types`, whose 2.11.2 PyPI has yanked (the #493 specimen), deps.dev reports `isDeprecated=false` for every version. **deps.dev sees cargo yanks and not pypi yanks**, so ADR-0023's PyPI bound is still required and is not superseded.

## What the filter does

`Version` carries `DeprecatedReason`. `pickStableDevAndMax` partitions candidates through `withdrawnFromStable` before any Stable rule runs, so the exclusion applies to the `preferredStable` bound, to `isDefault`, and to the `IsStableVersion` fallback alike. Dev and `MaxSemverVersion` keep the unfiltered list — Max's purpose is "highest version that exists", and a yanked release does still exist.

When every stable release is withdrawn, Stable is left **empty** rather than falling back to a yanked release. That is the same choice ADR-0023 made when its bound excludes everything, and the same answer crates.io gives: it reports `max_stable_version: null` for such crates.

Be precise about what that buys, though. `batch_details.go` resolves the effective PURL as Stable → MaxSemver → PreRelease → original, so for a crate whose *every* release is yanked, resolution still lands on the yanked max-semver release. That is not a regression — the same crate previously selected the yanked release as Stable outright — but closing it needs the max-semver decision ADR-0023 deferred, not this one. Where an un-yanked release exists, which is the common case, Stable now selects it and the fallback never runs.

Because the string is observed rather than contractual, a cargo release that is `isDeprecated` with an **unrecognised** reason is logged at WARN and treated as not withdrawn — drift degrades to the previous behaviour audibly, not silently. That WARN branch is what would surface a deps.dev rename at runtime; the tests run on local fixtures and pin our reading of the string against accidental local edits, not against upstream change.

Full rationale, the rejected alternatives and what is deliberately left unfixed are in [ADR-0024](docs/adr/0024-cargo-yank-from-depsdev.md).

## Runtime verification

Real binaries built from this branch and its base (`0efb509`), live registries, 2026-09-02.

```
$ uzomuzo scan pkg:cargo/owo-colors
  before: │ Stable: 5.0.0 (2024-09-10) ⚠️ [DEPRECATED]
          │ Pre-release: 4.0.0-rc.1 (2023-10-13)

  after : │ Stable: 4.4.0 (2026-08-27)
          │ Pre-release: 4.0.0-rc.1 (2023-10-13)
          │ Highest (SemVer): 5.0.0 (2024-09-10) ⚠️ [DEPRECATED]
```

`4.4.0` is exactly what crates.io reports as `max_stable_version` for this crate. `5.0.0` correctly remains as Highest (SemVer), still flagged DEPRECATED — Max is deliberately unfiltered.

The all-yanked case, on a crate whose every release is yanked:

```
$ uzomuzo scan pkg:cargo/promptforge-gateway-config
  after : │ Highest (SemVer): 1.1.0 (2026-08-31) ⚠️ [DEPRECATED]
          (no Stable line — crates.io likewise reports max_stable_version: null)
```

Nothing else moved:

```
$ uzomuzo scan pkg:pypi/pydantic-extra-types                 -> IDENTICAL before/after
    (Stable: 2.11.1, not the yanked 2.11.2 — ADR-0023's bound still governs)
$ uzomuzo scan pkg:npm/request pkg:npm/express \
      pkg:golang/github.com/gin-gonic/gin                    -> IDENTICAL before/after
```

> **Registry state moves.** `promptforge-gateway-config` had only `1.1.0` yanked when it was found; `0.2.0` was yanked a few hours later, mid-task. It is therefore used as the all-yanked specimen only — `owo-colors` pins the ordinary case in both test files — and ADR-0024 records the transition so the two fixtures do not read as contradicting each other. A reviewer re-running these commands may see different state; the httptest fixtures pin both shapes so CI does not depend on live registries.

## Tests

`go build`, `go vet`, `go test ./...`, `golangci-lint run` all clean.

- `selection_yanked_test.go` — the predicate and selection: yanked `isDefault` loses, all-yanked leaves Stable empty, case/whitespace insensitivity, unknown reason stays eligible, and npm/pypi are unaffected.
- `release_cargo_yank_test.go` — the same contract end to end over httptest, so the decode and carry steps are pinned too. Without it, deleting the `deprecatedReason` struct tag or the carry assignment disabled the fix with every test still green; both mutations now fail.

Each new test was verified to fail against the unfixed code rather than merely pass against the fixed code.

`docs/data-flow.md` gains `deprecatedReason` in the deps.dev versions-endpoint field list and drops the blanket "no yank data" claim for cargo, citing ADR-0024.

A local review pass (`/review-until-clean` Phase A: five Claude agents plus the GitHub Copilot CLI) ran before this was opened for review. It corrected ADR rationale that had been restated in comments rather than cited by ID, a double evaluation of `purl.IsStableVersion` per loop iteration, a test helper that used `panic` instead of `t.Fatalf`, an inaccurate claim that a fixture test could detect upstream drift in CI, and the promptforge dual-specimen inconsistency described above.

## Note for review

This PR does not touch ADR-0021 or ADR-0023, whose Context sections carry the corrected premise. Those corrections are owned separately, per the handoff. The decisions themselves are unaffected: ADR-0021's conclusion does not depend on where yank data comes from, and ADR-0023's PyPI bound is still needed because deps.dev does not see PyPI yanks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PJFTi2wF7u3ZiUJL3qxcXn
