### PR TITLE
feat(scan): allow --fail-on review-needed, and stop the label list drifting

### DIFF
--- a/cmd/uzomuzo/commands.go
+++ b/cmd/uzomuzo/commands.go
@@ -15,6 +15,7 @@ import (
 	scanapp "github.com/future-architect/uzomuzo-oss/internal/application/scan"
 	domaincfg "github.com/future-architect/uzomuzo-oss/internal/domain/config"
 	"github.com/future-architect/uzomuzo-oss/internal/domain/depparser"
+	domainscan "github.com/future-architect/uzomuzo-oss/internal/domain/scan"
 	"github.com/future-architect/uzomuzo-oss/internal/infrastructure/actionscan"
 	infradepparser "github.com/future-architect/uzomuzo-oss/internal/infrastructure/depparser"
 	"github.com/future-architect/uzomuzo-oss/internal/infrastructure/depparser/cyclonedx"
@@ -34,7 +35,7 @@ func scanFlags() []urfcli.Flag {
 		&urfcli.StringFlag{Name: "format", Aliases: []string{"f"}, Usage: "Output format: detailed, table, json, csv (default: auto)"},
 
 		// CI gate
-		&urfcli.StringFlag{Name: "fail-on", Usage: "Comma-separated lifecycle labels that trigger exit 1 (eol-confirmed,eol-effective,eol-scheduled,stalled,legacy-safe)"},
+		&urfcli.StringFlag{Name: "fail-on", Usage: "Comma-separated lifecycle labels that trigger exit 1 (" + strings.Join(domainscan.ValidFailLabels(), ",") + ")"},
 
 		// File mode options
 		&urfcli.IntFlag{Name: "sample", Usage: "Randomly sample up to N PURLs and N GitHub URLs (file mode only)"},

--- a/docs/integration-examples.md
+++ b/docs/integration-examples.md
@@ -30,7 +30,9 @@ syft . -o cyclonedx-json | ./uzomuzo scan --sbom -
 ### CI Pipeline Example
 
 ```bash
-# Fail the build if any dependency is EOL or archived
+# Fail the build if any dependency is end-of-life.
+# An archived repository with no EOL signal is labelled Stalled, not EOL (ADR-0020),
+# so add `stalled` to --fail-on if the build should stop for those too.
 trivy fs . --format cyclonedx | ./uzomuzo scan --sbom - --fail-on eol-confirmed,eol-effective --format json
 # Exit code 0 = no dependencies matched --fail-on policy
 # Exit code 1 = at least one dependency matched --fail-on policy

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -615,7 +615,8 @@ CSV output comprehensively covers security metrics:
 - **Basic info**: PURL, repository URL, package metadata
 - **Scorecard metrics**: All OpenSSF Scorecard check results
 - **Security assessment**: Vulnerability scores, maintenance status
-- **Lifecycle assessment**: Automatic classification (Active / Stalled / Legacy-Safe / EOL)
+- **Lifecycle assessment**: Automatic classification into one of the maintenance
+  statuses listed above, including `Review Needed` when uzomuzo cannot decide
 - **Repository status**: Stars, forks, archive status, last commit
 
 ### CLI Display Order

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -615,8 +615,8 @@ CSV output comprehensively covers security metrics:
 - **Basic info**: PURL, repository URL, package metadata
 - **Scorecard metrics**: All OpenSSF Scorecard check results
 - **Security assessment**: Vulnerability scores, maintenance status
-- **Lifecycle assessment**: Automatic classification into one of the maintenance
-  statuses listed above, including `Review Needed` when uzomuzo cannot decide
+- **Lifecycle assessment**: Automatic classification into one of the seven
+  lifecycle states in [Lifecycle Classification](../README.md#lifecycle-classification)
 - **Repository status**: Stars, forks, archive status, last commit
 
 ### CLI Display Order

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -402,7 +402,13 @@ Exit with code 1 when any dependency matches the specified lifecycle labels:
 ./uzomuzo scan --sbom bom.json --fail-on eol-confirmed,eol-effective,stalled
 ```
 
-Valid labels: `eol-confirmed`, `eol-effective`, `eol-scheduled`, `stalled`, `legacy-safe`
+Valid labels: `eol-confirmed`, `eol-effective`, `eol-scheduled`, `stalled`, `legacy-safe`, `review-needed`
+
+`review-needed` covers the cases uzomuzo cannot decide on its own — including a
+package whose every published release is yanked (see
+[ADR-0022](adr/0022-all-releases-yanked-is-not-eol.md)). Add it to `--fail-on`
+when CI should stop for a human to look, rather than only for a confirmed
+end-of-life.
 
 Without `--fail-on`, exit code is always 0 regardless of scan results.
 

--- a/internal/domain/scan/policy.go
+++ b/internal/domain/scan/policy.go
@@ -18,11 +18,19 @@ var labelMap = map[string]analysis.MaintenanceStatus{
 	"eol-scheduled": analysis.LabelEOLScheduled,
 	"stalled":       analysis.LabelStalled,
 	"legacy-safe":   analysis.LabelLegacySafe,
+	"review-needed": analysis.LabelReviewNeeded,
 }
 
-// ValidFailLabels returns the list of valid --fail-on label strings.
+// ValidFailLabels returns the valid --fail-on label strings, ordered for display
+// rather than sorted: descending severity first, then the two non-severity
+// buckets. Map iteration order cannot be used because this feeds user-visible
+// help and error text.
+//
+// This slice and labelMap must hold the same keys; Test_ValidFailLabels_MatchesLabelMap
+// fails if they drift. A label present in one but not the other is how
+// review-needed was left un-gatable after it became reachable (#498).
 func ValidFailLabels() []string {
-	return []string{"eol-confirmed", "eol-effective", "eol-scheduled", "stalled", "legacy-safe"}
+	return []string{"eol-confirmed", "eol-effective", "eol-scheduled", "stalled", "legacy-safe", "review-needed"}
 }
 
 // FailPolicy determines which lifecycle labels trigger a non-zero exit.

--- a/internal/domain/scan/policy.go
+++ b/internal/domain/scan/policy.go
@@ -11,26 +11,43 @@ import (
 	domainaudit "github.com/future-architect/uzomuzo-oss/internal/domain/audit"
 )
 
-// labelMap maps CLI label strings to domain MaintenanceStatus values.
-var labelMap = map[string]analysis.MaintenanceStatus{
-	"eol-confirmed": analysis.LabelEOLConfirmed,
-	"eol-effective": analysis.LabelEOLEffective,
-	"eol-scheduled": analysis.LabelEOLScheduled,
-	"stalled":       analysis.LabelStalled,
-	"legacy-safe":   analysis.LabelLegacySafe,
-	"review-needed": analysis.LabelReviewNeeded,
+// failLabels is the single source of the --fail-on vocabulary: which CLI label
+// strings exist, which MaintenanceStatus each names, and the order they appear
+// in. The order is deliberate, not sorted — it feeds user-visible help and error
+// text, so it runs by descending severity and ends with the labels that are not
+// a severity at all.
+//
+// One literal rather than a list plus a map: the vocabulary used to be written
+// out three times, and a label added to one copy but not the others is how
+// review-needed became reachable but not gatable (#498).
+var failLabels = []struct {
+	label  string
+	status analysis.MaintenanceStatus
+}{
+	{"eol-confirmed", analysis.LabelEOLConfirmed},
+	{"eol-effective", analysis.LabelEOLEffective},
+	{"eol-scheduled", analysis.LabelEOLScheduled},
+	{"stalled", analysis.LabelStalled},
+	{"legacy-safe", analysis.LabelLegacySafe},
+	{"review-needed", analysis.LabelReviewNeeded},
 }
 
-// ValidFailLabels returns the valid --fail-on label strings, ordered for display
-// rather than sorted: descending severity first, then the two non-severity
-// buckets. Map iteration order cannot be used because this feeds user-visible
-// help and error text.
-//
-// This slice and labelMap must hold the same keys; Test_ValidFailLabels_MatchesLabelMap
-// fails if they drift. A label present in one but not the other is how
-// review-needed was left un-gatable after it became reachable (#498).
+// labelMap indexes failLabels for lookup while parsing.
+var labelMap = func() map[string]analysis.MaintenanceStatus {
+	m := make(map[string]analysis.MaintenanceStatus, len(failLabels))
+	for _, fl := range failLabels {
+		m[fl.label] = fl.status
+	}
+	return m
+}()
+
+// ValidFailLabels returns the valid --fail-on label strings in display order.
 func ValidFailLabels() []string {
-	return []string{"eol-confirmed", "eol-effective", "eol-scheduled", "stalled", "legacy-safe", "review-needed"}
+	out := make([]string, 0, len(failLabels))
+	for _, fl := range failLabels {
+		out = append(out, fl.label)
+	}
+	return out
 }
 
 // FailPolicy determines which lifecycle labels trigger a non-zero exit.

--- a/internal/domain/scan/policy_labels_test.go
+++ b/internal/domain/scan/policy_labels_test.go
@@ -1,0 +1,82 @@
+package scan
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/future-architect/uzomuzo-oss/internal/domain/analysis"
+)
+
+// Test_ValidFailLabels_MatchesLabelMap pins the two halves of the --fail-on
+// vocabulary together. ValidFailLabels feeds the CLI help text and the parse
+// error message; labelMap decides what actually parses. A label in one but not
+// the other is either a label users are told about but cannot use, or one that
+// works but is never advertised.
+//
+// This is the drift that left review-needed un-gatable after ADR-0022 made it
+// reachable (#498).
+func Test_ValidFailLabels_MatchesLabelMap(t *testing.T) {
+	t.Parallel()
+
+	listed := append([]string(nil), ValidFailLabels()...)
+	mapped := make([]string, 0, len(labelMap))
+	for k := range labelMap {
+		mapped = append(mapped, k)
+	}
+	sort.Strings(listed)
+	sort.Strings(mapped)
+
+	if len(listed) != len(mapped) {
+		t.Fatalf("label count: ValidFailLabels has %d, labelMap has %d\n  listed=%v\n  mapped=%v",
+			len(listed), len(mapped), listed, mapped)
+	}
+	for i := range listed {
+		if listed[i] != mapped[i] {
+			t.Errorf("label mismatch at %d: ValidFailLabels=%q, labelMap=%q\n  listed=%v\n  mapped=%v",
+				i, listed[i], mapped[i], listed, mapped)
+		}
+	}
+}
+
+// Test_ValidFailLabels_AllParse asserts every advertised label round-trips
+// through ParseFailPolicy and lands on the MaintenanceStatus it names, so a
+// label cannot be advertised while mapping to the wrong status.
+func Test_ValidFailLabels_AllParse(t *testing.T) {
+	t.Parallel()
+
+	for _, label := range ValidFailLabels() {
+		t.Run(label, func(t *testing.T) {
+			t.Parallel()
+
+			p, err := ParseFailPolicy(label)
+			if err != nil {
+				t.Fatalf("ParseFailPolicy(%q) failed: %v", label, err)
+			}
+			want, ok := labelMap[label]
+			if !ok {
+				t.Fatalf("labelMap has no entry for advertised label %q", label)
+			}
+			if !p.IsTriggered(want) {
+				t.Errorf("ParseFailPolicy(%q) does not trigger on %v", label, want)
+			}
+		})
+	}
+}
+
+// Test_ParseFailPolicy_ReviewNeeded pins the label added for ADR-0022: a package
+// whose every release is yanked is assessed Review Needed, and CI must be able
+// to stop on it. Before #498 the label was reachable but not gatable.
+func Test_ParseFailPolicy_ReviewNeeded(t *testing.T) {
+	t.Parallel()
+
+	p, err := ParseFailPolicy("review-needed")
+	if err != nil {
+		t.Fatalf("ParseFailPolicy failed: %v", err)
+	}
+	if !p.IsTriggered(analysis.LabelReviewNeeded) {
+		t.Error("review-needed does not trigger on LabelReviewNeeded")
+	}
+	if p.IsTriggered(analysis.LabelActive) {
+		t.Error("review-needed must not trigger on Active")
+	}
+}

--- a/internal/domain/scan/policy_labels_test.go
+++ b/internal/domain/scan/policy_labels_test.go
@@ -1,71 +1,82 @@
 package scan
 
 import (
-	"sort"
 	"testing"
 
 	"github.com/future-architect/uzomuzo-oss/internal/domain/analysis"
 )
 
-// Test_ValidFailLabels_MatchesLabelMap pins the two halves of the --fail-on
-// vocabulary together. ValidFailLabels feeds the CLI help text and the parse
-// error message; labelMap decides what actually parses. A label in one but not
-// the other is either a label users are told about but cannot use, or one that
-// works but is never advertised.
-//
-// This is the drift that left review-needed un-gatable after ADR-0022 made it
-// reachable (#498).
-func Test_ValidFailLabels_MatchesLabelMap(t *testing.T) {
+// wantFailLabels is an independent statement of the --fail-on vocabulary and its
+// display order. It is written out by hand on purpose: deriving it from
+// failLabels would only compare the production table with itself, and a wrong
+// MaintenanceStatus on either side would pass.
+var wantFailLabels = []struct {
+	label  string
+	status analysis.MaintenanceStatus
+}{
+	{"eol-confirmed", analysis.LabelEOLConfirmed},
+	{"eol-effective", analysis.LabelEOLEffective},
+	{"eol-scheduled", analysis.LabelEOLScheduled},
+	{"stalled", analysis.LabelStalled},
+	{"legacy-safe", analysis.LabelLegacySafe},
+	{"review-needed", analysis.LabelReviewNeeded},
+}
+
+// Test_ValidFailLabels_ContentAndOrder pins what --fail-on accepts and the order
+// users see it in. Order is part of the contract: ValidFailLabels feeds the CLI
+// help text and the parse error message, so a reordering is user-visible.
+func Test_ValidFailLabels_ContentAndOrder(t *testing.T) {
 	t.Parallel()
 
-	listed := append([]string(nil), ValidFailLabels()...)
-	mapped := make([]string, 0, len(labelMap))
-	for k := range labelMap {
-		mapped = append(mapped, k)
+	got := ValidFailLabels()
+	if len(got) != len(wantFailLabels) {
+		t.Fatalf("label count: got %d %v, want %d", len(got), got, len(wantFailLabels))
 	}
-	sort.Strings(listed)
-	sort.Strings(mapped)
-
-	if len(listed) != len(mapped) {
-		t.Fatalf("label count: ValidFailLabels has %d, labelMap has %d\n  listed=%v\n  mapped=%v",
-			len(listed), len(mapped), listed, mapped)
-	}
-	for i := range listed {
-		if listed[i] != mapped[i] {
-			t.Errorf("label mismatch at %d: ValidFailLabels=%q, labelMap=%q\n  listed=%v\n  mapped=%v",
-				i, listed[i], mapped[i], listed, mapped)
+	for i, want := range wantFailLabels {
+		if got[i] != want.label {
+			t.Errorf("label %d: got %q, want %q (full: %v)", i, got[i], want.label, got)
 		}
 	}
 }
 
-// Test_ValidFailLabels_AllParse asserts every advertised label round-trips
-// through ParseFailPolicy and lands on the MaintenanceStatus it names, so a
-// label cannot be advertised while mapping to the wrong status.
-func Test_ValidFailLabels_AllParse(t *testing.T) {
+// Test_ParseFailPolicy_EachLabelTriggersItsOwnStatus pins the label-to-status
+// mapping against hand-written expectations rather than against the production
+// table, so a label wired to the wrong MaintenanceStatus is caught. Each case
+// also asserts the policy does not trigger on some other status, so a policy
+// that matched everything would fail.
+func Test_ParseFailPolicy_EachLabelTriggersItsOwnStatus(t *testing.T) {
 	t.Parallel()
 
-	for _, label := range ValidFailLabels() {
-		t.Run(label, func(t *testing.T) {
+	for _, tt := range wantFailLabels {
+		t.Run(tt.label, func(t *testing.T) {
 			t.Parallel()
 
-			p, err := ParseFailPolicy(label)
+			p, err := ParseFailPolicy(tt.label)
 			if err != nil {
-				t.Fatalf("ParseFailPolicy(%q) failed: %v", label, err)
+				t.Fatalf("ParseFailPolicy(%q) failed: %v", tt.label, err)
 			}
-			want, ok := labelMap[label]
-			if !ok {
-				t.Fatalf("labelMap has no entry for advertised label %q", label)
+			if !p.IsTriggered(tt.status) {
+				t.Errorf("%q does not trigger on %v", tt.label, tt.status)
 			}
-			if !p.IsTriggered(want) {
-				t.Errorf("ParseFailPolicy(%q) does not trigger on %v", label, want)
+			for _, other := range wantFailLabels {
+				if other.status == tt.status {
+					continue
+				}
+				if p.IsTriggered(other.status) {
+					t.Errorf("%q also triggers on %v; a single label must select a single status",
+						tt.label, other.status)
+				}
+			}
+			if p.IsTriggered(analysis.LabelActive) {
+				t.Errorf("%q triggers on Active; no fail label maps to a healthy package", tt.label)
 			}
 		})
 	}
 }
 
-// Test_ParseFailPolicy_ReviewNeeded pins the label added for ADR-0022: a package
-// whose every release is yanked is assessed Review Needed, and CI must be able
-// to stop on it. Before #498 the label was reachable but not gatable.
+// Test_ParseFailPolicy_ReviewNeeded is the regression pin for #498: ADR-0022
+// made Review Needed reachable for a package whose every release is yanked, but
+// --fail-on could not gate on it, so CI had no way to stop.
 func Test_ParseFailPolicy_ReviewNeeded(t *testing.T) {
 	t.Parallel()
 
@@ -75,8 +86,5 @@ func Test_ParseFailPolicy_ReviewNeeded(t *testing.T) {
 	}
 	if !p.IsTriggered(analysis.LabelReviewNeeded) {
 		t.Error("review-needed does not trigger on LabelReviewNeeded")
-	}
-	if p.IsTriggered(analysis.LabelActive) {
-		t.Error("review-needed must not trigger on Active")
 	}
 }

--- a/internal/infrastructure/depsdev/selection_test.go
+++ b/internal/infrastructure/depsdev/selection_test.go
@@ -83,8 +83,8 @@ func TestPickStableDevAndMax_NoStable_DefaultsAbsent(t *testing.T) {
 func TestPickStableDevAndMax_HintEmpty_MatchesOldBehavior(t *testing.T) {
 	versions := []Version{
 		v("1.0.0-rc1", "2024-01-01T00:00:00Z", false), // non-stable (contains "rc") -> Dev candidate
-		v("1.0.0", "2024-02-01T00:00:00Z", true),       // isDefault=true -> Stable
-		v("2.0.0", "2024-03-01T00:00:00Z", false),      // highest valid SemVer -> Max
+		v("1.0.0", "2024-02-01T00:00:00Z", true),      // isDefault=true -> Stable
+		v("2.0.0", "2024-03-01T00:00:00Z", false),     // highest valid SemVer -> Max
 	}
 
 	stable, dev, max := pickStableDevAndMax(versions, "")


### PR DESCRIPTION
## `--fail-on review-needed` now exists, and the label list can no longer drift

Closes #498. 6 files, +140/-15.

#495 made "every published release is yanked" reachable as a **Review Needed** assessment. `--fail-on` could not gate on it, so CI had no way to stop for a package the registry offers no installable version of. With no further tag expected soon, #495's headline outcome would have sat unusable in CI for months.

## The wall: one vocabulary, written three times

`--fail-on`'s label set lived in three places with nothing tying them together:

```
internal/domain/scan/policy.go  labelMap          → what actually parses
internal/domain/scan/policy.go  ValidFailLabels() → the parse error message
cmd/uzomuzo/commands.go         Usage: "...(eol-confirmed,eol-effective,...)"
```

#495 updated none of them, and nothing failed. That is the bug — the missing label is just its symptom.

## How it is fixed

```mermaid
flowchart LR
    src["failLabels<br>one ordered table<br>label + status"] --> map["labelMap"]
    src --> list["ValidFailLabels()"]
    map --> parse["ParseFailPolicy<br>what actually parses"]
    list --> err["parse error message"]
    list --> usage["CLI --fail-on help text"]
    c2["copy 2<br>hand-kept label list"] -.-> |"removed"| list
    c3["copy 3<br>hardcoded Usage string"] -.-> |"removed"| usage
```

Three copies become **one**. `labelMap` indexes `failLabels`, `ValidFailLabels()` projects its label column, and the CLI help text renders that — so the copies cannot disagree, rather than being watched for disagreement. Display order survives, which was the reason not to sort a derived list.

The test states its expectations independently, in a hand-written `wantFailLabels` table. That matters: an earlier revision took the expected status *from* `labelMap` and compared it back against `labelMap`, so a label wired to the wrong `MaintenanceStatus` would have passed. Each label must now trigger its own status and no other, and none may trigger on `Active`.

Also corrects `docs/integration-examples.md`, whose CI example was captioned *"Fail the build if any dependency is EOL or archived"* while gating only on `eol-confirmed,eol-effective`. There is no `archived` label, and since [ADR-0020](docs/adr/0020-archived-registry-liveness.md) an archived repository with no EOL signal is labelled `Stalled` — so the build did not stop for the case the caption advertised.

## Runtime verification

`pkg:pypi/python-apt` has every release yanked and assesses Review Needed:

```
$ uzomuzo scan pkg:pypi/python-apt --fail-on review-needed ; echo $?
🔍 review   pkg:pypi/python-apt  Review Needed
1

$ uzomuzo scan pkg:pypi/python-apt --fail-on eol-confirmed ; echo $?
0
```

The mapping test was confirmed load-bearing by injecting a wrong wiring (`stalled` → `LabelLegacySafe`), which fails with `"stalled" does not trigger on Stalled` and `"stalled" also triggers on Legacy-Safe`. The circular version this replaced would have passed that injection. `go build`, `go vet`, `go test ./...`, `golangci-lint` (0 issues) all pass.

## Also in this diff

`internal/infrastructure/depsdev/selection_test.go` gets a two-line gofmt comment realignment, picked up incidentally by `goimports -w .`. It is unrelated to `--fail-on`, and is disclosed rather than split out because it is whitespace only.

It is worth knowing why it was there: `.golangci.yml` enables `errcheck`, `govet`, `ineffassign`, `staticcheck` and `unused` — no formatter — so `main` was not gofmt-clean and CI did not notice. That gap is a separate change and is not fixed here.

## Related

Completes #495 / [ADR-0022](docs/adr/0022-all-releases-yanked-is-not-eol.md) for CI use. Found during the pre-release audit for `v0.3.0`; the same audit surfaced a separate, pre-existing disagreement between `Verdict` and `MaintenanceStatus` for archived packages, filed separately rather than folded in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DDXfwFvuX3MTnQdT6F1nTH
